### PR TITLE
Generalize HeterogeneousEvent::getByToken() to support standard products

### DIFF
--- a/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
@@ -54,6 +54,12 @@ namespace edm {
       }
     }
 
+    // Delegate standard getByToken to edm::Event
+    template <typename Token, typename Type>
+    void getByToken(const Token& token, edm::Handle<Type>& handle) const {
+      constEvent_->getByToken(token, handle);
+    }
+
     template <typename PROD>
     auto put(std::unique_ptr<PROD> product) {
       return event_->put(std::move(product));

--- a/HeterogeneousCore/Producer/test/testGPUMock_cfg.py
+++ b/HeterogeneousCore/Producer/test/testGPUMock_cfg.py
@@ -15,8 +15,11 @@ process.options = cms.untracked.PSet(
 
 #process.Tracer = cms.Service("Tracer")
 process.prod1 = cms.EDProducer('TestHeterogeneousEDProducerGPUMock')
-process.prod2= cms.EDProducer('TestHeterogeneousEDProducerGPUMock',
+process.prod2 = cms.EDProducer('TestHeterogeneousEDProducerGPUMock',
     src = cms.InputTag("prod1")
+)
+process.prod3 =  cms.EDProducer('TestHeterogeneousEDProducerGPUMock',
+    srcInt = cms.InputTag("prod1")
 )
 
 #process.t = cms.Task(process.prod1, process.prod2)
@@ -26,7 +29,7 @@ process.eca = cms.EDAnalyzer("EventContentAnalyzer",
     getDataForModuleLabels = cms.untracked.vstring("producer"),
     listContent = cms.untracked.bool(True),
 )
-process.p = cms.Path(process.prod1+process.prod2)#+process.eca)
+process.p = cms.Path(process.prod1+process.prod2+process.prod3)#+process.eca)
 #process.p.associate(process.t)
 
 # Example of forcing module to run a specific device for one module via configuration


### PR DESCRIPTION
Title says it all.

Tested in CMSSW_10_2_0_pre3.

@felicepantaleo 