### PR TITLE
Work to support GCC 7 with CUDA

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cuda_cxx17.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cuda_cxx17.h
@@ -1,0 +1,72 @@
+#ifndef HeterogeneousCore_CUDAUtilities_cuda_cxx17_h
+#define HeterogeneousCore_CUDAUtilities_cuda_cxx17_h
+
+#include <initializer_list>
+
+// CUDA does not support C++17 yet, so we define here some of the missing library functions
+#if __cplusplus < 201703L
+
+namespace std {
+
+  // from https://en.cppreference.com/w/cpp/iterator/size
+  template <class C>
+  constexpr auto size(const C& c) -> decltype(c.size())
+  {
+    return c.size();
+  }
+
+  template <class T, std::size_t N>
+  constexpr std::size_t size(const T (&array)[N]) noexcept
+  {
+    return N;
+  }
+
+  // from https://en.cppreference.com/w/cpp/iterator/empty
+  template <class C>
+  constexpr auto empty(const C& c) -> decltype(c.empty())
+  {
+    return c.empty();
+  }
+
+  template <class T, std::size_t N>
+  constexpr bool empty(const T (&array)[N]) noexcept
+  {
+    return false;
+  }
+
+  template <class E>
+  constexpr bool empty(std::initializer_list<E> il) noexcept
+  {
+    return il.size() == 0;
+  }
+
+  // from https://en.cppreference.com/w/cpp/iterator/data
+  template <class C>
+  constexpr auto data(C& c) -> decltype(c.data())
+  {
+    return c.data();
+  }
+
+  template <class C>
+  constexpr auto data(const C& c) -> decltype(c.data())
+  {
+    return c.data();
+  }
+
+  template <class T, std::size_t N>
+  constexpr T* data(T (&array)[N]) noexcept
+  {
+    return array;
+  }
+
+  template <class E>
+  constexpr const E* data(std::initializer_list<E> il) noexcept
+  {
+    return il.begin();
+  }
+
+}
+
+#endif
+
+#endif  // HeterogeneousCore_CUDAUtilities_cuda_cxx17_h

--- a/HeterogeneousCore/Product/interface/HeterogeneousProduct.h
+++ b/HeterogeneousCore/Product/interface/HeterogeneousProduct.h
@@ -4,6 +4,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <bitset>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <tuple>

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -1,12 +1,14 @@
-#pragma once
+#ifndef RecoLocalTracker_SiPixelRecHits_pixelCPEforGPU_h
+#define RecoLocalTracker_SiPixelRecHits_pixelCPEforGPU_h
 
-#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
-#include "DataFormats/GeometrySurface/interface/SOARotation.h"
-#include <cstdint>
+#include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 
-#include<cassert>
+#include "DataFormats/GeometrySurface/interface/SOARotation.h"
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cuda_cxx17.h"
 
 namespace pixelCPEforGPU {
 
@@ -256,3 +258,5 @@ namespace pixelCPEforGPU {
    }
 
 }
+
+#endif  // RecoLocalTracker_SiPixelRecHits_pixelCPEforGPU_h


### PR DESCRIPTION
With GCC 6.x, we got away using some C++17 library functions in CUDA code, because the GCC headers were compatible (or not properly guarded).

With GCC 7.x this no longer works: when compiling CUDA code we need to set the standard to C++14 for both the device build (preprocessed by `g++` and compiled by `cicc`) and the host build (preprocessed and compiled by `g++`).

As a workaround, we implement in `HeterogeneousCore/CUDAUtilities/interface/cuda_cxx17.h` some C++17 library functions that do not require any additional compiler support.