### PR TITLE
Reducing number of arrays used for the error unpacking

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -466,11 +466,9 @@ __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint3
         continue ; // 0: bad word
       }
 
-
       uint32_t link  = getLink(ww);            // Extract link
       uint32_t roc   = getRoc(ww);             // Extract Roc in link
       DetIdGPU detId = getRawId(Map, fedId, link, roc);
-
 
       uint32_t errorType = checkROC(ww, fedId, link, Map, debug);
       skipROC = (roc < maxROCIndex) ? false : (errorType != 0);

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
@@ -161,10 +161,7 @@ struct context {
   uint16_t * adc_d;
   uint16_t * layer_d;
   uint32_t * rawIdArr_d;
-  uint32_t * errType_d;
-  uint32_t * errWord_d;
-  uint32_t * errFedID_d;
-  uint32_t * errRawID_d;
+  uint32_t * error_d;
 
   // store the start and end index for each module (total 1856 modules-phase 1)
   int *mIndexStart_d;
@@ -175,8 +172,8 @@ struct context {
 // wrapper function to call RawToDigi on the GPU from host side
 void RawToDigi_wrapper(context &, const SiPixelFedCablingMapGPU* cablingMapDevice, const uint32_t wordCounter, uint32_t *word, 
                         const uint32_t fedCounter,  uint8_t *fedId_h,
-                        bool convertADCtoElectrons, uint32_t * pdigi_h, int *mIndexStart_h, int *mIndexEnd_h, 
-                        uint32_t *rawIdArr_h, uint32_t *errType_h, uint32_t *errWord_h, uint32_t *errFedID_h, uint32_t *errRawID_h,
+                        bool convertADCtoElectrons, uint32_t * pdigi_h, int *mIndexStart_h, int *mIndexEnd_h,
+                        uint32_t *rawIdArr_h, uint32_t *error_h,
                         bool useQualityInfo, bool includeErrors, bool debug = false);
 
 // void initCablingMap();

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
@@ -25,8 +25,8 @@ void processCablingMap(SiPixelFedCablingMap const& cablingMap, SiPixelFedCabling
   std::vector<unsigned int>  RawId(MAX_SIZE);
   std::vector<unsigned int>  rocInDet(MAX_SIZE);
   std::vector<unsigned int>  moduleId(MAX_SIZE);
-  std::vector<short int>     badRocs(MAX_SIZE);
-  std::vector<short int>     modToUnp(MAX_SIZE);
+  std::vector<unsigned char> badRocs(MAX_SIZE);
+  std::vector<unsigned char> modToUnp(MAX_SIZE);
   std::set<unsigned int>     rawIdSet;
 
   unsigned int startFed = *(fedIds.begin());
@@ -90,9 +90,9 @@ void processCablingMap(SiPixelFedCablingMap const& cablingMap, SiPixelFedCabling
       moduleId[i] = it->second;
     }
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << fedMap[i]  << std::setw(20) << linkMap[i]  << std::setw(20) << rocMap[i] << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << RawId[i]   << std::setw(20) << rocInDet[i] << std::setw(20) << moduleId[i] << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << badRocs[i] << std::setw(20) << modToUnp[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << fedMap[i]       << std::setw(20) << linkMap[i]       << std::setw(20) << rocMap[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << RawId[i]        << std::setw(20) << rocInDet[i]      << std::setw(20) << moduleId[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << (int)badRocs[i] << std::setw(20) << (int)modToUnp[i] << std::endl;
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
   }
 
@@ -103,8 +103,8 @@ void processCablingMap(SiPixelFedCablingMap const& cablingMap, SiPixelFedCabling
   cudaCheck(cudaMemcpy(cablingMapGPU->RawId,    RawId.data(),    RawId.size()    * sizeof(unsigned int), cudaMemcpyHostToDevice));
   cudaCheck(cudaMemcpy(cablingMapGPU->rocInDet, rocInDet.data(), rocInDet.size() * sizeof(unsigned int), cudaMemcpyHostToDevice));
   cudaCheck(cudaMemcpy(cablingMapGPU->moduleId, moduleId.data(), moduleId.size() * sizeof(unsigned int), cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(cablingMapGPU->badRocs,  badRocs.data(),  badRocs.size()  * sizeof(short int), cudaMemcpyHostToDevice));
-  cudaCheck(cudaMemcpy(cablingMapGPU->modToUnp, modToUnp.data(), modToUnp.size() * sizeof(short int), cudaMemcpyHostToDevice));
+  cudaCheck(cudaMemcpy(cablingMapGPU->badRocs,  badRocs.data(),  badRocs.size()  * sizeof(unsigned char), cudaMemcpyHostToDevice));
+  cudaCheck(cudaMemcpy(cablingMapGPU->modToUnp, modToUnp.data(), modToUnp.size() * sizeof(unsigned char), cudaMemcpyHostToDevice));
   cudaCheck(cudaMemcpy(cablingMapDevice, cablingMapGPU, sizeof(SiPixelFedCablingMapGPU), cudaMemcpyHostToDevice));
   cudaDeviceSynchronize();
 }

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.h
@@ -15,7 +15,7 @@ const unsigned int MAX_LINK =  48;  // maximum links/channels for Phase 1
 const unsigned int MAX_ROC  =   8;
 const unsigned int MAX_SIZE = MAX_FED * MAX_LINK * MAX_ROC;
 const unsigned int MAX_SIZE_BYTE_INT  = MAX_SIZE * sizeof(unsigned int);
-const unsigned int MAX_SIZE_BYTE_BOOL = MAX_SIZE * sizeof(short int);
+const unsigned int MAX_SIZE_BYTE_BOOL = MAX_SIZE * sizeof(unsigned char);
 
 struct SiPixelFedCablingMapGPU {
   unsigned int size;
@@ -25,8 +25,8 @@ struct SiPixelFedCablingMapGPU {
   unsigned int * RawId;
   unsigned int * rocInDet;
   unsigned int * moduleId;
-  short int * modToUnp;
-  short int * badRocs;
+  unsigned char * modToUnp;
+  unsigned char * badRocs;
 };
 
 inline

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
@@ -68,7 +68,8 @@ private:
 
   // to store the output
   uint32_t *pdigi_h, *rawIdArr_h;                   // host copy of output
-  uint32_t *errType_h, *errWord_h, *errFedID_h, *errRawID_h;    // host copy of output
+  uint32_t *error_h;
+>>>>>>> calabria-cmssw/GPU_SiPixel_RawToDigi_VI1_Cesare_2
   // store the start and end index for each module (total 1856 modules-phase 1)
   int *mIndexStart_h, *mIndexEnd_h;
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
@@ -69,7 +69,6 @@ private:
   // to store the output
   uint32_t *pdigi_h, *rawIdArr_h;                   // host copy of output
   uint32_t *error_h;
->>>>>>> calabria-cmssw/GPU_SiPixel_RawToDigi_VI1_Cesare_2
   // store the start and end index for each module (total 1856 modules-phase 1)
   int *mIndexStart_h, *mIndexEnd_h;
 

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -35,6 +35,7 @@ siPixelDigisGPU.UsePhase1 = cms.bool(False)
 ## Empty Regions PSet means complete unpacking
 siPixelDigisGPU.Regions = cms.PSet( )
 siPixelDigisGPU.CablingMapLabel = cms.string("")
+siPixelDigisGPU.enableErrorDebug = cms.bool(False)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigis, UsePhase1=True)


### PR DESCRIPTION
Using just one array for the error unpacking.
Some clean up.
Restore the use of unsigned char in the cabling map.
Introduce parameter to enable the error debug.