### PR TITLE
Remove -O2/-O3 from CUDA flags

### DIFF
--- a/DataFormats/GeometrySurface/test/BuildFile.xml
+++ b/DataFormats/GeometrySurface/test/BuildFile.xml
@@ -1,31 +1,29 @@
-<use   name="DataFormats/GeometrySurface"/>
-<use   name="cppunit"/>
-<use   name="boost"/>
-<bin   file="FrameTransformTest.cpp">
+<use name="boost"/>
+<use name="cppunit"/>
+<use name="DataFormats/GeometrySurface"/>
+
+<bin file="FrameTransformTest.cpp">
 </bin>
-<bin   file="OldFrameTransformTest.cpp">
+<bin file="OldFrameTransformTest.cpp">
+</bin>
+<bin file="PrecisionMixSurface.cpp">
+</bin>
+<bin file="referencecounted_t.cpp">
+</bin>
+<bin file="testGeometricSort.cpp" name="testGeometricSort">
+</bin>
+<bin file="Bounds_t.cpp">
 </bin>
 
-<bin   file="PrecisionMixSurface.cpp">
-</bin>
-<bin   file="referencecounted_t.cpp">
-</bin>
-<bin   file="testGeometricSort.cpp" name="testGeometricSort">
-</bin>
-<bin   file="Bounds_t.cpp">
-</bin>
-
-
-<use name="cuda"/>
-<use name="cuda-api-wrappers"/>
 <bin file="gpuFrameTransformKernel.cu, gpuFrameTransformTest.cpp" name="gpuFrameTransformTest">
+  <use name="cuda"/>
+  <use name="cuda-api-wrappers"/>
   <flags CXXFLAGS="-g"/>
-  <flags CUDA_FLAGS="-O3 --expt-relaxed-constexpr"/>
 </bin>
-
 
 <bin file="gpuFrameTransformKernel.cu, gpuFrameTransformTest.cpp" name="gpuFrameTransformTestRep">
-  <flags CUDA_FLAGS="-O3 --expt-relaxed-constexpr -fmad=false -ftz=false -prec-div=true -prec-sqrt=true"/>
+  <use name="cuda"/>
+  <use name="cuda-api-wrappers"/>
   <flags CXXFLAGS="-ffp-contract=off"/>
+  <flags CUDA_FLAGS="-fmad=false -ftz=false -prec-div=true -prec-sqrt=true"/>
 </bin>
-

--- a/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
@@ -1,10 +1,9 @@
-<use   name="EventFilter/SiPixelRawToDigi"/>
-<library   file="SiPixelDigiToRaw.cc SiPixelRawToDigi.cc SealModule.cc" name="EventFilterSiPixelRawToDigiPlugins">
-  <flags   EDM_PLUGIN="1"/>
+<use name="EventFilter/SiPixelRawToDigi"/>
+<library file="SiPixelDigiToRaw.cc SiPixelRawToDigi.cc SealModule.cc" name="EventFilterSiPixelRawToDigiPlugins">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<library   file="SiPixelRawToDigiGPU.cc SiPixelFedCablingMapGPU.cc RawToDigiGPU.cu" name="EventFilterSiPixelRawToDigiGPUPlugins">
-  <use   name="cuda"/>
-  <use   name="CalibTracker/SiPixelESProducers"/>
-  <flags   EDM_PLUGIN="1"/>
-  <flags   CUDA_FLAGS="-O2 --expt-relaxed-constexpr"/>
+<library file="SiPixelRawToDigiGPU.cc SiPixelFedCablingMapGPU.cc RawToDigiGPU.cu" name="EventFilterSiPixelRawToDigiGPUPlugins">
+  <use name="cuda"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <flags EDM_PLUGIN="1"/>
 </library>

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -1,3 +1,2 @@
-<bin   file="test_GPUSimpleVector.cu" name="test_GPUSimpleVector">
-  <flags   CUDA_FLAGS="-std=c++14"/>
+<bin file="test_GPUSimpleVector.cu" name="test_GPUSimpleVector">
 </bin>

