### PR TITLE
Remove the use of #pragma once

### DIFF
--- a/CondFormats/SiPixelObjects/interface/SiPixelGainForHLTonGPU.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainForHLTonGPU.h
@@ -1,9 +1,10 @@
-#pragma once
+#ifndef CondFormats_SiPixelObjects_SiPixelGainForHLTonGPU_h
+#define CondFormats_SiPixelObjects_SiPixelGainForHLTonGPU_h
 
-#include<cstdint>
-#include<tuple>
-#include<cassert>
-#include<cstdio>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <tuple>
 
 struct SiPixelGainForHLTonGPU_DecodingStructure{
   uint8_t gain;
@@ -67,3 +68,4 @@ class SiPixelGainForHLTonGPU {
   unsigned int noisyFlag_;
 };
 
+#endif // CondFormats_SiPixelObjects_SiPixelGainForHLTonGPU_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
@@ -1,10 +1,11 @@
-#pragma once
+#ifndef RecoLocalTracker_SiPixelClusterizer_plugins_gpuCalibPixel_h
+#define RecoLocalTracker_SiPixelClusterizer_plugins_gpuCalibPixel_h
 
-#include "CondFormats/SiPixelObjects/interface/SiPixelGainForHLTonGPU.h"
-
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
-#include <cassert>
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainForHLTonGPU.h"
 
 namespace gpuCalibPixel {
 
@@ -123,3 +124,5 @@ namespace gpuCalibPixel {
 
 
 }
+
+#endif // RecoLocalTracker_SiPixelClusterizer_plugins_gpuCalibPixel_h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -1,8 +1,9 @@
-#pragma once
+#ifndef RecoLocalTracker_SiPixelClusterizer_plugins_gpuClustering_h
+#define RecoLocalTracker_SiPixelClusterizer_plugins_gpuClustering_h
 
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
-#include<cassert>
 
 namespace gpuClustering {
 
@@ -166,3 +167,4 @@ namespace gpuClustering {
   
 } //namespace gpuClustering
 
+#endif // RecoLocalTracker_SiPixelClusterizer_plugins_gpuClustering_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
@@ -1,19 +1,15 @@
-#pragma once
-
-#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
-#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
-#include "CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h"
-
-
-// The template header files
-#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
-#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/CUDAHostAllocator.h"
+#ifndef RecoLocalTracker_SiPixelRecHits_PixelCPEFast_h
+#define RecoLocalTracker_SiPixelRecHits_PixelCPEFast_h
 
 #include <utility>
 #include <vector>
 
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAHostAllocator.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelGenError.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
 
 class MagneticField;
 class PixelCPEFast final : public PixelCPEBase
@@ -85,3 +81,5 @@ public :
    pixelCPEforGPU::ParamsOnGPU h_paramsOnGPU;
    pixelCPEforGPU::ParamsOnGPU * d_paramsOnGPU;  // copy of the above on the Device  
 };
+
+#endif // RecoLocalTracker_SiPixelRecHits_PixelCPEFast_h

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -1,7 +1,8 @@
-#pragma once
+#ifndef RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
+#define RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
 
-#include<cstdint>
-#include<vector>
+#include <cstdint>
+#include <vector>
 
 namespace pixelCPEforGPU {
   struct ParamsOnGPU;
@@ -37,3 +38,5 @@ HitsOnCPU pixelRecHits_wrapper(
       uint32_t nModules, // active modules (with digis)
       HitsOnGPU & hh
 );
+
+#endif // RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -1,12 +1,12 @@
-#pragma once
+#ifndef RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
+#define RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h
 
-#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
-
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <limits>
-#include <cassert>
 
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
 
 namespace gpuPixelRecHits {
 
@@ -132,3 +132,4 @@ namespace gpuPixelRecHits {
 
 }
 
+#endif // RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h


### PR DESCRIPTION
Replace `#pragma once` with classical include guards. 