### PR TITLE
R2D: use GPU::SimpleVector for the error unpacking

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -46,6 +46,9 @@ context initDeviceMemory() {
   constexpr uint32_t MAX_WORD08_SIZE = MAX_FED * MAX_WORD  * sizeof(uint8_t);
   constexpr uint32_t MAX_WORD32_SIZE = MAX_FED * MAX_WORD  * sizeof(uint32_t);
   constexpr uint32_t MAX_WORD16_SIZE = MAX_FED * MAX_WORD  * sizeof(uint16_t);
+  constexpr uint32_t VSIZE = sizeof(GPU::SimpleVector<error_obj>);
+  constexpr uint32_t ESIZE = sizeof(error_obj);
+  constexpr uint32_t MAX_ERROR_SIZE  = MAX_FED * MAX_WORD * ESIZE;
 
   cudaCheck(cudaMalloc((void**) & c.word_d,        MAX_WORD32_SIZE));
   cudaCheck(cudaMalloc((void**) & c.fedId_d,       MAX_WORD08_SIZE));
@@ -56,11 +59,8 @@ context initDeviceMemory() {
 
   cudaCheck(cudaMalloc((void**) & c.moduleInd_d,   MAX_WORD16_SIZE));
   cudaCheck(cudaMalloc((void**) & c.rawIdArr_d,    MAX_WORD32_SIZE));
-  cudaCheck(cudaMalloc((void**) & c.errType_d,     MAX_WORD32_SIZE));
-  cudaCheck(cudaMalloc((void**) & c.errWord_d,     MAX_WORD32_SIZE));
-  cudaCheck(cudaMalloc((void**) & c.errFedID_d,    MAX_WORD32_SIZE));
-  cudaCheck(cudaMalloc((void**) & c.errRawID_d,    MAX_WORD32_SIZE));
-
+  cudaCheck(cudaMalloc((void**) & c.error_d,       VSIZE));
+  cudaCheck(cudaMalloc((void**) & c.data_d,        MAX_ERROR_SIZE));
 
   // for the clusterizer
   cudaCheck(cudaMalloc((void**) & c.clus_d,        MAX_WORD32_SIZE)); // cluser index in module
@@ -70,7 +70,6 @@ context initDeviceMemory() {
   cudaCheck(cudaMalloc((void**) & c.moduleId_d,   (MaxNumModules)*sizeof(uint32_t) ));
 
   cudaCheck(cudaMalloc((void**) & c.debug_d,        MAX_WORD32_SIZE));
-
 
   // create a CUDA stream
   cudaCheck(cudaStreamCreate(&c.stream));
@@ -89,10 +88,8 @@ void freeMemory(context & c) {
   cudaCheck(cudaFree(c.adc_d));
   cudaCheck(cudaFree(c.moduleInd_d));
   cudaCheck(cudaFree(c.rawIdArr_d));
-  cudaCheck(cudaFree(c.errType_d));
-  cudaCheck(cudaFree(c.errWord_d));
-  cudaCheck(cudaFree(c.errFedID_d));
-  cudaCheck(cudaFree(c.errRawID_d));
+  cudaCheck(cudaFree(c.error_d));
+  cudaCheck(cudaFree(c.data_d));
 
  // these are for the clusterizer (to be moved)
  cudaCheck(cudaFree(c.moduleStart_d));
@@ -453,11 +450,10 @@ __device__ uint32_t getErrRawID(uint32_t fedId, uint32_t errWord, uint32_t error
 __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint32_t wordCounter, const uint32_t *Word, const uint8_t *fedIds,
                                  uint16_t * XX, uint16_t * YY, uint16_t * ADC,
                                  uint32_t * pdigi, uint32_t *rawIdArr, uint16_t * moduleId,
-                                 uint32_t *errType, uint32_t *errWord, uint32_t *errFedID, uint32_t *errRawID,
+                                 GPU::SimpleVector<error_obj> *err,
                                  bool useQualityInfo, bool includeErrors, bool debug)
 {
   uint32_t blockId  = blockIdx.x;
-
   uint32_t threadId  = threadIdx.x;
 
   bool skipROC = false;
@@ -474,14 +470,7 @@ __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint3
       rawIdArr[gIndex] = 0;
       moduleId[gIndex] = 9999; 
 
-
       uint32_t ww = Word[gIndex]; // Array containing 32 bit raw data
-      if (includeErrors) {
-        errType[gIndex]  = 0;
-        errWord[gIndex]  = ww;
-        errFedID[gIndex] = fedId;
-        errRawID[gIndex] = 0;
-      }
       if (ww == 0) {
         //noise and dead channels are ignored
         XX[gIndex]    = 0;  // 0 is an indicator of a noise/dead channel
@@ -501,10 +490,12 @@ __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint3
       if (includeErrors and skipROC)
       {
         uint32_t rID = getErrRawID(fedId, ww, errorType, Map, debug);
-        errType[gIndex]  = errorType;
-        errWord[gIndex]  = ww;
-        errFedID[gIndex] = fedId;
-        errRawID[gIndex] = rID;
+        error_obj temp_err;
+        temp_err.errorType = errorType;
+        temp_err.word = ww;
+        temp_err.fedId = fedId;
+        temp_err.rawId = rID;
+        err->push_back(temp_err);
         continue;
       }
 
@@ -551,10 +542,12 @@ __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint3
         if (includeErrors) {
           if (not rocRowColIsValid(row, col)) {
             uint32_t error = conversionError(fedId, 3, debug); //use the device function and fill the arrays
-            errType[gIndex]  = error;
-            errWord[gIndex]  = ww;
-            errFedID[gIndex] = fedId;
-            errRawID[gIndex] = rawId;
+            error_obj temp_err;
+            temp_err.errorType = error;
+            temp_err.word = ww;
+            temp_err.fedId = fedId;
+            temp_err.rawId = rawId;
+            err->push_back(temp_err);
             if(debug) printf("BPIX1  Error status: %i\n", error);
             continue;
           }
@@ -569,10 +562,12 @@ __global__ void RawToDigi_kernel(const SiPixelFedCablingMapGPU *Map, const uint3
         localPix.col = col;
         if (includeErrors and not dcolIsValid(dcol, pxid)) {
           uint32_t error = conversionError(fedId, 3, debug);
-          errType[gIndex] = error;
-          errWord[gIndex] = ww;
-          errFedID[gIndex] = fedId;
-          errRawID[gIndex] = rawId;
+          error_obj temp_err;
+          temp_err.errorType = error;
+          temp_err.word = ww;
+          temp_err.fedId = fedId;
+          temp_err.rawId = rawId;
+          err->push_back(temp_err);
           if(debug) printf("Error status: %i %d %d %d %d\n", error, dcol, pxid, fedId, roc);
           continue;
         }
@@ -599,7 +594,7 @@ void RawToDigi_wrapper(
     const uint32_t wordCounter, uint32_t *word, const uint32_t fedCounter,  uint8_t *fedId_h,
     bool convertADCtoElectrons, 
     uint32_t * pdigi_h, uint32_t *rawIdArr_h, 
-    uint32_t *errType_h, uint32_t *errWord_h, uint32_t *errFedID_h, uint32_t *errRawID_h,
+    GPU::SimpleVector<error_obj> *error_h, GPU::SimpleVector<error_obj> *error_h_tmp, error_obj *data_h,
     bool useQualityInfo, bool includeErrors, bool debug, uint32_t & nModulesActive)
 {
   const int threadsPerBlock = 512;
@@ -610,7 +605,13 @@ void RawToDigi_wrapper(
   // wordCounter is the total no of words in each event to be trasfered on device
   cudaCheck(cudaMemcpyAsync(&c.word_d[0],     &word[0],     wordCounter*sizeof(uint32_t), cudaMemcpyHostToDevice, c.stream));
   cudaCheck(cudaMemcpyAsync(&c.fedId_d[0], &fedId_h[0], wordCounter*sizeof(uint8_t)/2, cudaMemcpyHostToDevice, c.stream));
-
+    
+  constexpr uint32_t VSIZE = sizeof(GPU::SimpleVector<error_obj>);
+  constexpr uint32_t ESIZE = sizeof(error_obj);
+  //cudaCheck(cudaMemcpyAsync(c.error_d, error_h_tmp, VSIZE, cudaMemcpyHostToDevice, c.stream));
+  bool success = cudaMemcpy(c.error_d, error_h_tmp, VSIZE, cudaMemcpyHostToDevice) == cudaSuccess;
+  assert(success);
+    
   // Launch rawToDigi kernel
   RawToDigi_kernel<<<blocks, threadsPerBlock, 0, c.stream>>>(
       cablingMapDevice,
@@ -621,10 +622,7 @@ void RawToDigi_wrapper(
       c.pdigi_d,
       c.rawIdArr_d,
       c.moduleInd_d,
-      c.errType_d,
-      c.errWord_d,
-      c.errFedID_d,
-      c.errRawID_d,
+      c.error_d,
       useQualityInfo,
       includeErrors,
       debug);
@@ -636,10 +634,13 @@ void RawToDigi_wrapper(
   cudaCheck(cudaMemcpyAsync(rawIdArr_h, c.rawIdArr_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
 
   if (includeErrors) {
-    cudaCheck(cudaMemcpyAsync(errType_h, c.errType_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
-    cudaCheck(cudaMemcpyAsync(errWord_h, c.errWord_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
-    cudaCheck(cudaMemcpyAsync(errFedID_h, c.errFedID_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
-    cudaCheck(cudaMemcpyAsync(errRawID_h, c.errRawID_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
+      cudaCheck(cudaMemcpy(error_h, c.error_d, VSIZE, cudaMemcpyDeviceToHost));
+
+      assert(error_h->size() == ((blocks * threadsPerBlock) < (MAX_FED * MAX_WORD)
+                                 ? (blocks * threadsPerBlock)
+                                 : (MAX_FED * MAX_WORD)));
+
+      cudaCheck(cudaMemcpy(data_h, c.data_d, (error_h->size())*ESIZE, cudaMemcpyDeviceToHost));
   }
   cudaStreamSynchronize(c.stream);
   // End  of Raw2Digi and passing data for cluserisation

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -603,9 +603,7 @@ void RawToDigi_wrapper(
     
   constexpr uint32_t VSIZE = sizeof(GPU::SimpleVector<error_obj>);
   constexpr uint32_t ESIZE = sizeof(error_obj);
-  //cudaCheck(cudaMemcpyAsync(c.error_d, error_h_tmp, VSIZE, cudaMemcpyHostToDevice, c.stream));
-  bool success = cudaMemcpy(c.error_d, error_h_tmp, VSIZE, cudaMemcpyHostToDevice) == cudaSuccess;
-  assert(success);
+  cudaCheck(cudaMemcpyAsync(c.error_d, error_h_tmp, VSIZE, cudaMemcpyHostToDevice, c.stream));
     
   // Launch rawToDigi kernel
   RawToDigi_kernel<<<blocks, threadsPerBlock, 0, c.stream>>>(
@@ -632,21 +630,12 @@ void RawToDigi_wrapper(
       cudaCheck(cudaMemcpy(error_h, c.error_d, VSIZE, cudaMemcpyDeviceToHost));
       error_h->set_data(data_h);
       int size = error_h->size();
-      std::cout<<"crepamento1: "<<size<<std::endl;
-      std::cout<<"error_h: "<<error_h->size()<<" "<<(error_h->data())<<" "<<(data_h)<<std::endl;
-      std::cout<<"boh1 "<<data_h<<std::endl;
       cudaCheck(cudaMemcpy(data_h, c.data_d, size*ESIZE, cudaMemcpyDeviceToHost));
-      std::cout<<"boh2 "<<std::endl;
-      std::cout<<"crepamento2: "<<size<<std::endl;
-      std::cout<<"boh3 "<<data_h<<" "<<error_h->data()<<std::endl;
-      std::cout<<"boh4 "<<(int)data_h[1].errorType<<" "<<data_h[1].word<<" "<<(int)data_h[1].fedId<<" "<<data_h[1].rawId<<std::endl;
-      std::cout<<"boh5 "<<(int)(*error_h)[1].errorType<<" "<<(*error_h)[1].word<<" "<<(int)(*error_h)[1].fedId<<" "<<(*error_h)[1].rawId<<std::endl;
-
   }
   cudaStreamSynchronize(c.stream);
   // End  of Raw2Digi and passing data for cluserisation
 
- /*{
+ {
    // clusterizer ...
    using namespace gpuClustering;
   int threadsPerBlock = 256;
@@ -688,7 +677,7 @@ void RawToDigi_wrapper(
 
   cudaCheck(cudaMemsetAsync(c.clusInModule_d, 0, (MaxNumModules)*sizeof(uint32_t),c.stream));
 
-  /
+  /*
   gpuCalibPixel::calibADCByModule<<<blocks, threadsPerBlock, 0, c.stream>>>(
                c.moduleInd_d,
                c.xx_d, c.yy_d, c.adc_d,
@@ -696,7 +685,7 @@ void RawToDigi_wrapper(
                ped, 
                wordCounter
              );
-  /
+  */
 
   findClus<<<blocks, threadsPerBlock, 0, c.stream>>>(
                c.moduleInd_d,
@@ -714,5 +703,5 @@ void RawToDigi_wrapper(
   nModulesActive = nModules;
 
  } // end clusterizer scope
-*/
+
 }

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -612,7 +612,7 @@ void RawToDigi_wrapper(
   cudaCheck(cudaMemcpyAsync(rawIdArr_h, c.rawIdArr_d, wordCounter*sizeof(uint32_t), cudaMemcpyDeviceToHost, c.stream));
 
   if (includeErrors) {
-      cudaCheck(cudaMemcpy(error_h, c.error_d, vsize, cudaMemcpyDeviceToHost));
+      cudaCheck(cudaMemcpyAsync(error_h, c.error_d, vsize, cudaMemcpyDeviceToHost, c.stream));
       error_h->set_data(data_h);
       int size = error_h->size();
       cudaCheck(cudaMemcpyAsync(data_h, c.data_d, size*esize, cudaMemcpyDeviceToHost, c.stream));

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -613,11 +613,11 @@ void RawToDigi_wrapper(
 
   if (includeErrors) {
       cudaCheck(cudaMemcpyAsync(error_h, c.error_d, vsize, cudaMemcpyDeviceToHost, c.stream));
+      cudaStreamSynchronize(c.stream);
       error_h->set_data(data_h);
       int size = error_h->size();
       cudaCheck(cudaMemcpyAsync(data_h, c.data_d, size*esize, cudaMemcpyDeviceToHost, c.stream));
   }
-  cudaStreamSynchronize(c.stream);
   // End  of Raw2Digi and passing data for cluserisation
 
  {

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.cu
@@ -615,7 +615,7 @@ void RawToDigi_wrapper(
       cudaCheck(cudaMemcpy(error_h, c.error_d, vsize, cudaMemcpyDeviceToHost));
       error_h->set_data(data_h);
       int size = error_h->size();
-      cudaCheck(cudaMemcpy(data_h, c.data_d, size*esize, cudaMemcpyDeviceToHost));
+      cudaCheck(cudaMemcpyAsync(data_h, c.data_d, size*esize, cudaMemcpyDeviceToHost, c.stream));
   }
   cudaStreamSynchronize(c.stream);
   // End  of Raw2Digi and passing data for cluserisation

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
@@ -8,6 +8,7 @@
 #include <cuda_runtime.h>
 
 #include "SiPixelFedCablingMapGPU.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 #include<algorithm>
 
 const uint32_t layerStartBit_   = 20;
@@ -145,6 +146,12 @@ inline uint32_t pack(uint32_t row, uint32_t col, uint32_t adc) {
 
 }
 
+typedef struct error {
+    uint32_t rawId;
+    uint32_t word;
+    unsigned char errorType;
+    unsigned char fedId;
+    } error_obj;
 
 // configuration and memory buffers alocated on the GPU
 struct context {
@@ -159,12 +166,10 @@ struct context {
 
   uint16_t * moduleInd_d;
   uint32_t * rawIdArr_d;
-  uint32_t * errType_d;
-  uint32_t * errWord_d;
-  uint32_t * errFedID_d;
-  uint32_t * errRawID_d;
 
-
+  GPU::SimpleVector<error_obj> * error_d;
+  error_obj * data_d;
+    
   // these are for the clusterizer (to be moved)
   uint32_t * moduleStart_d;
   int32_t *  clus_d;
@@ -180,7 +185,7 @@ void RawToDigi_wrapper(context &, const SiPixelFedCablingMapGPU* cablingMapDevic
                         const uint32_t wordCounter, uint32_t *word, 
                         const uint32_t fedCounter,  uint8_t *fedId_h,
                         bool convertADCtoElectrons, uint32_t * pdigi_h,
-                        uint32_t *rawIdArr_h, uint32_t *errType_h, uint32_t *errWord_h, uint32_t *errFedID_h, uint32_t *errRawID_h,
+                        uint32_t *rawIdArr_h, GPU::SimpleVector<error_obj> *error_h, GPU::SimpleVector<error_obj> *error_h_tmp, error_obj *data_h,
                         bool useQualityInfo, bool includeErrors, bool debug, uint32_t & nModulesActive);
 
 // void initCablingMap();

--- a/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/RawToDigiGPU.h
@@ -146,12 +146,14 @@ inline uint32_t pack(uint32_t row, uint32_t col, uint32_t adc) {
 
 }
 
-typedef struct error {
-    uint32_t rawId;
-    uint32_t word;
-    unsigned char errorType;
-    unsigned char fedId;
-    } error_obj;
+struct error_obj {
+  uint32_t rawId;
+  uint32_t word;
+  unsigned char errorType;
+  unsigned char fedId;
+  __host__ __device__ error_obj(uint32_t a_, uint32_t b_, unsigned char c_, unsigned char d_):
+    rawId(a_), word(b_), errorType(c_), fedId(d_) {}
+};
 
 // configuration and memory buffers alocated on the GPU
 struct context {
@@ -181,12 +183,15 @@ struct context {
 
 
 // wrapper function to call RawToDigi on the GPU from host side
-void RawToDigi_wrapper(context &, const SiPixelFedCablingMapGPU* cablingMapDevice, SiPixelGainForHLTonGPU * const ped, 
-                        const uint32_t wordCounter, uint32_t *word, 
-                        const uint32_t fedCounter,  uint8_t *fedId_h,
-                        bool convertADCtoElectrons, uint32_t * pdigi_h,
-                        uint32_t *rawIdArr_h, GPU::SimpleVector<error_obj> *error_h, GPU::SimpleVector<error_obj> *error_h_tmp, error_obj *data_h,
-                        bool useQualityInfo, bool includeErrors, bool debug, uint32_t & nModulesActive);
+void RawToDigi_wrapper(context &, const SiPixelFedCablingMapGPU* cablingMapDevice,
+                       SiPixelGainForHLTonGPU * const ped,
+                       const uint32_t wordCounter, uint32_t *word,
+                       const uint32_t fedCounter,  uint8_t *fedId_h,
+                       bool convertADCtoElectrons, uint32_t * pdigi_h,
+                       uint32_t *rawIdArr_h, GPU::SimpleVector<error_obj> *error_h,
+                       GPU::SimpleVector<error_obj> *error_h_tmp, error_obj *data_h,
+                       bool useQualityInfo, bool includeErrors, bool debug,
+                       uint32_t & nModulesActive);
 
 // void initCablingMap();
 context initDeviceMemory();

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
@@ -92,7 +92,7 @@ void processCablingMap(SiPixelFedCablingMap const& cablingMap,  TrackerGeometry 
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
     LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << fedMap[i]  << std::setw(20) << linkMap[i]  << std::setw(20) << rocMap[i] << std::endl;
     LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << RawId[i]   << std::setw(20) << rocInDet[i] << std::setw(20) << moduleId[i] << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << (int)badRocs[i] << std::setw(20) << (int)modToUnp[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << (bool)badRocs[i] << std::setw(20) << (bool)modToUnp[i] << std::endl;
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
   }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc
@@ -90,9 +90,9 @@ void processCablingMap(SiPixelFedCablingMap const& cablingMap,  TrackerGeometry 
       moduleId[i] = gdet->index();
     }
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << fedMap[i]         << std::setw(20) << linkMap[i]         << std::setw(20) << rocMap[i]   << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << RawId[i]          << std::setw(20) << rocInDet[i]        << std::setw(20) << moduleId[i] << std::endl;
-    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << (bool) badRocs[i] << std::setw(20) << (bool) modToUnp[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << fedMap[i]  << std::setw(20) << linkMap[i]  << std::setw(20) << rocMap[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << RawId[i]   << std::setw(20) << rocInDet[i] << std::setw(20) << moduleId[i] << std::endl;
+    LogDebug("SiPixelFedCablingMapGPU") << i << std::setw(20) << (int)badRocs[i] << std::setw(20) << (int)modToUnp[i] << std::endl;
     LogDebug("SiPixelFedCablingMapGPU") << "----------------------------------------------------------------------------" << std::endl;
   }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -394,7 +394,6 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
   }
 
     uint32_t size = error_h->size();
-    cout<<"size: "<<size<<endl;
     for (uint32_t i = 0; i < size; i++) {
         error_obj err = (*error_h)[i];
         if (err.errorType != 0) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -386,8 +386,8 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     theDigiCounter++;
   }
 
-  uint32_t size = error_h->size();
-  for (uint32_t i = 0; i < size; i++) {
+  auto size = error_h->size();
+  for (auto i = 0; i < size; i++) {
     error_obj err = (*error_h)[i];
     if (err.errorType != 0) {
         SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -148,12 +148,6 @@ SiPixelRawToDigiGPU::SiPixelRawToDigiGPU( const edm::ParameterSet& conf )
   assert(error_h->capacity() == static_cast<int>(MAX_FED*MAX_WORD));
   assert(error_h_tmp->size() == 0);
   assert(error_h_tmp->capacity() == static_cast<int>(MAX_FED*MAX_WORD));
-    
-  // // allocate auxilary memory for clustering
-  // initDeviceMemCluster();
-
-  // // allocate memory for CPE on GPU
-  // initDeviceMemCPE();
 }
 
 // -----------------------------------------------------------------------------
@@ -276,7 +270,6 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     // convert the cabling map to a GPU-friendly version
     processCablingMap(*cablingMap, *geom.product(), cablingMapGPUHost_, cablingMapGPUDevice_, badPixelInfo_, modules);
     processGainCalibration(theSiPixelGainCalibration_.payload(), *geom.product(), gainForHLTonGPU_, gainDataOnGPU_);
-
   }
 
   edm::Handle<FEDRawDataCollection> buffers;
@@ -393,13 +386,12 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     theDigiCounter++;
   }
 
-    uint32_t size = error_h->size();
-    for (uint32_t i = 0; i < size; i++) {
-        error_obj err = (*error_h)[i];
-        if (err.errorType != 0) {
-            SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);
-            errors[err.rawId].push_back(error);
-        }
+  uint32_t size = error_h->size();
+  for (uint32_t i = 0; i < size; i++) {
+    error_obj err = (*error_h)[i];
+    if (err.errorType != 0) {
+        SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);
+        errors[err.rawId].push_back(error);
     }
   }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -64,8 +64,9 @@ SiPixelRawToDigiGPU::SiPixelRawToDigiGPU( const edm::ParameterSet& conf )
     usererrorlist = config_.getParameter<std::vector<int> > ("UserErrorList");
   }
   tFEDRawDataCollection = consumes <FEDRawDataCollection> (config_.getParameter<edm::InputTag>("InputLabel"));
+  debug = config_.getParameter<bool>("enableErrorDebug");
 
-  // start counters
+  //start counters
   ndigis = 0;
   nwords = 0;
 
@@ -127,16 +128,32 @@ SiPixelRawToDigiGPU::SiPixelRawToDigiGPU( const edm::ParameterSet& conf )
   cudaMallocHost(&pdigi_h,    sizeof(uint32_t)*WSIZE);
   cudaMallocHost(&rawIdArr_h, sizeof(uint32_t)*WSIZE);
 
-  cudaMallocHost(&errType_h,  sizeof(uint32_t)*WSIZE);
-  cudaMallocHost(&errRawID_h, sizeof(uint32_t)*WSIZE);
-  cudaMallocHost(&errWord_h,  sizeof(uint32_t)*WSIZE);
-  cudaMallocHost(&errFedID_h, sizeof(uint32_t)*WSIZE);
+  uint32_t VSIZE = sizeof(GPU::SimpleVector<error_obj>);
+  uint32_t ESIZE = sizeof(error_obj);
+  bool success = cudaMallocHost(&error_h, VSIZE) == cudaSuccess &&
+                 cudaMallocHost(&error_h_tmp, VSIZE) == cudaSuccess &&
+                 cudaMallocHost(&data_h, MAX_FED*MAX_WORD*ESIZE) == cudaSuccess;
+
+  assert(success);
 
   cudaMallocHost(&mIndexStart_h, sizeof(int)*(NMODULE+1));
   cudaMallocHost(&mIndexEnd_h,   sizeof(int)*(NMODULE+1));
 
   // allocate memory for RawToDigi on GPU
   context_ = initDeviceMemory();
+
+  new (error_h) GPU::SimpleVector<error_obj>(MAX_FED*MAX_WORD, data_h);
+  new (error_h_tmp) GPU::SimpleVector<error_obj>(MAX_FED*MAX_WORD, context_.data_d);
+  assert(error_h->size() == 0);
+  assert(error_h->capacity() == static_cast<int>(MAX_FED*MAX_WORD));
+  assert(error_h_tmp->size() == 0);
+  assert(error_h_tmp->capacity() == static_cast<int>(MAX_FED*MAX_WORD));
+    
+  // // allocate auxilary memory for clustering
+  // initDeviceMemCluster();
+
+  // // allocate memory for CPE on GPU
+  // initDeviceMemCPE();
 }
 
 // -----------------------------------------------------------------------------
@@ -154,10 +171,9 @@ SiPixelRawToDigiGPU::~SiPixelRawToDigiGPU() {
   cudaFreeHost(fedId_h);
   cudaFreeHost(pdigi_h);
   cudaFreeHost(rawIdArr_h);
-  cudaFreeHost(errType_h);
-  cudaFreeHost(errRawID_h);
-  cudaFreeHost(errWord_h);
-  cudaFreeHost(errFedID_h);
+  cudaFreeHost(error_h);
+  cudaFreeHost(error_h_tmp);
+  cudaFreeHost(data_h);
   cudaFreeHost(mIndexStart_h);
   cudaFreeHost(mIndexEnd_h);
 
@@ -209,6 +225,7 @@ SiPixelRawToDigiGPU::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<std::string>("CablingMapLabel","")->setComment("CablingMap label"); //Tav
   desc.addOptional<bool>("CheckPixelOrder");  // never used, kept for back-compatibility
   desc.add<bool>("ConvertADCtoElectrons", false)->setComment("## do the calibration ADC-> Electron and apply the threshold, requried for clustering");
+  desc.add<bool>("enableErrorDebug",false);
   descriptions.add("siPixelRawToDigiGPU",desc);
 }
 
@@ -222,7 +239,6 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
   int theWordCounter = 0;
   int theDigiCounter = 0;
   const uint32_t dummydetid = 0xffffffff;
-  debug = edm::MessageDrop::instance()->debugEnabled;
 
   // initialize quality record or update if necessary
   if (qualityWatcher.check( es ) && useQuality) {
@@ -260,6 +276,7 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     // convert the cabling map to a GPU-friendly version
     processCablingMap(*cablingMap, *geom.product(), cablingMapGPUHost_, cablingMapGPUDevice_, badPixelInfo_, modules);
     processGainCalibration(theSiPixelGainCalibration_.payload(), *geom.product(), gainForHLTonGPU_, gainDataOnGPU_);
+
   }
 
   edm::Handle<FEDRawDataCollection> buffers;
@@ -347,8 +364,7 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
 
   // GPU specific: RawToDigi -> clustering
   uint32_t nModulesActive=0;
-  RawToDigi_wrapper(context_, cablingMapGPUDevice_, gainForHLTonGPU_, wordCounterGPU, word, fedCounter, fedId_h, convertADCtoElectrons, pdigi_h, 
-      rawIdArr_h, errType_h, errWord_h, errFedID_h, errRawID_h, useQuality, includeErrors, debug, nModulesActive);
+  RawToDigi_wrapper(context_, cablingMapGPUDevice_, gainForHLTonGPU_, wordCounterGPU, word, fedCounter, fedId_h, convertADCtoElectrons, pdigi_h, rawIdArr_h, error_h, error_h_tmp, data_h, useQuality, includeErrors, debug,nModulesActive);
 
   auto gpuProd = std::make_unique<std::vector<unsigned long long>>();
   gpuProd->resize(3);
@@ -377,10 +393,14 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     theDigiCounter++;
   }
 
-  for (uint32_t i = 0; i < wordCounterGPU; i++) {
-    if (errType_h[i] != 0) {
-      SiPixelRawDataError error(errWord_h[i], errType_h[i], errFedID_h[i]+1200);
-      errors[errRawID_h[i]].push_back(error);
+    uint32_t vec_size = error_h->size();
+    for (uint32_t i = 0; i < vec_size; i++) {
+//      error_obj err = *error_h[i];
+//      if (err.errorType != 0) {
+//          SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);
+//          errors[err.rawId].push_back(error);
+//      }
+
     }
   }
 

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -436,7 +436,6 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
         std::vector<PixelFEDChannel> disabledChannelsDetSet;
 
         for (auto const& aPixelError : errorDetSet) {
-            cout<<"DetId: "<<errordetid<<", error: "<<aPixelError.getType()<<endl;
           // For the time being, we extend the error handling functionality with ErrorType 25
           // In the future, we should sort out how the usage of tkerrorlist can be generalized
           if (aPixelError.getType() == 25) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -128,13 +128,11 @@ SiPixelRawToDigiGPU::SiPixelRawToDigiGPU( const edm::ParameterSet& conf )
   cudaMallocHost(&pdigi_h,    sizeof(uint32_t)*WSIZE);
   cudaMallocHost(&rawIdArr_h, sizeof(uint32_t)*WSIZE);
 
-  uint32_t VSIZE = sizeof(GPU::SimpleVector<error_obj>);
-  uint32_t ESIZE = sizeof(error_obj);
-  bool success = cudaMallocHost(&error_h, VSIZE) == cudaSuccess &&
-                 cudaMallocHost(&error_h_tmp, VSIZE) == cudaSuccess &&
-                 cudaMallocHost(&data_h, MAX_FED*MAX_WORD*ESIZE) == cudaSuccess;
-
-  assert(success);
+  uint32_t vsize = sizeof(GPU::SimpleVector<error_obj>);
+  uint32_t esize = sizeof(error_obj);
+  cudaCheck(cudaMallocHost(&error_h, vsize));
+  cudaCheck(cudaMallocHost(&error_h_tmp, vsize));
+  cudaCheck(cudaMallocHost(&data_h, MAX_FED*MAX_WORD*esize));
 
   cudaMallocHost(&mIndexStart_h, sizeof(int)*(NMODULE+1));
   cudaMallocHost(&mIndexEnd_h,   sizeof(int)*(NMODULE+1));
@@ -357,7 +355,9 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
 
   // GPU specific: RawToDigi -> clustering
   uint32_t nModulesActive=0;
-  RawToDigi_wrapper(context_, cablingMapGPUDevice_, gainForHLTonGPU_, wordCounterGPU, word, fedCounter, fedId_h, convertADCtoElectrons, pdigi_h, rawIdArr_h, error_h, error_h_tmp, data_h, useQuality, includeErrors, debug,nModulesActive);
+  RawToDigi_wrapper(context_, cablingMapGPUDevice_, gainForHLTonGPU_, wordCounterGPU, word, fedCounter,
+                    fedId_h, convertADCtoElectrons, pdigi_h, rawIdArr_h, error_h, error_h_tmp, data_h,
+                    useQuality, includeErrors, debug,nModulesActive);
 
   auto gpuProd = std::make_unique<std::vector<unsigned long long>>();
   gpuProd->resize(3);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.cc
@@ -393,14 +393,14 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
     theDigiCounter++;
   }
 
-    uint32_t vec_size = error_h->size();
-    for (uint32_t i = 0; i < vec_size; i++) {
-//      error_obj err = *error_h[i];
-//      if (err.errorType != 0) {
-//          SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);
-//          errors[err.rawId].push_back(error);
-//      }
-
+    uint32_t size = error_h->size();
+    cout<<"size: "<<size<<endl;
+    for (uint32_t i = 0; i < size; i++) {
+        error_obj err = (*error_h)[i];
+        if (err.errorType != 0) {
+            SiPixelRawDataError error(err.word, err.errorType, err.fedId + 1200);
+            errors[err.rawId].push_back(error);
+        }
     }
   }
 
@@ -436,6 +436,7 @@ SiPixelRawToDigiGPU::produce( edm::Event& ev, const edm::EventSetup& es)
         std::vector<PixelFEDChannel> disabledChannelsDetSet;
 
         for (auto const& aPixelError : errorDetSet) {
+            cout<<"DetId: "<<errordetid<<", error: "<<aPixelError.getType()<<endl;
           // For the time being, we extend the error handling functionality with ErrorType 25
           // In the future, we should sort out how the usage of tkerrorlist can be generalized
           if (aPixelError.getType() == 25) {

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigiGPU.h
@@ -74,7 +74,9 @@ private:
 
   // to store the output
   uint32_t *pdigi_h, *rawIdArr_h;                   // host copy of output
-  uint32_t *errType_h, *errWord_h, *errFedID_h, *errRawID_h;    // host copy of output
+  error_obj *data_h = nullptr;
+  GPU::SimpleVector<error_obj> *error_h = nullptr;
+  GPU::SimpleVector<error_obj> *error_h_tmp = nullptr;
   // store the start and end index for each module (total 1856 modules-phase 1)
   int *mIndexStart_h, *mIndexEnd_h;
 

--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -35,6 +35,7 @@ siPixelDigisGPU.UsePhase1 = cms.bool(False)
 ## Empty Regions PSet means complete unpacking
 siPixelDigisGPU.Regions = cms.PSet( )
 siPixelDigisGPU.CablingMapLabel = cms.string("")
+siPixelDigisGPU.enableErrorDebug = cms.bool(False)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigis, UsePhase1=True)

--- a/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
@@ -11,7 +11,7 @@ namespace GPU {
 template <class T> struct SimpleVector {
   // Constructors
   __host__ __device__ SimpleVector(int capacity, T *data) // ownership of m_data stays within the caller
-      : m_size(0), m_data(data), m_capacity(capacity) {
+      : m_size(0), m_capacity(capacity), m_data(data) {
     static_assert(std::is_trivially_destructible<T>::value);
   }
 

--- a/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
@@ -83,6 +83,11 @@ template <class T> struct SimpleVector {
   __inline__ __host__ __device__ int capacity() const { return m_capacity; }
 
   __inline__ __host__ __device__ T *data() const { return m_data; }
+    
+  __inline__ __host__ __device__ void set_size(int size) { m_size = size; }
+    
+  __inline__ __host__ __device__ void set_data(T * data) { m_data = data; }
+
 
 private:
   int m_size;

--- a/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
@@ -84,7 +84,7 @@ template <class T> struct SimpleVector {
 
   __inline__ __host__ __device__ T *data() const { return m_data; }
     
-  __inline__ __host__ __device__ void set_size(int size) { m_size = size; }
+  __inline__ __host__ __device__ void resize(int size) { m_size = size; }
     
   __inline__ __host__ __device__ void set_data(T * data) { m_data = data; }
 
@@ -98,3 +98,4 @@ private:
 } // namespace GPU
 
 #endif // HeterogeneousCore_CUDAUtilities_GPUSimpleVector_h
+


### PR DESCRIPTION
@fwyzard @felicepantaleo @VinInn 

My changes seem to work fine (always same number and type of errors as in the serial code), but there is a crash due to the calibration part. I don't know if this was expected because still under development.

-bash-4.2$ cmsRun tkreco.py 
%MSG-i ThreadStreamSetup:  (NoModuleName) 16-Feb-2018 15:42:01 CET pre-events
setting # threads 8
setting # streams 8
%MSG
16-Feb-2018 15:42:12 CET  Initiating request to open file file:/data/patatrack/innocent/run2017/JetHT_raw304797HL.root
16-Feb-2018 15:42:13 CET  Successfully opened file file:/data/patatrack/innocent/run2017/JetHT_raw304797HL.root
Begin processing the 1st record. Run 304797, Event 105123496, LumiSection 70 on stream 2 at 16-Feb-2018 15:42:32.267 CET
%MSG-w HcalSeverityLevelComputer:  HBHEPhase1Reconstructor:hbheprereco  16-Feb-2018 15:42:34 CET Run: 304797 Event: 105123496
HcalSeverityLevelComputer: Error: RecHitFlag >>HFDigiTime<< unknown. Ignoring.
%MSG
caching calibs for 1856 pixel detectors of size 1647360
sizes 1 1 2
precisions g 1.23308 0.0761627
1440 1856
cmsRun: /afs/cern.ch/work/c/calabria/private/CMSSW_10_1_0_pre1/src/EventFilter/SiPixelRawToDigi/plugins/SiPixelFedCablingMapGPU.cc:164: void processGainCalibration(const SiPixelGainCalibrationForHLT&, const TrackerGeometry&, SiPixelGainForHLTonGPU*&, SiPixelGainForHLTonGPU::DecodingStructure*&): Assertion `p!=ind.end() && p->detid==dus[i]->geographicalId()' failed.


A fatal system signal has occurred: abort signal
The following is the call stack containing the origin of the signal.
