### PR TITLE
Set siPixelClusters.payloadType=HLT

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -27,7 +27,8 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
 )
 
-# to ensure reproducibility for CPU<->GPU comparisons
+# *only for the cms-patatrack repository*
+# ensure reproducibility for CPU <--> GPU comparisons
 siPixelClusters.payloadType = "HLT"
 
 # phase1 pixel

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -27,6 +27,9 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     maxNumberOfClusters = cms.int32(-1), # -1 means no limit.
 )
 
+# to ensure reproducibility for CPU<->GPU comparisons
+siPixelClusters.payloadType = "HLT"
+
 # phase1 pixel
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelClusters,
@@ -49,6 +52,3 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   ElectronPerADCGain = cms.double(600.) # it can be changed to something else (e.g. 135e) if needed
 )
 
-# to ensure reproducibility
-from Configuration.ProcessModifiers.gpu_cff import gpu
-gpu.toModify(siPixelClusters, payloadType = "HLT")


### PR DESCRIPTION
Easiest is to set it for everything.

It can be limited to the pixelTrackingOnly workflow only as well, but that would need tiny bit more work (a modifier), so I didn't do it because I suppose this PR is good-enough in practice.