--- a/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
@@ -1,42 +1,39 @@
-<use name="cuda"/>
-<use name="cuda-api-wrappers"/>
-<bin file="gpuClustering.cu" name="gpuClustering_t">
-  <flags CXXFLAGS="-g"/>
-  <flags CUDA_FLAGS="-O3"/>
-</bin>
+<use name="boost"/>
+<use name="clhep"/>
+<use name="root"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="CondFormats/L1TObjects"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/L1GlobalTrigger"/>
+<use name="DataFormats/Luminosity"/>
+<use name="DataFormats/VertexReco"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="L1Trigger/GlobalTriggerAnalyzer"/>
+<use name="RecoLuminosity/LumiProducer"/>
+<use name="TrackingTools/TrackFitters"/>
+<use name="TrackingTools/TrajectoryState"/>
+<use name="TrackingTools/TransientTrack"/>
 
-<use   name="Geometry/TrackerGeometryBuilder"/>
-<use   name="FWCore/Framework"/>
-<use   name="DataFormats/Common"/>
-<use   name="FWCore/ParameterSet"/>
-<use   name="FWCore/PluginManager"/>
-<use   name="clhep"/>
-<use   name="boost"/>
-<use   name="root"/>
-<use   name="DataFormats/L1GlobalTrigger"/>
-<use   name="CondFormats/L1TObjects"/>
-<use   name="L1Trigger/GlobalTriggerAnalyzer"/>
-<use   name="CommonTools/UtilAlgos"/>
-<use   name="Geometry/Records"/>
-<use   name="DataFormats/DetId"/>
-# for tracks
-<use   name="TrackingTools/TrajectoryState"/>
-<use   name="TrackingTools/TrackFitters"/>
-<use   name="TrackingTools/TransientTrack"/>
-<use   name="DataFormats/VertexReco"/>
-# for lumi
-<use   name="DataFormats/Luminosity"/>
-<use   name="RecoLuminosity/LumiProducer"/>
-#
-<flags   EDM_PLUGIN="1"/>
-<library   file="ReadPixClusters.cc" name="ReadPixClusters">
+<library file="ReadPixClusters.cc" name="ReadPixClusters">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<flags   EDM_PLUGIN="1"/>
-<library   file="TestClusters.cc" name="TestClusters">
+<library file="TestClusters.cc" name="TestClusters">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<flags   EDM_PLUGIN="1"/>
-<library   file="TestWithTracks.cc" name="TestWithTracks">
+<library file="TestWithTracks.cc" name="TestWithTracks">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<flags   EDM_PLUGIN="1"/>
-<library   file="Triplet.cc" name="Triplet">
+<library file="Triplet.cc" name="Triplet">
+  <flags EDM_PLUGIN="1"/>
 </library>
+
+<bin file="gpuClustering.cu" name="gpuClustering_t">
+  <use name="cuda"/>
+  <use name="cuda-api-wrappers"/>
+  <flags CXXFLAGS="-g"/>
+</bin>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -1,9 +1,8 @@
-<use   name="RecoLocalTracker/ClusterParameterEstimator"/>
-<use   name="RecoLocalTracker/Records"/>
-<use   name="RecoLocalTracker/SiPixelRecHits"/>
-<use   name="DataFormats/TrackerCommon"/>
-<library   file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
-  <use   name="cuda"/>
-  <flags   EDM_PLUGIN="1"/>
-  <flags   CUDA_FLAGS="-O2 --expt-relaxed-constexpr"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="RecoLocalTracker/ClusterParameterEstimator"/>
+<use name="RecoLocalTracker/Records"/>
+<use name="RecoLocalTracker/SiPixelRecHits"/>
+<library file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
+  <use name="cuda"/>
+  <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
After #28 / cms-sw/cmsdist#3786 the default CUDA flags are set to `-O3 -std=c++14 --expt-relaxed-constexpr --expt-extended-lambda` .

Since `nvcc` does not support multiple `-On` options on the command line, remove them from the `CUDA_FLAGS` set in the BuildFile.xml .