### PR TITLE
Various updates to the heterogeneous framework

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -916,6 +916,8 @@ class ConfigBuilder(object):
 		    self.loadAndRemember('SimGeneral.HepPDTESSource.'+self._options.particleTable+'_cfi')
 
         self.loadAndRemember('FWCore/MessageService/MessageLogger_cfi')
+        # Eventually replace with some more generic file to load
+        self.loadAndRemember('HeterogeneousCore/CUDAServices/CUDAService_cfi')
 
         self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreams_cff"
         self.GENDefaultCFF="Configuration/StandardSequences/Generator_cff"

--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -69,7 +69,7 @@ namespace heterogeneous {
                                      ](cuda::stream::id_t streamId, cuda::status_t status) mutable {
                                       if(status == cudaSuccess) {
                                         locationSetter(HeterogeneousDeviceId(HeterogeneousDevice::kGPUCuda, deviceId));
-                                        edm::LogPrint("GPUCuda") << "  GPU kernel finished (in callback) device " << deviceId << " CUDA stream " << streamId;
+                                        LogTrace("GPUCuda") << "  GPU kernel finished (in callback) device " << deviceId << " CUDA stream " << streamId;
                                         waitingTaskHolder.doneWaiting(nullptr);
                                       }
                                       else {

--- a/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
@@ -65,6 +65,11 @@ namespace edm {
       return event_->put(std::move(product));
     }
 
+    template <typename PROD>
+    auto put(std::unique_ptr<PROD> product, std::string const& productInstanceName) {
+      return event_->put(std::move(product), productInstanceName);
+    }
+
     template <typename Product, typename Type>
     void put(std::unique_ptr<Type> product) {
       assert(location().deviceType() == HeterogeneousDevice::kCPU);

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUMock.cc
@@ -65,6 +65,7 @@ TestHeterogeneousEDProducerGPUMock::TestHeterogeneousEDProducerGPUMock(edm::Para
 
   produces<HeterogeneousProduct>();
   produces<int>();
+  produces<int>("foo");
 }
 
 void TestHeterogeneousEDProducerGPUMock::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -139,6 +140,7 @@ void TestHeterogeneousEDProducerGPUMock::produceCPU(edm::HeterogeneousEvent& iEv
 
   iEvent.put<OutputType>(std::make_unique<unsigned int>(output));
   iEvent.put(std::make_unique<int>(1));
+  iEvent.put(std::make_unique<int>(2), "foo");
 
   edm::LogPrint("TestHeterogeneousEDProducerGPUMock") << label_ << " TestHeterogeneousEDProducerGPUMock::produceCPU end event " << iEvent.id().event() << " stream " << iEvent.streamID() << " result " << output;
 }


### PR DESCRIPTION
This PR updates the heterogeneous framework as follows:
* silences a printout in the CUDA callback function (`LogPrint` -> `LogTrace`)
* Add support for product label in `HeterogeneousEvent::put()` of standard products
* Add loading of `CUDAService` to ConfigBuilder

Tested in 10_2_0_pre3.

@fwyzard @felicepantaleo 