### PR TITLE
GPU Clusterizer

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -641,7 +641,6 @@ void RawToDigi_wrapper(
   }
   cudaStreamSynchronize(c.stream);
   // End  of Raw2Digi and passing data for cluserisation
-  // PixelCluster_Wrapper(c.xx_adc , c.yy_adc, c.adc_d,wordCounter, c.mIndexStart_d, c.mIndexEnd_d);
 
  { 
    // clusterizer ...
@@ -655,11 +654,11 @@ void RawToDigi_wrapper(
 
 
   uint32_t nModules=0;
-  cudaCheck(cudaMemcpyAsync(&c.moduleStart_d, &nModules, sizeof(uint32_t), cudaMemcpyHostToDevice, c.stream));
+  cudaCheck(cudaMemcpyAsync(c.moduleStart_d, &nModules, sizeof(uint32_t), cudaMemcpyHostToDevice, c.stream));
 
   countModules<<<blocks, threadsPerBlock, 0, c.stream>>>(c.moduleInd_d, c.moduleStart_d, c.clus_d, wordCounter);
 
-  cudaCheck(cudaMemcpyAsync(&nModules, &c.moduleStart_d, sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
+  cudaCheck(cudaMemcpyAsync(&nModules, c.moduleStart_d, sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
 
   std::cout << "found " << nModules << " Modules active" << std::endl;
 
@@ -671,6 +670,7 @@ void RawToDigi_wrapper(
     << "CUDA findModules kernel launch with " << blocksPerGrid
     << " blocks of " << threadsPerBlock << " threads\n";
 
+  cudaCheck(cudaMemsetAsync(c.clusInModule_d, 0, (MaxNumModules)*sizeof(uint32_t),c.stream));
 
   findClus<<<blocks, threadsPerBlock, 0, c.stream>>>(
                c.moduleInd_d,

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
@@ -155,27 +155,30 @@ struct context {
   uint32_t * pdigi_d;
   uint16_t * xx_d;
   uint16_t * yy_d;
-  uint16_t * xx_adc;
-  uint16_t * yy_adc;
-  uint32_t * moduleId_d;
   uint16_t * adc_d;
-  uint16_t * layer_d;
+
+  uint16_t * moduleInd_d;
   uint32_t * rawIdArr_d;
   uint32_t * errType_d;
   uint32_t * errWord_d;
   uint32_t * errFedID_d;
   uint32_t * errRawID_d;
 
-  // store the start and end index for each module (total 1856 modules-phase 1)
-  int *mIndexStart_d;
-  int *mIndexEnd_d;
+
+  // these are for the clusterizer (to be moved)
+  uint32_t * moduleStart_d;
+  int32_t *  clus_d;
+  uint32_t * clusInModule_d;
+  uint32_t * moduleId_d;
+
+  uint32_t * debug_d;
 };
 
 
 // wrapper function to call RawToDigi on the GPU from host side
 void RawToDigi_wrapper(context &, const SiPixelFedCablingMapGPU* cablingMapDevice, const uint32_t wordCounter, uint32_t *word, 
                         const uint32_t fedCounter,  uint8_t *fedId_h,
-                        bool convertADCtoElectrons, uint32_t * pdigi_h, int *mIndexStart_h, int *mIndexEnd_h, 
+                        bool convertADCtoElectrons, uint32_t * pdigi_h,
                         uint32_t *rawIdArr_h, uint32_t *errType_h, uint32_t *errWord_h, uint32_t *errFedID_h, uint32_t *errRawID_h,
                         bool useQualityInfo, bool includeErrors, bool debug = false);
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.h
@@ -7,6 +7,7 @@
 
 class SiPixelFedCablingMap;
 class SiPixelQuality;
+class TrackerGeometry;
 
 // Maximum fed for phase1 is 150 but not all of them are filled
 // Update the number FED based on maximum fed found in the cabling map
@@ -58,7 +59,8 @@ void deallocateCablingMap(SiPixelFedCablingMapGPU* cablingMapHost, SiPixelFedCab
   delete cablingMapHost;
 }
 
-void processCablingMap(SiPixelFedCablingMap const& cablingMap, SiPixelFedCablingMapGPU* cablingMapGPU, SiPixelFedCablingMapGPU* cablingMapDevice, const SiPixelQuality* badPixelInfo, std::set<unsigned int> const& modules);
+void processCablingMap(SiPixelFedCablingMap const& cablingMap, TrackerGeometry const& trackerGeom,
+                       SiPixelFedCablingMapGPU* cablingMapGPU, SiPixelFedCablingMapGPU* cablingMapDevice, const SiPixelQuality* badPixelInfo, std::set<unsigned int> const& modules);
 
 #endif // SiPixelFedCablingMapGPU_h
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -362,7 +362,7 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
 
 
 
-    RawToDigi_wrapper(context_, cablingMapGPUDevice_, wordCounterGPU, word, fedCounter, fedId_h, convertADCtoElectrons, pdigi_h, mIndexStart_h, mIndexEnd_h, 
+    RawToDigi_wrapper(context_, cablingMapGPUDevice_, wordCounterGPU, word, fedCounter, fedId_h, convertADCtoElectrons, pdigi_h, 
                       rawIdArr_h, errType_h, errWord_h, errFedID_h, errRawID_h, useQuality, includeErrors, debug);
 
 

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include<cstdint>
+
+namespace phase1PixelTopology {
+
+  constexpr uint16_t numRowsInRoc     = 80;
+  constexpr uint16_t numColsInRoc     = 52;
+  constexpr uint16_t lastRowInRoc     = 79;
+  constexpr uint16_t lastColInRoc     = 51;
+
+  constexpr uint16_t numRowsInModule  = 2*80;
+  constexpr uint16_t numColsInModule  = 8*52;
+  constexpr uint16_t lastRowInModule  = 2*80-1;
+  constexpr uint16_t lastColInModule  = 8*52-1;
+
+  constexpr int16_t xOffset = -81;
+  constexpr int16_t yOffset = -54*4;
+    
+  
+  constexpr uint32_t numPixsInModule  =  uint32_t(numRowsInModule)* uint32_t(numColsInModule);
+
+
+  // this is for the ROC n<512 (upgrade 1024)
+  constexpr inline
+  uint16_t  divu52(uint16_t n) {
+    n = n>>2;
+    uint16_t q = (n>>1) + (n>>4);
+    q = q + (q>>4) + (q>>5); q = q >> 3;
+    uint16_t r = n - q*13;
+    return q + ((r + 3) >> 4);
+    // return q + (r > 12);
+  }
+
+  constexpr inline
+  bool isEdgeX(uint16_t px) { return (px==0) | (px==lastRowInModule);}
+  constexpr inline
+  bool isEdgeY(uint16_t	py) { return (py==0) | (py==lastColInModule);}
+
+  
+  constexpr inline
+  uint16_t toRocX(uint16_t px) { return (px<numRowsInRoc) ? px : px-numRowsInRoc; }
+  constexpr inline
+  uint16_t toRocY(uint16_t py) {  
+    auto roc = divu52(py);
+    return py - 52*roc;
+  }
+
+  constexpr inline
+  bool isBigPixX(uint16_t px) {
+    return (px==79) | (px==80);
+  }
+
+  constexpr inline
+  bool isBigPixY(uint16_t py) {
+    auto ly=toRocY(py);
+    return (ly==0) | (ly==lastColInRoc);
+  }
+
+
+  constexpr inline
+  uint16_t localX(uint16_t px) {
+    auto shift = 0;
+    if (px>lastRowInRoc) shift+=1;
+    if (px>numRowsInRoc) shift+=1;
+    return px+shift;
+  }
+
+  constexpr inline
+  uint16_t localY(uint16_t py) {
+    auto roc = divu52(py);
+    auto shift = 2*roc;
+    auto yInRoc = py - 52*roc;
+    if (yInRoc>0) shift+=1;
+    return py+shift;
+  }
+  
+}
+

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -27,3 +27,7 @@
   <use   name="Geometry/Records"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+
+
+
+<bin file="phase1PixelTopology_t.cpp"/>

--- a/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cpp
+++ b/Geometry/TrackerGeometryBuilder/test/phase1PixelTopology_t.cpp
@@ -1,0 +1,146 @@
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
+#include<cassert>
+#include<tuple>
+
+namespace {
+
+  // original code from CMSSW_4_4
+
+  std::tuple<int,bool> localXori(int mpx) {
+   const float m_pitchx=1.f;
+   int binoffx = int(mpx);             // truncate to int
+   float local_pitchx = m_pitchx;      // defaultpitch
+
+   if (binoffx>80) {            // ROC 1 - handles x on edge cluster
+     binoffx=binoffx+2;
+   } else if (binoffx==80) {    // ROC 1
+     binoffx=binoffx+1;
+     local_pitchx = 2 * m_pitchx;
+     
+   } else if (binoffx==79) {      // ROC 0
+     binoffx=binoffx+0;
+     local_pitchx = 2 * m_pitchx;    
+   } else if (binoffx>=0) {       // ROC 0
+     binoffx=binoffx+0;
+     
+   } else { // too small
+       assert("binoffx too small"==0);
+   }
+
+   return std::make_tuple(binoffx,local_pitchx>m_pitchx);
+  }
+
+
+  std::tuple<int,bool> localYori(int mpy) {
+   const float m_pitchy=1.f;
+   int binoffy = int(mpy);             // truncate to int
+   float local_pitchy = m_pitchy;      // defaultpitch
+ 
+   if (binoffy>416) {            // ROC 8, not real ROC
+     binoffy=binoffy+17;
+   } else if (binoffy==416) {    // ROC 8
+     binoffy=binoffy+16;
+     local_pitchy = 2 * m_pitchy;
+         
+   } else if (binoffy==415) {    // ROC 7, last big pixel
+     binoffy=binoffy+15;
+     local_pitchy = 2 * m_pitchy;
+   } else if (binoffy>364) {     // ROC 7
+     binoffy=binoffy+15;
+   } else if (binoffy==364) {    // ROC 7
+     binoffy=binoffy+14;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==363) {      // ROC 6
+     binoffy=binoffy+13;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>312) {       // ROC 6
+     binoffy=binoffy+13;
+   } else if (binoffy==312) {      // ROC 6
+     binoffy=binoffy+12;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==311) {      // ROC 5
+     binoffy=binoffy+11;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>260) {      // ROC 5
+     binoffy=binoffy+11;
+   } else if (binoffy==260) {     // ROC 5
+     binoffy=binoffy+10;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==259) {      // ROC 4
+     binoffy=binoffy+9;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>208) {       // ROC 4
+     binoffy=binoffy+9;
+   } else if (binoffy==208) {      // ROC 4
+     binoffy=binoffy+8;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==207)  {      // ROC 3
+     binoffy=binoffy+7;
+     local_pitchy = 2 * m_pitchy;    
+     } else if (binoffy>156) {       // ROC 3
+     binoffy=binoffy+7;
+   } else if (binoffy==156) {      // ROC 3
+     binoffy=binoffy+6;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==155) {      // ROC 2
+     binoffy=binoffy+5;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>104) {       // ROC 2
+     binoffy=binoffy+5;
+   } else if (binoffy==104) {      // ROC 2
+     binoffy=binoffy+4;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==103) {      // ROC 1
+     binoffy=binoffy+3;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>52) {       // ROC 1
+     binoffy=binoffy+3;
+   } else if (binoffy==52) {      // ROC 1
+     binoffy=binoffy+2;
+     local_pitchy = 2 * m_pitchy;
+     
+   } else if (binoffy==51) {      // ROC 0
+     binoffy=binoffy+1;
+     local_pitchy = 2 * m_pitchy;    
+   } else if (binoffy>0) {         // ROC 0
+     binoffy=binoffy+1;
+   } else if (binoffy==0) {       // ROC 0
+     binoffy=binoffy+0;
+     local_pitchy = 2 * m_pitchy;
+   } else {
+       assert("binoffy too small"==0);
+   } 
+
+   return std::make_tuple(binoffy,local_pitchy>m_pitchy);
+  }   
+
+}
+
+#include<iostream>
+int main() {
+
+  for (uint16_t ix=0; ix<80*2; ++ix) {
+    auto ori = localXori(ix);
+    auto xl = phase1PixelTopology::localX(ix);
+    auto bp = phase1PixelTopology::isBigPixX(ix);
+    if (std::get<0>(ori)!=xl) std::cout << "Error " << std::get<0>(ori) << "!=" << xl << std::endl;
+    assert(std::get<1>(ori)==bp);
+  }
+
+  for (uint16_t iy=0; iy<52*8; ++iy) {
+    auto ori = localYori(iy);
+    auto yl = phase1PixelTopology::localY(iy);
+    auto bp = phase1PixelTopology::isBigPixY(iy);
+    if (std::get<0>(ori)!=yl) std::cout << "Error " << std::get<0>(ori) << "!=" << yl << std::endl;
+    assert(std::get<1>(ori)==bp);
+  }
+
+
+  return 0;
+}

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+
+namespace gpuClustering {
+
+  constexpr uint32_t MaxNumModules = 2000;
+
+  constexpr uint32_t MaxNumPixels = 256*2000;  // this does not mean maxPixelPerModule==256!
+  
+  constexpr uint16_t InvId=9999; // must be > MaxNumModules
+  
+  __global__ void countModules(uint16_t const * id,
+			       uint32_t * moduleStart,
+			       int32_t * clus,
+			       int numElements){
+    
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i >= numElements) return;
+    clus[i]=i;
+    if (InvId==id[i]) return;
+    auto j=i-1;
+    while(j>=0 && id[j]==InvId) --j;
+    if(j<0 || id[j]!=id[i]) {
+      // boundary...
+      auto loc = atomicInc(moduleStart,MaxNumModules);
+      moduleStart[loc+1]=i;
+    }
+  }
+  
+  
+  __global__ void findClus(uint16_t const * id,
+			   uint16_t const * x,
+			   uint16_t const * y,
+			   uint8_t const * adc,
+			   uint32_t const * moduleStart,
+			 uint32_t * clusInModule, uint32_t * moduleId,
+			   int32_t * clus, uint32_t * debug, 
+			   int numElements){
+    
+    __shared__ bool go;
+    __shared__ int nclus;
+    
+    
+    auto first = moduleStart[1 + blockIdx.x];  
+    
+    auto me = id[first];
+    
+    first+=threadIdx.x;
+    
+    go=true;
+    nclus=0;
+    __syncthreads();
+    
+    
+    while (go) {
+      __syncthreads();
+      go=false;
+      __syncthreads();
+
+      for (int i=first; i<numElements; i+=blockDim.x) {
+	if (id[i]==InvId) continue;  // not valid
+	if (id[i]!=me) break;  // end of module
+	++debug[i];
+	for (int j=i+1; j<numElements; ++j) {
+	if (id[j]==InvId) continue;  // not valid
+	if (id[j]!=me) break;  // end of module
+
+	if (std::abs(int(x[j])-int(x[i]))>1) continue;
+	if (std::abs(int(y[j])-int(y[i]))>1) continue;
+	auto old = atomicMin(&clus[j],clus[i]);
+	if (old!=clus[i]) go=true;
+	atomicMin(&clus[i],old);
+	}
+      }
+      
+    __syncthreads();
+    }
+    
+    /*
+    // fast count (nice but not much useful)
+    auto laneId = threadIdx.x & 0x1f;
+    
+    for (int i=first; i<numElements; i+=blockDim.x) {
+    if (id[i]==InvId) continue;  // not valid
+    if (id[i]!=me) break;  // end of module
+    auto value = clus[i]^i;
+    auto mask = __ballot_sync(0xffffffff,value==0);
+    if (laneId==0) atomicAdd(&nclus,__popc(mask));
+    }
+    
+    __syncthreads();
+    if (me<30)
+    if (laneId==0) printf("%d clusters in module %d\n",nclus,me);
+    */
+
+    nclus=0;
+    __syncthreads();
+    for (int i=first; i<numElements; i+=blockDim.x) {
+      if (id[i]==InvId) continue;  // not valid
+      if (id[i]!=me) break;  // end of module
+      if (clus[i]==i) {
+	auto old = atomicAdd(&nclus,1);
+	clus[i]=-(old+1);
+      }
+    }
+    
+    __syncthreads();
+    
+    for (int i=first; i<numElements; i+=blockDim.x) {
+      if (id[i]==InvId) continue;  // not valid
+      if (id[i]!=me) break;  // end of module
+      if (clus[i]>=0) clus[i]=clus[clus[i]];
+    }
+    
+    __syncthreads();
+    for (int i=first; i<numElements; i+=blockDim.x) {
+      if (id[i]==InvId) {clus[i]=-9999; continue; } // not valid
+      if (id[i]!=me) break;  // end of module
+      clus[i] = -clus[i] -1;
+    }
+    
+  
+    __syncthreads();
+    if (threadIdx.x==0) {
+      clusInModule[blockIdx.x]=nclus;
+      moduleId[blockIdx.x]=me;
+    }
+    
+    
+    if (me<30)
+      if (threadIdx.x==0) printf("%d clusters in module %d\n",nclus,me);
+    
+  }
+  
+} //namespace gpuClustering
+

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -124,7 +124,7 @@ namespace gpuClustering {
   
     __syncthreads();
     if (threadIdx.x==0) {
-      clusInModule[blockIdx.x]=nclus;
+      clusInModule[me]=nclus;
       moduleId[blockIdx.x]=me;
     }
     

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -33,9 +33,9 @@ namespace gpuClustering {
   __global__ void findClus(uint16_t const * id,
 			   uint16_t const * x,
 			   uint16_t const * y,
-			   uint8_t const * adc,
+			   uint16_t const * adc,
 			   uint32_t const * moduleStart,
-			 uint32_t * clusInModule, uint32_t * moduleId,
+			   uint32_t * clusInModule, uint32_t * moduleId,
 			   int32_t * clus, uint32_t * debug, 
 			   int numElements){
     

--- a/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
@@ -1,3 +1,10 @@
+<use name="cuda"/>
+<use name="cuda-api-wrappers"/>
+<bin file="gpuClustering.cu" name="gpuClustering_t">
+  <flags CXXFLAGS="-g"/>
+  <flags CUDA_FLAGS="-O3"/>
+</bin>
+
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/Common"/>

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
@@ -1,0 +1,355 @@
+#include "cuda/api_wrappers.h"
+
+#include <iostream>
+#include <iomanip>
+
+#include <cstdint>
+#include <memory>
+#include <algorithm>
+#include<cmath>
+#include<cassert>
+
+#include<set>
+#include<vector>
+
+
+constexpr uint32_t numRowsInRoc     = 80;
+constexpr uint32_t numColsInRoc     = 52;
+
+constexpr uint32_t numRowsInModule  = 2*80;
+constexpr uint32_t numColsInModule  = 8*52;
+constexpr uint32_t numPixsInModule  = numRowsInModule*numColsInModule;
+
+
+constexpr uint32_t numColsInHalfModule  = 4*52;
+constexpr uint32_t numPixsInHalfModule  = numRowsInModule*numColsInHalfModule;
+
+
+constexpr uint32_t MaxNumModules = 2000;
+
+constexpr uint32_t MaxNumPixels = 128*4000;
+
+
+__global__ void countModules(uint32_t const * id,
+			     uint32_t * moduleStart,
+			     int32_t * clus,
+			     int numElements){
+
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i >= numElements) return;
+  clus[i]=i;
+  if (id[i]==0) return;
+  auto j=i-1;
+  while(j>=0 && id[j]==0) --j;
+  if(j<0 || id[j]!=id[i]) {
+    // boundary...
+    auto loc = atomicInc(moduleStart,MaxNumModules);
+    moduleStart[loc+1]=i;
+  }
+}
+
+
+__global__ void findClus(uint32_t const * id,
+			 uint16_t const * x,
+			 uint16_t const * y,
+			 uint8_t const * adc,
+			 uint32_t const * moduleStart,
+			 int32_t * clus, uint32_t * debug, 
+			 int numElements){
+
+  __shared__ bool go;
+  __shared__ int nclus;
+
+ 
+  auto first = moduleStart[1 + blockIdx.x];  
+
+  auto me = id[first];
+
+  first+=threadIdx.x;
+  
+  go=true;
+  nclus=0;
+  __syncthreads();
+
+  
+  while (go) {
+   __syncthreads();
+    go=false;
+    __syncthreads();
+
+    for (int i=first; i<numElements; i+=blockDim.x) {
+      if (id[i]==0) continue;  // not valid
+      if (id[i]!=me) break;  // end of module
+      ++debug[i];
+      for (int j=i+1; j<numElements; ++j) {
+	if (id[j]==0) continue;  // not valid
+	if (id[j]!=me) break;  // end of module
+	// if (clus[i]<i) continue; // already clusterized
+	if (std::abs(int(x[j])-int(x[i]))>1) continue;
+	if (std::abs(int(y[j])-int(y[i]))>1) continue;
+	auto old = atomicMin(&clus[j],clus[i]);
+	if (old!=clus[i]) go=true;
+	atomicMin(&clus[i],old);
+      }
+    }
+  
+    __syncthreads();
+  }
+
+  /*
+  // fast count (nice but not much useful)
+  auto laneId = threadIdx.x & 0x1f;
+
+  for (int i=first; i<numElements; i+=blockDim.x) {
+    if (id[i]==0) continue;  // not valid
+    if (id[i]!=me) break;  // end of module
+    auto value = clus[i]^i;
+    auto mask = __ballot_sync(0xffffffff,value==0);
+    if (laneId==0) atomicAdd(&nclus,__popc(mask));
+  }
+  
+  __syncthreads();
+  if (me<30)
+  if (laneId==0) printf("%d clusters in module %d\n",nclus,me);
+  */
+
+   nclus=0;
+  __syncthreads();
+  for (int i=first; i<numElements; i+=blockDim.x) {
+    if (id[i]==0) continue;  // not valid
+    if (id[i]!=me) break;  // end of module
+    if (clus[i]==i) {
+      auto old = atomicAdd(&nclus,1);
+      clus[i]=-(old+1);
+    }
+  }
+
+   __syncthreads();
+
+  for (int i=first; i<numElements; i+=blockDim.x) {
+    if (id[i]==0) continue;  // not valid
+    if (id[i]!=me) break;  // end of module
+    if (clus[i]>=0) clus[i]=clus[clus[i]];
+  }
+
+  __syncthreads();
+  for (int i=first; i<numElements; i+=blockDim.x) {
+    if (id[i]==0) {clus[i]=nclus+1; continue; } // not valid
+    if (id[i]!=me) break;  // end of module
+    clus[i] = -clus[i] -1;
+  }
+
+  
+  __syncthreads();
+  if (me<30)
+  if (threadIdx.x==0) printf("%d clusters in module %d\n",nclus,me);
+
+}
+
+
+int main(void)
+{
+  if (cuda::device::count() == 0) {
+    std::cerr << "No CUDA devices on this system" << "\n";
+    exit(EXIT_FAILURE);
+  }
+  
+  int numElements = 200000;
+ 
+  
+  auto h_id = std::make_unique<uint32_t[]>(numElements);
+  auto h_x = std::make_unique<uint16_t[]>(numElements);
+  auto h_y = std::make_unique<uint16_t[]>(numElements);
+  auto h_adc = std::make_unique<uint8_t[]>(numElements);
+  auto h_clus = std::make_unique<int[]>(numElements);
+  
+  auto h_debug = std::make_unique<unsigned int[]>(numElements);
+ 
+  
+  auto current_device = cuda::device::current::get();
+  auto d_id = cuda::memory::device::make_unique<uint32_t[]>(current_device, numElements);
+  auto d_x = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
+  auto d_y = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
+  auto d_adc = cuda::memory::device::make_unique<uint8_t[]>(current_device, numElements);
+  
+  auto d_clus = cuda::memory::device::make_unique<int[]>(current_device, numElements);
+
+  auto d_moduleStart = cuda::memory::device::make_unique<uint32_t[]>(current_device, MaxNumModules+1);
+  
+  auto d_debug = cuda::memory::device::make_unique<unsigned int[]>(current_device, numElements);
+
+  
+    // later random number
+  int n=0;
+  int ncl=0;
+  int y[10]={5,7,9,1,3,0,4,8,2,6};
+
+  {
+    // isolated
+    int id = 1;
+    int x = 10;
+    ++ncl;
+    h_id[n]=id;
+    h_x[n]=x;
+    h_y[n]=x;
+    h_adc[n]=100;
+    ++n;
+    // diagonal
+    ++ncl;
+    for (int x=20; x<25; ++x) {
+      h_id[n]=id;
+      h_x[n]=x;
+      h_y[n]=x;
+      h_adc[n]=100;
+      ++n;
+    }
+    ++ncl;
+    // reversed
+    for (int x=45; x>40; --x) {
+      h_id[n]=id;
+      h_x[n]=x;
+      h_y[n]=x;
+      h_adc[n]=100;
+      ++n;
+    }
+    ++ncl;
+    h_id[n++]=0; // error
+    // messy
+    int xx[5] = {21,25,23,24,22};
+    for (int k=0; k<5; ++k) {
+      h_id[n]=id;
+      h_x[n]=xx[k];
+      h_y[n]=20+xx[k];
+      h_adc[n]=100;
+      ++n;
+    }
+    // holes
+    ++ncl;
+    for (int k=0; k<5; ++k) {
+      h_id[n]=id;
+      h_x[n]=xx[k];
+      h_y[n]=100;
+      h_adc[n]=100;
+      ++n;
+      if (xx[k]%2==0) {
+	h_id[n]=id;
+	h_x[n]=xx[k];
+	h_y[n]=101;
+	h_adc[n]=100;
+      ++n;
+      }
+    }
+  }
+  
+
+  for(int id=11; id<=10000; id+=10) {
+    if (id/100%2) h_id[n++]=0;  // error
+    for (int x=0; x<40; x+=4) {	 
+      ++ncl;
+      if ((id/10)%2) {
+	for (int k=0; k<10; ++k) {
+	  h_id[n]=id;
+	  h_x[n]=x;
+	  h_y[n]=x+y[k];
+	  h_adc[n]=100;
+	  ++n;
+	  h_id[n]=id;
+	  h_x[n]=x+1;
+	  h_y[n]=x+y[k]+2;
+	  h_adc[n]=100;
+	  ++n;
+	}
+      } else {
+	for (int k=0; k<10; ++k) {
+	  h_id[n]=id;
+	  h_x[n]=x;
+	  h_y[n]=x+y[9-k];
+	  h_adc[n]=100;
+	  ++n;
+	  if (y[k]==3) continue; // hole
+	  if (id==51)  {h_id[n++]=0; h_id[n++]=0; }// error
+	  h_id[n]=id;
+	  h_x[n]=x+1;
+	  h_y[n]=x+y[k]+2;
+	  h_adc[n]=100;
+	  ++n;
+	}
+      }
+    }
+  }
+  std::cout << "created " << n << " digis in " << ncl << " clusters" << std::endl;
+  assert(n<=numElements);
+  size_t size32 = n * sizeof(unsigned int);
+  size_t size16 = n * sizeof(unsigned short);
+  size_t size8 = n * sizeof(uint8_t);
+	 
+  uint32_t nModules=0;
+  cuda::memory::copy(d_moduleStart.get(),&nModules,sizeof(uint32_t));
+  
+  cuda::memory::copy(d_id.get(), h_id.get(), size32);
+  cuda::memory::copy(d_x.get(), h_x.get(), size16);
+  cuda::memory::copy(d_y.get(), h_y.get(), size16);
+  cuda::memory::copy(d_adc.get(), h_adc.get(), size8);
+  cuda::memory::device::zero(d_debug.get(),size32);
+  
+  // Launch CUDA Kernels
+
+  
+  int threadsPerBlock = 256;
+  int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
+  std::cout
+    << "CUDA countModules kernel launch with " << blocksPerGrid
+    << " blocks of " << threadsPerBlock << " threads\n";
+		     
+  cuda::launch(
+	       countModules, 
+	       { blocksPerGrid, threadsPerBlock },
+	       d_id.get(), d_moduleStart.get() ,d_clus.get(),n
+	       );
+  
+  cuda::memory::copy(&nModules,d_moduleStart.get(),sizeof(uint32_t));
+		     
+  std::cout << "found " << nModules << " Modules active" << std::endl;
+
+  
+  threadsPerBlock = 256;
+  blocksPerGrid = nModules;
+
+
+
+  std::cout
+    << "CUDA findModules kernel launch with " << blocksPerGrid
+    << " blocks of " << threadsPerBlock << " threads\n";
+
+  cuda::launch(
+	       findClus,
+	       { blocksPerGrid, threadsPerBlock },
+	       d_id.get(), d_x.get(), d_y.get(),  d_adc.get(),
+	       d_moduleStart.get(),
+	       d_clus.get(), d_debug.get(),
+	       n
+	       );
+
+  cuda::memory::copy(h_clus.get(), d_clus.get(), size32);
+  cuda::memory::copy(h_debug.get(), d_debug.get(), size32);
+
+  auto p = std::minmax_element(h_debug.get(),h_debug.get()+n);
+  std::cout << "debug " << *p.first << ' ' << *p.second << std::endl;  
+
+  std::set<unsigned int> clids;
+  std::vector<unsigned int> seeds;
+  for (int i=0; i<n; ++i) {
+    if (h_id[i]==0) continue;
+    clids.insert(h_id[i]*100+h_clus[i]);
+		 // clids.insert(h_clus[i]);
+    if (h_clus[i]==i) seeds.push_back(i);
+  }
+   
+  std::cout << "found " << clids.size() << " clusters and " << seeds.size() << " seeds" << std::endl;
+
+
+
+  return 0;
+
+}
+

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
@@ -1,3 +1,6 @@
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h"
+
+
 #include "cuda/api_wrappers.h"
 
 #include <iostream>
@@ -13,158 +16,19 @@
 #include<vector>
 
 
-constexpr uint32_t numRowsInRoc     = 80;
-constexpr uint32_t numColsInRoc     = 52;
-
-constexpr uint32_t numRowsInModule  = 2*80;
-constexpr uint32_t numColsInModule  = 8*52;
-constexpr uint32_t numPixsInModule  = numRowsInModule*numColsInModule;
-
-
-constexpr uint32_t numColsInHalfModule  = 4*52;
-constexpr uint32_t numPixsInHalfModule  = numRowsInModule*numColsInHalfModule;
-
-
-constexpr uint32_t MaxNumModules = 2000;
-
-
-constexpr uint32_t MaxNumPixels = 256*2000;
-
-
-constexpr uint16_t InvId=9999; // must be > MaxNumModules
-
-__global__ void countModules(uint16_t const * id,
-			     uint32_t * moduleStart,
-			     int32_t * clus,
-			     int numElements){
-
-  int i = blockDim.x * blockIdx.x + threadIdx.x;
-  if (i >= numElements) return;
-  clus[i]=i;
-  if (InvId==id[i]) return;
-  auto j=i-1;
-  while(j>=0 && id[j]==InvId) --j;
-  if(j<0 || id[j]!=id[i]) {
-    // boundary...
-    auto loc = atomicInc(moduleStart,MaxNumModules);
-    moduleStart[loc+1]=i;
-  }
-}
-
-
-__global__ void findClus(uint16_t const * id,
-			 uint16_t const * x,
-			 uint16_t const * y,
-			 uint8_t const * adc,
-			 uint32_t const * moduleStart,
-			 uint32_t * clusInModule, uint32_t * moduleId,
-			 int32_t * clus, uint32_t * debug, 
-			 int numElements){
-
-  __shared__ bool go;
-  __shared__ int nclus;
-
- 
-  auto first = moduleStart[1 + blockIdx.x];  
-
-  auto me = id[first];
-
-  first+=threadIdx.x;
-  
-  go=true;
-  nclus=0;
-  __syncthreads();
 
   
-  while (go) {
-   __syncthreads();
-    go=false;
-    __syncthreads();
-
-    for (int i=first; i<numElements; i+=blockDim.x) {
-      if (id[i]==InvId) continue;  // not valid
-      if (id[i]!=me) break;  // end of module
-      ++debug[i];
-      for (int j=i+1; j<numElements; ++j) {
-	if (id[j]==InvId) continue;  // not valid
-	if (id[j]!=me) break;  // end of module
-	// if (clus[i]<i) continue; // already clusterized
-	if (std::abs(int(x[j])-int(x[i]))>1) continue;
-	if (std::abs(int(y[j])-int(y[i]))>1) continue;
-	auto old = atomicMin(&clus[j],clus[i]);
-	if (old!=clus[i]) go=true;
-	atomicMin(&clus[i],old);
-      }
-    }
-  
-    __syncthreads();
-  }
-
-  /*
-  // fast count (nice but not much useful)
-  auto laneId = threadIdx.x & 0x1f;
-
-  for (int i=first; i<numElements; i+=blockDim.x) {
-    if (id[i]==InvId) continue;  // not valid
-    if (id[i]!=me) break;  // end of module
-    auto value = clus[i]^i;
-    auto mask = __ballot_sync(0xffffffff,value==0);
-    if (laneId==0) atomicAdd(&nclus,__popc(mask));
-  }
-  
-  __syncthreads();
-  if (me<30)
-  if (laneId==0) printf("%d clusters in module %d\n",nclus,me);
-  */
-
-   nclus=0;
-  __syncthreads();
-  for (int i=first; i<numElements; i+=blockDim.x) {
-    if (id[i]==InvId) continue;  // not valid
-    if (id[i]!=me) break;  // end of module
-    if (clus[i]==i) {
-      auto old = atomicAdd(&nclus,1);
-      clus[i]=-(old+1);
-    }
-  }
-
-   __syncthreads();
-
-  for (int i=first; i<numElements; i+=blockDim.x) {
-    if (id[i]==InvId) continue;  // not valid
-    if (id[i]!=me) break;  // end of module
-    if (clus[i]>=0) clus[i]=clus[clus[i]];
-  }
-
-  __syncthreads();
-  for (int i=first; i<numElements; i+=blockDim.x) {
-    if (id[i]==InvId) {clus[i]=-9999; continue; } // not valid
-    if (id[i]!=me) break;  // end of module
-    clus[i] = -clus[i] -1;
-  }
-
-  
-  __syncthreads();
-  if (threadIdx.x==0) {
-    clusInModule[blockIdx.x]=nclus;
-    moduleId[blockIdx.x]=me;
-  }
-
-  
-  if (me<30)
-  if (threadIdx.x==0) printf("%d clusters in module %d\n",nclus,me);
-
-}
-
-
 int main(void)
 {
   if (cuda::device::count() == 0) {
     std::cerr << "No CUDA devices on this system" << "\n";
     exit(EXIT_FAILURE);
   }
+
+
+  using namespace gpuClustering;
   
-  int numElements = 200000;
+  int numElements = MaxNumPixels;
  
 
   // these in reality are already on GPU

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering.cu
@@ -35,7 +35,7 @@ int main(void)
   auto h_id = std::make_unique<uint16_t[]>(numElements);
   auto h_x = std::make_unique<uint16_t[]>(numElements);
   auto h_y = std::make_unique<uint16_t[]>(numElements);
-  auto h_adc = std::make_unique<uint8_t[]>(numElements);
+  auto h_adc = std::make_unique<uint16_t[]>(numElements);
 
   auto h_clus = std::make_unique<int[]>(numElements);
   
@@ -46,7 +46,7 @@ int main(void)
   auto d_id = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
   auto d_x = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
   auto d_y = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
-  auto d_adc = cuda::memory::device::make_unique<uint8_t[]>(current_device, numElements);
+  auto d_adc = cuda::memory::device::make_unique<uint16_t[]>(current_device, numElements);
   
   auto d_clus = cuda::memory::device::make_unique<int[]>(current_device, numElements);
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
@@ -1,0 +1,96 @@
+#pragma once
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h"
+
+
+// The template header files
+//#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplateReco.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h"
+
+
+#include <utility>
+#include <vector>
+
+
+class MagneticField;
+class PixelCPEFast final : public PixelCPEBase
+{
+public:
+   struct ClusterParamGeneric : ClusterParam
+   {
+      ClusterParamGeneric(const SiPixelCluster & cl) : ClusterParam(cl){}
+      // The truncation value pix_maximum is an angle-dependent cutoff on the
+      // individual pixel signals. It should be applied to all pixels in the
+      // cluster [signal_i = fminf(signal_i, pixmax)] before the column and row
+      // sums are made. Morris
+      int pixmx;
+      
+      // These are errors predicted by PIXELAV
+      float sigmay; // CPE Generic y-error for multi-pixel cluster
+      float sigmax; // CPE Generic x-error for multi-pixel cluster
+      float sy1   ; // CPE Generic y-error for single single-pixel
+      float sy2   ; // CPE Generic y-error for single double-pixel cluster
+      float sx1   ; // CPE Generic x-error for single single-pixel cluster
+      float sx2   ; // CPE Generic x-error for single double-pixel cluster
+      
+   };
+   
+   PixelCPEFast(edm::ParameterSet const& conf, const MagneticField *,
+                   const TrackerGeometry&, const TrackerTopology&, const SiPixelLorentzAngle *,
+                   const SiPixelGenErrorDBObject *, const SiPixelLorentzAngle *);
+   
+   
+   
+private:
+   ClusterParam * createClusterParam(const SiPixelCluster & cl) const override;
+   
+   LocalPoint localPosition (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
+   LocalError localError   (DetParam const & theDetParam, ClusterParam & theClusterParam) const override;
+   
+   //--------------------------------------------------------------------
+   //  Methods.
+   //------------------------------------------------------------------
+   static float
+   generic_position_formula( int size,                //!< Size of this projection.
+                            int Q_f,              //!< Charge in the first pixel.
+                            int Q_l,              //!< Charge in the last pixel.
+                            uint16_t upper_edge_first_pix, //!< As the name says.
+                            uint16_t lower_edge_last_pix,  //!< As the name says.
+                            float lorentz_shift,   //!< L-width
+                            float theThickness,   //detector thickness
+                            float cot_angle,            //!< cot of alpha_ or beta_
+                            float pitch,            //!< thePitchX or thePitchY
+                            bool first_is_big,       //!< true if the first is big
+                            bool last_is_big        //!< true if the last is big
+   );
+   
+   static void
+   collect_edge_charges(ClusterParam & theClusterParam,  //!< input, the cluster
+                        int & Q_f_X,              //!< output, Q first  in X
+                        int & Q_l_X,              //!< output, Q last   in X
+                        int & Q_f_Y,              //!< output, Q first  in Y
+                        int & Q_l_Y,              //!< output, Q last   in Y
+                        bool truncate
+   );
+   
+   
+   bool UseErrorsFromTemplates_;
+   bool TruncatePixelCharge_;
+   
+   float EdgeClusterErrorX_;
+   float EdgeClusterErrorY_;
+   
+   std::vector<float> xerr_barrel_l1_,yerr_barrel_l1_,xerr_barrel_ln_;
+   std::vector<float> yerr_barrel_ln_,xerr_endcap_,yerr_endcap_;
+   float xerr_barrel_l1_def_, yerr_barrel_l1_def_,xerr_barrel_ln_def_;
+   float yerr_barrel_ln_def_, xerr_endcap_def_, yerr_endcap_def_;
+   
+   //--- DB Error Parametrization object, new light templates 
+   std::vector< SiPixelGenErrorStore > thePixelGenError_;
+   
+};
+
+
+
+

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
@@ -1,0 +1,103 @@
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+
+// new record 
+#include "CondFormats/DataRecord/interface/SiPixelGenErrorDBObjectRcd.h"
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include <memory>
+
+class  PixelCPEFastESProducer: public edm::ESProducer{
+ public:
+  PixelCPEFastESProducer(const edm::ParameterSet & p);
+  std::shared_ptr<PixelClusterParameterEstimator> produce(const TkPixelCPERecord &);
+ private:
+  std::shared_ptr<PixelClusterParameterEstimator> cpe_;
+  edm::ParameterSet pset_;
+  edm::ESInputTag magname_;
+  bool UseErrorsFromTemplates_;
+};
+
+
+#include <string>
+#include <memory>
+
+using namespace edm;
+
+
+
+
+PixelCPEFastESProducer::PixelCPEFastESProducer(const edm::ParameterSet & p) 
+{
+  std::string myname = p.getParameter<std::string>("ComponentName");
+  magname_ = p.existsAs<edm::ESInputTag>("MagneticFieldRecord")?
+    p.getParameter<edm::ESInputTag>("MagneticFieldRecord"):edm::ESInputTag("");
+  UseErrorsFromTemplates_    = p.getParameter<bool>("UseErrorsFromTemplates");
+
+
+  pset_ = p;
+  setWhatProduced(this,myname);
+
+
+}
+
+
+std::shared_ptr<PixelClusterParameterEstimator>
+PixelCPEFastESProducer::produce(const TkPixelCPERecord & iRecord){ 
+
+  ESHandle<MagneticField> magfield;
+  iRecord.getRecord<IdealMagneticFieldRecord>().get( magname_, magfield );
+
+  edm::ESHandle<TrackerGeometry> pDD;
+  iRecord.getRecord<TrackerDigiGeometryRecord>().get( pDD );
+
+  edm::ESHandle<TrackerTopology> hTT;
+  iRecord.getRecord<TrackerDigiGeometryRecord>().getRecord<TrackerTopologyRcd>().get(hTT);
+
+  // Lorant angle for offsets
+  ESHandle<SiPixelLorentzAngle> lorentzAngle;
+  iRecord.getRecord<SiPixelLorentzAngleRcd>().get(lorentzAngle );
+
+  // add the new la width object
+  ESHandle<SiPixelLorentzAngle> lorentzAngleWidth;
+  const SiPixelLorentzAngle * lorentzAngleWidthProduct = nullptr;
+  iRecord.getRecord<SiPixelLorentzAngleRcd>().get("forWidth",lorentzAngleWidth );
+  lorentzAngleWidthProduct = lorentzAngleWidth.product();
+
+  const SiPixelGenErrorDBObject * genErrorDBObjectProduct = nullptr;
+
+  // Errors take only from new GenError
+  ESHandle<SiPixelGenErrorDBObject> genErrorDBObject;
+  if(UseErrorsFromTemplates_) {  // do only when generrors are needed
+    iRecord.getRecord<SiPixelGenErrorDBObjectRcd>().get(genErrorDBObject); 
+    genErrorDBObjectProduct = genErrorDBObject.product();
+    //} else {
+    //std::cout<<" pass an empty GenError pointer"<<std::endl;
+  }
+  cpe_  = std::make_shared<PixelCPEFast>(
+                         pset_,magfield.product(),*pDD.product(),
+			 *hTT.product(),lorentzAngle.product(),
+			 genErrorDBObjectProduct,lorentzAngleWidthProduct);
+
+  return cpe_;
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEFastESProducer);
+

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -19,6 +19,7 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 # 4. Pixel Generic CPE
 #
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
+from RecoLocalTracker.SiPixelRecHits.PixelCPEFast_cfi import *
 #
 # 5. The new ESProducer for the Magnetic-field dependent template record
 #

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEFast_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEFast_cfi.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+PixelCPEFastESProducer = cms.ESProducer("PixelCPEFastESProducer",
+
+    ComponentName = cms.string('PixelCPEFast'),
+    Alpha2Order = cms.bool(True),
+
+    # Edge cluster errors in microns (determined by looking at residual RMS) 
+    EdgeClusterErrorX = cms.double( 50.0 ),                                      
+    EdgeClusterErrorY = cms.double( 85.0 ),                                                     
+
+    # these for CPEBase
+    useLAWidthFromDB = cms.bool(True),
+    useLAAlignmentOffsets = cms.bool(False),
+
+
+    # Can use errors predicted by the template code
+    # If UseErrorsFromTemplates is False, must also set
+    # TruncatePixelCharge and LoadTemplatesFromDB to be False                                        
+    UseErrorsFromTemplates = cms.bool(True),
+    LoadTemplatesFromDB = cms.bool(True),
+
+    # When set True this gives a slight improvement in resolution at no cost 
+    TruncatePixelCharge = cms.bool(True),
+
+    # petar, for clusterProbability() from TTRHs
+    ClusterProbComputationFlag = cms.int32(0),
+
+    #MagneticFieldRecord: e.g. "" or "ParabolicMF"
+    MagneticFieldRecord = cms.ESInputTag(""),
+)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -1,6 +1,6 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h"
 
-#include "RecoLocalTracker/SiPixelRecHits/interface/phase1PixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
@@ -14,10 +14,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-#include "boost/multi_array.hpp"
-
 #include <iostream>
-using namespace std;
 
 namespace {
    constexpr float micronsToCm = 1.0e-4;
@@ -34,12 +31,7 @@ PixelCPEFast::PixelCPEFast(edm::ParameterSet const & conf,
                                  const SiPixelLorentzAngle * lorentzAngle,
                                  const SiPixelGenErrorDBObject * genErrorDBObject,
                                  const SiPixelLorentzAngle * lorentzAngleWidth)
-: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, nullptr,lorentzAngleWidth,0) {
-   
-   if (theVerboseLevel > 0)
-      LogDebug("PixelCPEFast")
-      << " constructing a generic algorithm for ideal pixel detector.\n"
-      << " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
+                  : PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, nullptr,lorentzAngleWidth,0) {
    
    EdgeClusterErrorX_ = conf.getParameter<double>("EdgeClusterErrorX");
    EdgeClusterErrorY_ = conf.getParameter<double>("EdgeClusterErrorY");
@@ -55,9 +47,9 @@ PixelCPEFast::PixelCPEFast(edm::ParameterSet const & conf,
             throw cms::Exception("InvalidCalibrationLoaded")
             << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
             << ( *genErrorDBObject_ ).version();
-         if(MYDEBUG) cout<<"Loaded genErrorDBObject v"<<( *genErrorDBObject_ ).version()<<endl;
+     if(MYDEBUG) std::cout<<"Loaded genErrorDBObject v"<<( *genErrorDBObject_ ).version()<< std::endl;
    }  else {
-      if(MYDEBUG) cout<<" Use simple parametrised errors "<<endl;
+     if(MYDEBUG) std::cout<<" Use simple parametrised errors "<< std::endl;
    } // if ( UseErrorsFromTemplates_ )
    
    

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -1,0 +1,445 @@
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h"
+
+#include "RecoLocalTracker/SiPixelRecHits/interface/phase1PixelTopology.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+
+// this is needed to get errors from templates
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+
+// Services
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "boost/multi_array.hpp"
+
+#include <iostream>
+using namespace std;
+
+namespace {
+   constexpr float micronsToCm = 1.0e-4;
+   const bool MYDEBUG = false;
+}
+
+//-----------------------------------------------------------------------------
+//!  The constructor.
+//-----------------------------------------------------------------------------
+PixelCPEFast::PixelCPEFast(edm::ParameterSet const & conf,
+                                 const MagneticField * mag,
+                                 const TrackerGeometry& geom,
+                                 const TrackerTopology& ttopo,
+                                 const SiPixelLorentzAngle * lorentzAngle,
+                                 const SiPixelGenErrorDBObject * genErrorDBObject,
+                                 const SiPixelLorentzAngle * lorentzAngleWidth)
+: PixelCPEBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, nullptr,lorentzAngleWidth,0) {
+   
+   if (theVerboseLevel > 0)
+      LogDebug("PixelCPEFast")
+      << " constructing a generic algorithm for ideal pixel detector.\n"
+      << " CPEGeneric:: VerboseLevel = " << theVerboseLevel;
+   
+   EdgeClusterErrorX_ = conf.getParameter<double>("EdgeClusterErrorX");
+   EdgeClusterErrorY_ = conf.getParameter<double>("EdgeClusterErrorY");
+   
+   
+   UseErrorsFromTemplates_    = conf.getParameter<bool>("UseErrorsFromTemplates");
+   TruncatePixelCharge_       = conf.getParameter<bool>("TruncatePixelCharge");
+   
+   
+   // Use errors from templates or from GenError
+   if ( UseErrorsFromTemplates_ ) {
+     if ( !SiPixelGenError::pushfile( *genErrorDBObject_, thePixelGenError_) )
+            throw cms::Exception("InvalidCalibrationLoaded")
+            << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+            << ( *genErrorDBObject_ ).version();
+         if(MYDEBUG) cout<<"Loaded genErrorDBObject v"<<( *genErrorDBObject_ ).version()<<endl;
+   }  else {
+      if(MYDEBUG) cout<<" Use simple parametrised errors "<<endl;
+   } // if ( UseErrorsFromTemplates_ )
+   
+   
+   // Rechit errors in case other, more correct, errors are not vailable
+   // This are constants. Maybe there is a more efficienct way to store them.
+      xerr_barrel_l1_= {0.00115, 0.00120, 0.00088};
+      xerr_barrel_l1_def_=0.01030;
+      yerr_barrel_l1_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
+      yerr_barrel_l1_def_=0.00210;
+      xerr_barrel_ln_= {0.00115, 0.00120, 0.00088};
+      xerr_barrel_ln_def_=0.01030;
+      yerr_barrel_ln_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
+      yerr_barrel_ln_def_=0.00210;
+      xerr_endcap_= {0.0020, 0.0020};
+      xerr_endcap_def_=0.0020;
+      yerr_endcap_= {0.00210};
+      yerr_endcap_def_=0.00075;
+
+   
+   
+}
+
+PixelCPEBase::ClusterParam* PixelCPEFast::createClusterParam(const SiPixelCluster & cl) const
+{
+   return new ClusterParamGeneric(cl);
+}
+
+
+
+//-----------------------------------------------------------------------------
+//! Hit position in the local frame (in cm).  Unlike other CPE's, this
+//! one converts everything from the measurement frame (in channel numbers)
+//! into the local frame (in centimeters).
+//-----------------------------------------------------------------------------
+LocalPoint
+PixelCPEFast::localPosition(DetParam const & theDetParam, ClusterParam & theClusterParamBase) const
+{
+   
+   ClusterParamGeneric & theClusterParam = static_cast<ClusterParamGeneric &>(theClusterParamBase);
+
+   assert(!theClusterParam.with_track_angle); 
+   
+   float chargeWidthX = (theDetParam.lorentzShiftInCmX * theDetParam.widthLAFractionX);
+   float chargeWidthY = (theDetParam.lorentzShiftInCmY * theDetParam.widthLAFractionY);
+   float shiftX = 0.5f*theDetParam.lorentzShiftInCmX;
+   float shiftY = 0.5f*theDetParam.lorentzShiftInCmY;
+   
+   if ( UseErrorsFromTemplates_ ) {
+      
+      float qclus = theClusterParam.theCluster->charge();
+      float locBz = theDetParam.bz;
+      float locBx = theDetParam.bx;
+      //cout << "PixelCPEFast::localPosition(...) : locBz = " << locBz << endl;
+      
+      theClusterParam.pixmx  = std::numeric_limits<int>::max();  // max pixel charge for truncation of 2-D cluster
+
+      theClusterParam.sigmay = -999.9; // CPE Generic y-error for multi-pixel cluster
+      theClusterParam.sigmax = -999.9; // CPE Generic x-error for multi-pixel cluster
+      theClusterParam.sy1    = -999.9; // CPE Generic y-error for single single-pixel
+      theClusterParam.sy2    = -999.9; // CPE Generic y-error for single double-pixel cluster
+      theClusterParam.sx1    = -999.9; // CPE Generic x-error for single single-pixel cluster
+      theClusterParam.sx2    = -999.9; // CPE Generic x-error for single double-pixel cluster
+      
+      float dummy;
+      
+      SiPixelGenError gtempl(thePixelGenError_);
+      int gtemplID_ = theDetParam.detTemplateId;
+      
+      theClusterParam.qBin_ = gtempl.qbin( gtemplID_, theClusterParam.cotalpha, theClusterParam.cotbeta, locBz, locBx, qclus, 
+                                          false,
+                                          theClusterParam.pixmx, theClusterParam.sigmay, dummy,
+                                          theClusterParam.sigmax, dummy, theClusterParam.sy1,
+                                          dummy, theClusterParam.sy2, dummy, theClusterParam.sx1,
+                                          dummy, theClusterParam.sx2, dummy );
+      
+      
+      theClusterParam.sigmax = theClusterParam.sigmax * micronsToCm;
+      theClusterParam.sx1 = theClusterParam.sx1 * micronsToCm;
+      theClusterParam.sx2 = theClusterParam.sx2 * micronsToCm;
+      
+      theClusterParam.sigmay = theClusterParam.sigmay * micronsToCm;
+      theClusterParam.sy1 = theClusterParam.sy1 * micronsToCm;
+      theClusterParam.sy2 = theClusterParam.sy2 * micronsToCm;
+      
+   } // if ( UseErrorsFromTemplates_ )
+   else {
+     theClusterParam.qBin_ = 0;
+   }
+   
+   int Q_f_X;        //!< Q of the first  pixel  in X
+   int Q_l_X;        //!< Q of the last   pixel  in X
+   int Q_f_Y;        //!< Q of the first  pixel  in Y
+   int Q_l_Y;        //!< Q of the last   pixel  in Y
+   collect_edge_charges( theClusterParam,
+                        Q_f_X, Q_l_X,
+                        Q_f_Y, Q_l_Y,
+                        UseErrorsFromTemplates_ && TruncatePixelCharge_
+                        );
+   
+   //--- Find the inner widths along X and Y in one shot.  We
+   //--- compute the upper right corner of the inner pixels
+   //--- (== lower left corner of upper right pixel) and
+   //--- the lower left corner of the inner pixels
+   //--- (== upper right corner of lower left pixel), and then
+   //--- subtract these two points in the formula.
+   
+   //--- Upper Right corner of Lower Left pixel -- in measurement frame
+   uint16_t llx = theClusterParam.theCluster->minPixelRow()+1;
+   uint16_t lly = theClusterParam.theCluster->minPixelCol()+1;
+   
+   //--- Lower Left corner of Upper Right pixel -- in measurement frame
+   uint16_t urx = theClusterParam.theCluster->maxPixelRow();
+   uint16_t ury = theClusterParam.theCluster->maxPixelCol();
+   
+   auto llxl = phase1PixelTopology::localX(llx);   
+   auto	llyl = phase1PixelTopology::localY(lly);
+   auto	urxl = phase1PixelTopology::localX(urx);
+   auto uryl = phase1PixelTopology::localY(ury);
+
+   
+   float xPos =
+   generic_position_formula( theClusterParam.theCluster->sizeX(),
+                            Q_f_X, Q_l_X,
+                            llxl, urxl,
+                            chargeWidthX,   // lorentz shift in cm
+                            theDetParam.theThickness,
+                            theClusterParam.cotalpha,
+                            theDetParam.thePitchX,
+                            phase1PixelTopology::isBigPixX( theClusterParam.theCluster->minPixelRow() ),
+                            phase1PixelTopology::isBigPixX( theClusterParam.theCluster->maxPixelRow() )
+                           );   
+   
+   // apply the lorentz offset correction
+   xPos = xPos + shiftX + theDetParam.thePitchX*float(phase1PixelTopology::xOffset);
+   
+   float yPos =
+   generic_position_formula( theClusterParam.theCluster->sizeY(),
+                            Q_f_Y, Q_l_Y,
+                            llyl, uryl,
+                            chargeWidthY,   // lorentz shift in cm
+                            theDetParam.theThickness,
+                            theClusterParam.cotbeta,
+                            theDetParam.thePitchY,
+                            phase1PixelTopology::isBigPixY( theClusterParam.theCluster->minPixelCol() ),
+                            phase1PixelTopology::isBigPixY( theClusterParam.theCluster->maxPixelCol() )
+                           );   
+   // apply the lorentz offset correction
+   yPos = yPos + shiftY + theDetParam.thePitchY*float(phase1PixelTopology::yOffset);
+   
+   //--- Now put the two together
+   LocalPoint pos_in_local( xPos, yPos );
+   return pos_in_local;
+}
+
+
+
+//-----------------------------------------------------------------------------
+//!  A generic version of the position formula.  Since it works for both
+//!  X and Y, in the interest of the simplicity of the code, all parameters
+//!  are passed by the caller.  The only class variable used by this method
+//!  is the theThickness, since that's common for both X and Y.
+//-----------------------------------------------------------------------------
+float
+PixelCPEFast::
+generic_position_formula( int size,                //!< Size of this projection.
+                         int Q_f,              //!< Charge in the first pixel.
+                         int Q_l,              //!< Charge in the last pixel.
+                         uint16_t upper_edge_first_pix, //!< As the name says.
+                         uint16_t lower_edge_last_pix,  //!< As the name says.
+                         float lorentz_shift,   //!< L-shift at half thickness
+                         float theThickness,   //detector thickness
+                         float cot_angle,        //!< cot of alpha_ or beta_
+                         float pitch,            //!< thePitchX or thePitchY
+                         bool first_is_big,       //!< true if the first is big
+                         bool last_is_big        //!< true if the last is big
+                        )
+{
+   
+   float geom_center = 0.5f * pitch*float( upper_edge_first_pix + lower_edge_last_pix );
+   
+   //--- The case of only one pixel in this projection is separate.  Note that
+   //--- here first_pix == last_pix, so the average of the two is still the
+   //--- center of the pixel.
+   if ( size == 1 ) {return geom_center;}
+
+   float W_eff; // the compiler detects the logic below (and warns if buggy!!!!0 
+   bool simple=true;
+   if (size==2) {   
+     //--- Width of the clusters minus the edge (first and last) pixels.
+     //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
+     assert(lower_edge_last_pix>=upper_edge_first_pix);
+     float W_inner      =  pitch * float(lower_edge_last_pix-upper_edge_first_pix);  // in cm
+   
+     //--- Predicted charge width from geometry
+     float W_pred = theThickness * cot_angle                     // geometric correction (in cm)
+                    - lorentz_shift;                    // (in cm) &&& check fpix!
+   
+     W_eff = std::abs( W_pred ) - W_inner;
+
+     //--- If the observed charge width is inconsistent with the expectations
+     //--- based on the track, do *not* use W_pred-W_innner.  Instead, replace
+     //--- it with an *average* effective charge width, which is the average
+     //--- length of the edge pixels.
+     //
+     simple = ( W_eff < 0.0f ) | ( W_eff > pitch );
+
+   }
+   if (simple) {
+     //--- Total length of the two edge pixels (first+last)
+     float sum_of_edge = 2.0f;
+     if (first_is_big) sum_of_edge += 1.0f;
+     if (last_is_big)  sum_of_edge += 1.0f;
+     W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+   }
+   
+   
+   //--- Finally, compute the position in this projection
+   float Qdiff = Q_l - Q_f;
+   float Qsum  = Q_l + Q_f;
+   
+   //--- Temporary fix for clusters with both first and last pixel with charge = 0
+   if(Qsum==0) Qsum=1.0f;
+   float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff;
+   
+   return hit_pos;
+}
+
+
+//-----------------------------------------------------------------------------
+//!  Collect the edge charges in x and y, in a single pass over the pixel vector.
+//!  Calculate charge in the first and last pixel projected in x and y
+//!  and the inner cluster charge, projected in x and y.
+//-----------------------------------------------------------------------------
+void
+PixelCPEFast::
+collect_edge_charges(ClusterParam & theClusterParamBase,  //!< input, the cluster
+                     int & Q_f_X,              //!< output, Q first  in X
+                     int & Q_l_X,              //!< output, Q last   in X
+                     int & Q_f_Y,              //!< output, Q first  in Y
+                     int & Q_l_Y,              //!< output, Q last   in Y
+   	       	     bool truncate
+)
+{
+   ClusterParamGeneric & theClusterParam = static_cast<ClusterParamGeneric &>(theClusterParamBase);
+   
+   // Initialize return variables.
+   Q_f_X = Q_l_X = 0;
+   Q_f_Y = Q_l_Y = 0;
+   
+   
+   // Obtain boundaries in index units
+   int xmin = theClusterParam.theCluster->minPixelRow();
+   int xmax = theClusterParam.theCluster->maxPixelRow();
+   int ymin = theClusterParam.theCluster->minPixelCol();
+   int ymax = theClusterParam.theCluster->maxPixelCol();
+   
+   
+   // Iterate over the pixels.
+   int isize = theClusterParam.theCluster->size();
+   for (int i = 0;  i != isize; ++i)
+   {
+      auto const & pixel = theClusterParam.theCluster->pixel(i);
+      // ggiurgiu@fnal.gov: add pixel charge truncation
+      int pix_adc = pixel.adc;
+      if ( truncate )
+         pix_adc = std::min(pix_adc, theClusterParam.pixmx );
+      
+      //
+      // X projection
+      if ( pixel.x == xmin ) Q_f_X += pix_adc;
+      if ( pixel.x == xmax ) Q_l_X += pix_adc;
+      //
+      // Y projection
+      if ( pixel.y == ymin ) Q_f_Y += pix_adc;
+      if ( pixel.y == ymax ) Q_l_Y += pix_adc;
+   }
+}
+
+
+//==============  INFLATED ERROR AND ERRORS FROM DB BELOW  ================
+
+//-------------------------------------------------------------------------
+//  Hit error in the local frame
+//-------------------------------------------------------------------------
+LocalError
+PixelCPEFast::localError(DetParam const & theDetParam,  ClusterParam & theClusterParamBase) const
+{
+   
+   ClusterParamGeneric & theClusterParam = static_cast<ClusterParamGeneric &>(theClusterParamBase);
+   
+   // Default errors are the maximum error used for edge clusters.
+   // These are determined by looking at residuals for edge clusters
+   float xerr = EdgeClusterErrorX_ * micronsToCm;
+   float yerr = EdgeClusterErrorY_ * micronsToCm;
+   
+   
+   // Find if cluster is at the module edge.
+   int maxPixelCol = theClusterParam.theCluster->maxPixelCol();
+   int maxPixelRow = theClusterParam.theCluster->maxPixelRow();
+   int minPixelCol = theClusterParam.theCluster->minPixelCol();
+   int minPixelRow = theClusterParam.theCluster->minPixelRow();
+   
+   bool edgex =  phase1PixelTopology::isEdgeX(minPixelRow) | phase1PixelTopology::isEdgeX(maxPixelRow);
+   bool edgey =  phase1PixelTopology::isEdgeY(minPixelCol) | phase1PixelTopology::isEdgeY(maxPixelCol);
+   
+   unsigned int sizex = theClusterParam.theCluster->sizeX();
+   unsigned int sizey = theClusterParam.theCluster->sizeY();
+   
+   // Find if cluster contains double (big) pixels.
+   bool bigInX = theDetParam.theRecTopol->containsBigPixelInX( minPixelRow, maxPixelRow );
+   bool bigInY = theDetParam.theRecTopol->containsBigPixelInY( minPixelCol, maxPixelCol );
+   
+   if (UseErrorsFromTemplates_ ) {
+      //
+      // Use template errors
+      
+      if ( !edgex ) { // Only use this for non-edge clusters
+         if ( sizex == 1 ) {
+            if ( !bigInX ) {xerr = theClusterParam.sx1;}
+            else           {xerr = theClusterParam.sx2;}
+         } else {xerr = theClusterParam.sigmax;}
+      }
+      
+      if ( !edgey ) { // Only use for non-edge clusters
+         if ( sizey == 1 ) {
+            if ( !bigInY ) {yerr = theClusterParam.sy1;}
+            else           {yerr = theClusterParam.sy2;}
+         } else {yerr = theClusterParam.sigmay;}
+      }
+      
+   } else  { // simple errors
+      
+      // This are the simple errors, hardcoded in the code
+      //cout << "Track angles are not known " << endl;
+      //cout << "Default angle estimation which assumes track from PV (0,0,0) does not work." << endl;
+      
+      if ( GeomDetEnumerators::isTrackerPixel(theDetParam.thePart) ) {
+         if(GeomDetEnumerators::isBarrel(theDetParam.thePart)) {
+            
+            DetId id = (theDetParam.theDet->geographicalId());
+            int layer=ttopo_.layer(id);
+            if ( layer==1 ) {
+               if ( !edgex ) {
+                  if ( sizex<=xerr_barrel_l1_.size() ) xerr=xerr_barrel_l1_[sizex-1];
+                  else xerr=xerr_barrel_l1_def_;
+               }
+               
+               if ( !edgey ) {
+                  if ( sizey<=yerr_barrel_l1_.size() ) yerr=yerr_barrel_l1_[sizey-1];
+                  else yerr=yerr_barrel_l1_def_;
+               }
+            } else{  // layer 2,3
+               if ( !edgex ) {
+                  if ( sizex<=xerr_barrel_ln_.size() ) xerr=xerr_barrel_ln_[sizex-1];
+                  else xerr=xerr_barrel_ln_def_;
+               }
+               
+               if ( !edgey ) {
+                  if ( sizey<=yerr_barrel_ln_.size() ) yerr=yerr_barrel_ln_[sizey-1];
+                  else yerr=yerr_barrel_ln_def_;
+               }
+            }
+            
+         } else { // EndCap
+            
+            if ( !edgex ) {
+               if ( sizex<=xerr_endcap_.size() ) xerr=xerr_endcap_[sizex-1];
+               else xerr=xerr_endcap_def_;
+            }
+            
+            if ( !edgey ) {
+               if ( sizey<=yerr_endcap_.size() ) yerr=yerr_endcap_[sizey-1];
+               else yerr=yerr_endcap_def_;
+            }
+         } // end endcap
+      }
+      
+   } // end 
+   
+   auto xerr_sq = xerr*xerr; 
+   auto yerr_sq = yerr*yerr;
+   
+   return LocalError( xerr_sq, 0, yerr_sq );
+   
+}


### PR DESCRIPTION
further cleanup of unused array in Raw2Digi
introduced a clusterizer and its test (on GPU only)
call clusterizer in Raw2Digi wrapper

next step, get numberOfClustersPerModule, do prefix-scan (on cpu or gnu?) and schedule
PixelRecRecHit on GPU (  CPE + local2global) to produce x,y,z  (magically already ordered by module and layer...)
