### PR TITLE
Updates to HeterogeneousEDProducer

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/GPUCuda.h
+++ b/HeterogeneousCore/CUDACore/interface/GPUCuda.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "HeterogeneousCore/Producer/interface/DeviceWrapper.h"
 #include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
@@ -16,11 +17,14 @@ namespace heterogeneous {
   public:
     using CallbackType = std::function<void(cuda::device::id_t, cuda::stream::id_t, cuda::status_t)>;
 
+    explicit GPUCuda(const edm::ParameterSet& iConfig);
     virtual ~GPUCuda() noexcept(false);
 
     void call_beginStreamGPUCuda(edm::StreamID id);
     bool call_acquireGPUCuda(DeviceBitSet inputLocation, edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, edm::WaitingTaskWithArenaHolder waitingTaskHolder);
     void call_produceGPUCuda(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
   private:
     virtual void beginStreamGPUCuda(edm::StreamID id, cuda::stream_t<>& cudaStream) {};
@@ -29,6 +33,8 @@ namespace heterogeneous {
 
     std::unique_ptr<cuda::stream_t<>> cudaStream_;
     int deviceId_ = -1; // device assigned to this edm::Stream
+    bool enabled_;
+    const bool forced_;
   };
   DEFINE_DEVICE_WRAPPER(GPUCuda, HeterogeneousDevice::kGPUCuda);
 }

--- a/HeterogeneousCore/Producer/README.md
+++ b/HeterogeneousCore/Producer/README.md
@@ -90,6 +90,9 @@ particular order).
   - Well-performing allocators are typically highly non-trivial to construct
 * Conditions data on GPU
   - Currently each module takes care of formatting, transferring, and updating the conditions data to GPU
+  - This is probably good-enough for the current prototyping phase, but what about longer term?
+    * How to deal with multiple devices, multiple edm::Streams, and multiple lumi sections in flight?
+    * Do we need to make EventSetup aware of the devices? How much do the details depend on device type?
 * Add possibility to initiate the GPU->CPU transfer before the CPU product is needed
   - This would enable overlapping the GPU->CPU transfer while CPU is busy
     with other work, so the CPU product requestor would not have to wait

--- a/HeterogeneousCore/Producer/README.md
+++ b/HeterogeneousCore/Producer/README.md
@@ -96,8 +96,8 @@ particular order).
 * Add possibility to initiate the GPU->CPU transfer before the CPU product is needed
   - This would enable overlapping the GPU->CPU transfer while CPU is busy
     with other work, so the CPU product requestor would not have to wait
-* Add configurability
-  - E.g. for preferred device order, force specific algorithms to specific device
+* Improve configurability
+  - E.g. for preferred device order?
 * Add fault tolerance
   - E.g. in a case of a GPU running out of memory continue with CPU
   - Should be configurable

--- a/HeterogeneousCore/Producer/README.md
+++ b/HeterogeneousCore/Producer/README.md
@@ -11,12 +11,12 @@ More details can be found from the sub-package specific README files (when they 
 
 ## Sub-packages
 
-* [`CUDACore`](CUDACore) CUDA-specific core components
+* [`CUDACore`](../CUDACore) CUDA-specific core components
   - *TODO:* Do we actually need this separate from `CUDAServices`? Which one to keep?
-* [`CUDAServices`](CUDAServices) Various edm::Services related to CUDA
-* [`CUDAUtilities`](CUDAUtilities) Various utilities for CUDA kernel code
-* [`Producer`](Producer) Core of the mini-framework for code organization: a base EDProducer class with algorithm scheduling to devices
-* [`Product`](Product) Core of the mini-framework for data products
+* [`CUDAServices`](../CUDAServices) Various edm::Services related to CUDA
+* [`CUDAUtilities`](../CUDAUtilities) Various utilities for CUDA kernel code
+* [`Producer`](#heterogeneousedproducer) Core of the mini-framework for code organization: a base EDProducer class with algorithm scheduling to devices
+* [`Product`](../Product) Core of the mini-framework for data products
 
 ## Design goals
 
@@ -114,3 +114,7 @@ particular order).
 * Explore the implementation of these features into the core CMSSW framework
   - E.g. HeterogeneousProduct would likely go to edm::Wrapper
 * Explore how to make core framework/TBB scheduling aware of heterogenous devices
+
+# HeterogeneousEDProducer
+
+To be written.

--- a/HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h
@@ -21,13 +21,10 @@ namespace heterogeneous {
       beginStreamCPU(id);
     }
     bool call_acquireCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, edm::WaitingTaskWithArenaHolder waitingTaskHolder);
