### PR TITLE
Use the `gpu` modifier to read the pixel clusters from the unpacker

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -12,10 +12,12 @@ from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
     src = 'siPixelClustersPreSplitting'
-    )
+)
+gpu.toModify(siPixelClusterShapeCachePreSplitting, src = "siPixelDigis")
 
 # Global  reco
 from RecoEcal.Configuration.RecoEcal_cff import *

--- a/DQM/TrackingMonitorSource/python/pixelTracksMonitoring_cff.py
+++ b/DQM/TrackingMonitorSource/python/pixelTracksMonitoring_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
 pixelTracksMonitoring = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
@@ -21,3 +22,4 @@ pixelTracksMonitoring.doPlotsVsGoodPVtx         = True
 pixelTracksMonitoring.doPlotsVsLUMI             = True
 pixelTracksMonitoring.doPlotsVsBX               = True
 
+gpu.toModify(pixelTracksMonitoring, pixelCluster4lumi = "siPixelDigis")

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
@@ -1,7 +1,9 @@
-
 import FWCore.ParameterSet.Config as cms
 
-#
 from CondTools.SiPixel.SiPixelGainCalibrationService_cfi import *
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import siPixelClusters as _siPixelClusters
 siPixelClustersPreSplitting = _siPixelClusters.clone()
+
+# *only for the cms-patatrack repository*
+# ensure reproducibility for CPU <--> GPU comparisons
+siPixelClustersPreSplitting.payloadType = 'HLT'

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHitsGPU_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHitsGPU_cfi.py
@@ -2,12 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 siPixelRecHits = cms.EDProducer("SiPixelRecHitGPU",
     src = cms.InputTag("siPixelDigis"),
-#    src = cms.InputTag("siPixelClusters"),
-    CPE = cms.string('PixelCPEFast'),   # Generic'),
+    CPE = cms.string('PixelCPEFast'),   # Generic
     VerboseLevel = cms.untracked.int32(0),
-
-)
-
-siPixelRecHitsPreSplitting = siPixelRecHits.clone(
-    src = 'siPixelClustersPreSplitting'
 )

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 siPixelRecHits = cms.EDProducer("SiPixelRecHitConverter",
     src = cms.InputTag("siPixelClusters"),
     CPE = cms.string('PixelCPEGeneric'),
     VerboseLevel = cms.untracked.int32(0),
-
 )
 
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHitsGPU_cfi import siPixelRecHits as _siPixelRecHitsGPU
-from Configuration.ProcessModifiers.gpu_cff import gpu
 gpu.toReplaceWith(siPixelRecHits, _siPixelRecHitsGPU)
 
 siPixelRecHitsPreSplitting = siPixelRecHits.clone(
     src = 'siPixelClustersPreSplitting'
 )
+gpu.toModify(siPixelRecHitsPreSplitting, src = 'siPixelDigis')

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -21,6 +21,7 @@ from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import 
 import RecoTracker.IterativeTracking.iterativeTkConfig as _cfg
 import RecoTracker.IterativeTracking.iterativeTkUtils as _utils
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 ### First define the stuff for the standard validation sequence
 ## Track selectors
@@ -712,6 +713,8 @@ tracksValidationTrackingOnly = cms.Sequence(
 tpClusterProducerPixelTrackingOnly = tpClusterProducer.clone(
     pixelClusterSrc = "siPixelClustersPreSplitting"
 )
+gpu.toModify(tpClusterProducerPixelTrackingOnly, pixelClusterSrc = "siPixelDigis")
+
 quickTrackAssociatorByHitsPixelTrackingOnly = quickTrackAssociatorByHits.clone(
     cluster2TPSrc = "tpClusterProducerPixelTrackingOnly"
 )


### PR DESCRIPTION
When running the GPU algorithms, the pixel unpacker is reponsible for providing both the digis and the cluster. These changes make use of the unpacker label to access the clusters, conditionally on the presence of the `gpu` process modifier.