-    void call_produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) {
-      produceCPU(iEvent, iSetup);
-    }
+    void call_produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup);
 
   private:
     virtual void beginStreamCPU(edm::StreamID id) {};
-    virtual void acquireCPU(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) = 0;
     virtual void produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) = 0;
   };
   DEFINE_DEVICE_WRAPPER(CPU, HeterogeneousDevice::kCPU);

--- a/HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h
@@ -4,6 +4,8 @@
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -15,7 +17,10 @@
 namespace heterogeneous {
   class CPU {
   public:
+    explicit CPU(const edm::ParameterSet& iConfig) {}
     virtual ~CPU() noexcept(false);
+
+    static void fillPSetDescription(edm::ParameterSetDescription desc) {}
 
     void call_beginStreamCPU(edm::StreamID id) {
       beginStreamCPU(id);
@@ -31,7 +36,10 @@ namespace heterogeneous {
 
   class GPUMock {
   public:
+    explicit GPUMock(const edm::ParameterSet& iConfig);
     virtual ~GPUMock() noexcept(false);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
     void call_beginStreamGPUMock(edm::StreamID id) {
       beginStreamGPUMock(id);
@@ -45,6 +53,9 @@ namespace heterogeneous {
     virtual void beginStreamGPUMock(edm::StreamID id) {};
     virtual void acquireGPUMock(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, std::function<void()> callback) = 0;
     virtual void produceGPUMock(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) = 0;
+
+    const bool enabled_;
+    const bool forced_;
   };
   DEFINE_DEVICE_WRAPPER(GPUMock, HeterogeneousDevice::kGPUMock);
 }
@@ -129,6 +140,15 @@ namespace heterogeneous {
   template <typename ...Devices>
   class HeterogeneousDevices: public Devices... {
   public:
+    explicit HeterogeneousDevices(const edm::ParameterSet& iConfig): Devices(iConfig)... {}
+
+    static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+      // The usual trick to expand the parameter pack for function call
+      using expander = int[];
+      (void)expander {0, ((void)Devices::fillPSetDescription(desc), 1)... };
+      desc.addUntracked<std::string>("force", "");
+    }
+
     void call_beginStream(edm::StreamID id) {
       CallBeginStream<HeterogeneousDevices, Devices...>::call(*this, id);
     }
@@ -149,13 +169,21 @@ namespace heterogeneous {
 template <typename Devices, typename ...Capabilities>
 class HeterogeneousEDProducer: public Devices, public edm::stream::EDProducer<edm::ExternalWork, Capabilities...> {
 public:
-  HeterogeneousEDProducer() {}
+  explicit HeterogeneousEDProducer(const edm::ParameterSet& iConfig):
+    Devices(iConfig.getUntrackedParameter<edm::ParameterSet>("heterogeneousEnabled_"))
+  {}
   ~HeterogeneousEDProducer() = default;
 
 protected:
   edm::EDGetTokenT<HeterogeneousProduct> consumesHeterogeneous(const edm::InputTag& tag) {
     tokens_.push_back(this->template consumes<HeterogeneousProduct>(tag));
     return tokens_.back();
+  }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    edm::ParameterSetDescription nested;
+    Devices::fillPSetDescription(nested);
+    desc.addUntracked<edm::ParameterSetDescription>("heterogeneousEnabled_", nested);
   }
 
 private:

--- a/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
@@ -48,7 +48,7 @@ namespace edm {
         CASE(HeterogeneousDevice::kGPUMock);
         CASE(HeterogeneousDevice::kGPUCuda);
         default:
-          throw cms::Exception("LogicError") << "edm::HeterogeneousEvent::getByToken(): no case statement for device " << static_cast<unsigned int>(location().deviceType());
+          throw cms::Exception("LogicError") << "edm::HeterogeneousEvent::getByToken(): no case statement for device " << static_cast<unsigned int>(location().deviceType()) << ". If you are calling getByToken() from produceX() where X != CPU, please move the call to acquireX().";
         }
 #undef CASE
       }

--- a/HeterogeneousCore/Producer/src/HeterogeneousEDProducer.cc
+++ b/HeterogeneousCore/Producer/src/HeterogeneousEDProducer.cc
@@ -11,16 +11,17 @@ namespace heterogeneous {
   CPU::~CPU() noexcept(false) {}
 
   bool CPU::call_acquireCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
-    std::exception_ptr exc;
-    try {
-      iEvent.setInputLocation(HeterogeneousDeviceId(HeterogeneousDevice::kCPU));
-      acquireCPU(iEvent, iSetup);
-      iEvent.locationSetter()(HeterogeneousDeviceId(HeterogeneousDevice::kCPU));
-    } catch(...) {
-      exc = std::current_exception();
-    }
-    waitingTaskHolder.doneWaiting(exc);
+    // There is no need for acquire in CPU, everything can be done in produceCPU().
+    iEvent.locationSetter()(HeterogeneousDeviceId(HeterogeneousDevice::kCPU));
+    waitingTaskHolder.doneWaiting(nullptr);
     return true;
+  }
+
+  void CPU::call_produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) {
+    // For CPU we set the heterogeneous input location for produce, because there is no acquire
+    // For other devices this probably doesn't make sense, because the device code is supposed to be launched from acquire.
+    iEvent.setInputLocation(HeterogeneousDeviceId(HeterogeneousDevice::kCPU, 0));
+    produceCPU(iEvent, iSetup);
   }
 
   GPUMock::~GPUMock() noexcept(false) {}

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
@@ -70,7 +70,7 @@ TestHeterogeneousEDProducerGPU::TestHeterogeneousEDProducerGPU(edm::ParameterSet
 void TestHeterogeneousEDProducerGPU::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag());
-  descriptions.add("testHeterogeneousEDProducerGPU2", desc);
+  descriptions.add("testHeterogeneousEDProducerGPU", desc);
 }
 
 void TestHeterogeneousEDProducerGPU::beginStreamGPUCuda(edm::StreamID streamId, cuda::stream_t<>& cudaStream) {

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
@@ -145,6 +145,9 @@ void TestHeterogeneousEDProducerGPU::produceGPUCuda(edm::HeterogeneousEvent& iEv
                            dst = TestHeterogeneousEDProducerGPUTask::getResult(src, cudaStream);
                          });
 
+  // If, for any reason, you want to disable the automatic GPU->CPU transfer, pass heterogeneous::DisableTransfer{} insteads of the function, i.e.
+  //iEvent.put<OutputType>(std::make_unique<TestHeterogeneousEDProducerGPUTask::ResultTypeRaw>(gpuOutput_.first.get(), gpuOutput_.second.get()), heterogeneous::DisableTransfer{});
+
   edm::LogPrint("TestHeterogeneousEDProducerGPU") << label_ << " TestHeterogeneousEDProducerGPU::produceGPUCuda end event " << iEvent.id().event() << " stream " << iEvent.streamID() << " device " << cs->getCurrentDevice();
 }
 

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPU.cc
@@ -57,6 +57,7 @@ private:
 };
 
 TestHeterogeneousEDProducerGPU::TestHeterogeneousEDProducerGPU(edm::ParameterSet const& iConfig):
+  HeterogeneousEDProducer(iConfig),
   label_(iConfig.getParameter<std::string>("@module_label"))
 {
   auto srcTag = iConfig.getParameter<edm::InputTag>("src");
@@ -70,6 +71,7 @@ TestHeterogeneousEDProducerGPU::TestHeterogeneousEDProducerGPU(edm::ParameterSet
 void TestHeterogeneousEDProducerGPU::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag());
+  HeterogeneousEDProducer::fillPSetDescription(desc);
   descriptions.add("testHeterogeneousEDProducerGPU", desc);
 }
 

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
@@ -43,10 +43,6 @@ private:
   // simulating GPU memory
   unsigned int gpuOutput_;
 
-  // output
-  unsigned int output_;
-
-  void acquireCPU(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) override;
   void acquireGPUMock(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, std::function<void()> callback);
 
   void produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) override;
@@ -69,28 +65,6 @@ void TestHeterogeneousEDProducerGPUMock::fillDescriptions(edm::ConfigurationDesc
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag());
   descriptions.add("testHeterogeneousEDProducerGPUMock", desc);
-}
-
-void TestHeterogeneousEDProducerGPUMock::acquireCPU(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) {
-  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << label_ << " TestHeterogeneousEDProducerGPUMock::acquireCPU event " << iEvent.id().event() << " stream " << iEvent.streamID();
-
-  unsigned int input = 0;
-  if(!srcToken_.isUninitialized()) {
-    edm::Handle<unsigned int> hin;
-    iEvent.getByToken<OutputType>(srcToken_, hin);
-    input = *hin;
-  }
-
-  std::random_device r;
-  std::mt19937 gen(r());
-  auto dist = std::uniform_real_distribution<>(1.0, 3.0); 
-  auto dur = dist(gen);
-  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << "  Task (CPU) for event " << iEvent.id().event() << " in stream " << iEvent.streamID() << " will take " << dur << " seconds";
-  std::this_thread::sleep_for(std::chrono::seconds(1)*dur);
-
-  output_ = input+ iEvent.streamID()*100 + iEvent.id().event();
-
-  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << " " << label_ << " TestHeterogeneousEDProducerGPUMock::acquireCPU end event " << iEvent.id().event() << " stream " << iEvent.streamID();
 }
 
 void TestHeterogeneousEDProducerGPUMock::acquireGPUMock(const edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, std::function<void()> callback) {
@@ -129,10 +103,26 @@ void TestHeterogeneousEDProducerGPUMock::acquireGPUMock(const edm::Heterogeneous
 void TestHeterogeneousEDProducerGPUMock::produceCPU(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) {
   edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << label_ << " TestHeterogeneousEDProducerGPUMock::produceCPU begin event " << iEvent.id().event() << " stream " << iEvent.streamID();
 
-  iEvent.put<OutputType>(std::make_unique<unsigned int>(output_));
+  unsigned int input = 0;
+  if(!srcToken_.isUninitialized()) {
+    edm::Handle<unsigned int> hin;
+    iEvent.getByToken<OutputType>(srcToken_, hin);
+    input = *hin;
+  }
+
+  std::random_device r;
+  std::mt19937 gen(r());
+  auto dist = std::uniform_real_distribution<>(1.0, 3.0);
+  auto dur = dist(gen);
+  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << "  Task (CPU) for event " << iEvent.id().event() << " in stream " << iEvent.streamID() << " will take " << dur << " seconds";
+  std::this_thread::sleep_for(std::chrono::seconds(1)*dur);
+
+  const unsigned int output = input+ iEvent.streamID()*100 + iEvent.id().event();
+
+  iEvent.put<OutputType>(std::make_unique<unsigned int>(output));
   iEvent.put(std::make_unique<int>(1));
 
-  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << label_ << " TestHeterogeneousEDProducerGPUMock::produceCPU end event " << iEvent.id().event() << " stream " << iEvent.streamID() << " result " << output_;
+  edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << label_ << " TestHeterogeneousEDProducerGPUMock::produceCPU end event " << iEvent.id().event() << " stream " << iEvent.streamID() << " result " << output;
 }
 
 void TestHeterogeneousEDProducerGPUMock::produceGPUMock(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup) {

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
@@ -50,6 +50,7 @@ private:
 };
 
 TestHeterogeneousEDProducerGPUMock::TestHeterogeneousEDProducerGPUMock(edm::ParameterSet const& iConfig):
+  HeterogeneousEDProducer(iConfig),
   label_(iConfig.getParameter<std::string>("@module_label"))
 {
   auto srcTag = iConfig.getParameter<edm::InputTag>("src");
@@ -64,6 +65,7 @@ TestHeterogeneousEDProducerGPUMock::TestHeterogeneousEDProducerGPUMock(edm::Para
 void TestHeterogeneousEDProducerGPUMock::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag());
+  HeterogeneousEDProducer::fillPSetDescription(desc);
   descriptions.add("testHeterogeneousEDProducerGPUMock", desc);
 }
 

--- a/HeterogeneousCore/Producer/test/testGPUMock_cfg.py
+++ b/HeterogeneousCore/Producer/test/testGPUMock_cfg.py
@@ -28,3 +28,6 @@ process.eca = cms.EDAnalyzer("EventContentAnalyzer",
 )
 process.p = cms.Path(process.prod1+process.prod2)#+process.eca)
 #process.p.associate(process.t)
+
+# Example of forcing module to run a specific device for one module via configuration
+#process.prod1.heterogeneousEnabled_ = cms.untracked.PSet(force = cms.untracked.string("GPUMock"))

--- a/HeterogeneousCore/Producer/test/testGPU_cfg.py
+++ b/HeterogeneousCore/Producer/test/testGPU_cfg.py
@@ -12,17 +12,14 @@ process.options = cms.untracked.PSet(
     numberOfStreams = cms.untracked.uint32(0)
 )
 
+from HeterogeneousCore.Producer.testHeterogeneousEDProducerGPU_cfi import testHeterogeneousEDProducerGPU as prod
 
 #process.Tracer = cms.Service("Tracer")
 process.CUDAService = cms.Service("CUDAService")
-process.prod1 = cms.EDProducer('TestHeterogeneousEDProducerGPU')
-process.prod2 = cms.EDProducer('TestHeterogeneousEDProducerGPU',
-    src = cms.InputTag("prod1"),
-)
-process.prod3 = cms.EDProducer('TestHeterogeneousEDProducerGPU',
-    src = cms.InputTag("prod1"),
-)
-process.prod4 = cms.EDProducer('TestHeterogeneousEDProducerGPU')
+process.prod1 = prod.clone()
+process.prod2 = prod.clone(src = "prod1")
+process.prod3 = prod.clone(src = "prod1")
+process.prod4 = prod.clone()
 process.ana = cms.EDAnalyzer("TestHeterogeneousEDProducerAnalyzer",
     src = cms.VInputTag("prod2", "prod3", "prod4")
 )
@@ -30,3 +27,6 @@ process.ana = cms.EDAnalyzer("TestHeterogeneousEDProducerAnalyzer",
 process.t = cms.Task(process.prod1, process.prod2, process.prod3, process.prod4)
 process.p = cms.Path(process.ana)
 process.p.associate(process.t)
+
+# Example of disabling CUDA device type for one module via configuration
+#process.prod4.heterogeneousEnabled_.GPUCuda = False

--- a/HeterogeneousCore/Product/interface/HeterogeneousProduct.h
+++ b/HeterogeneousCore/Product/interface/HeterogeneousProduct.h
@@ -55,6 +55,9 @@ namespace heterogeneous {
   DEFINE_DEVICE_PRODUCT(GPUCuda);
 #undef DEFINE_DEVICE_PRODUCT
 
+  // Tag class to allow disabling automatic device->CPU transfers
+  struct DisableTransfer {};
+
   /**
    * Below are various helpers
    *
@@ -259,6 +262,18 @@ public:
     assert(location.deviceType() == Device);
     std::get<index>(products_) = std::move(data);
     std::get<index>(transfersToCPU_) = std::move(transferToCPU);
+    location_[index].set(location.deviceId());
+  }
+
+  /**
+   * Generic constructor for device data, but without the transfer function(!).
+   */
+  template <HeterogeneousDevice Device, typename D>
+  HeterogeneousProductImpl(heterogeneous::HeterogeneousDeviceTag<Device>, D&& data, HeterogeneousDeviceId location, heterogeneous::DisableTransfer) {
+    // TODO: try to avoid code duplication between the other device data
+    constexpr const auto index = static_cast<unsigned int>(Device);
+    assert(location.deviceType() == Device);
+    std::get<index>(products_) = std::move(data);
     location_[index].set(location.deviceId());
   }
 


### PR DESCRIPTION
This PR makes several small updates to HeterogenousEDProducer
* move overall `README.md` under `HeterogenousCore/Producer` to avoid CMS tools interpreting it as a package
* Tiny fix on a module label in `fillDescriptions()`of a  test program
* Remove `acquireCPU()` as unnecessary, all functionality is moved to `produceCPU()`
* Allow omitting device->CPU transfer function with `heterogeneous::DisableTransfer` tag
* Add per-device-type configurability (useful mostly for debugging and testing) to heterogeneous modules along
```
process.foo = cms.EDModule("FooProducer",
    a = cms.int32(1),
    b = cms.VPSet(...),
    ...
    heterogeneousEnabled_ = cms.untracked.PSet(
        GPUCuda = cms.untracked.bool(True),
        FPGA = cms.untracked.bool(False), # forbid the module from running on a device type
        force = cms.untracked.string("GPUCuda") # force the module to run on a specific device type
    )
)
```
(note though that there is no support for an FPGA yet in the system, so the example above is only illustrative in that sense)

Tested in CMSSW_10_2_0_pre3.