### PR TITLE
Add heterogeneous framework documentation and add some sanity checks in GPUCuda

### DIFF
--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -12,7 +12,11 @@ namespace heterogeneous {
   GPUCuda::GPUCuda(const edm::ParameterSet& iConfig):
     enabled_(iConfig.getUntrackedParameter<bool>("GPUCuda")),
     forced_(iConfig.getUntrackedParameter<std::string>("force") == "GPUCuda")
-  {}
+  {
+    if(forced_ && !enabled_) {
+      throw cms::Exception("Configuration") << "It makes no sense to force the module on GPUCuda, and then disable GPUCuda.";
+    }
+  }
 
   GPUCuda::~GPUCuda() noexcept(false) {}
 
@@ -24,6 +28,9 @@ namespace heterogeneous {
     edm::Service<CUDAService> cudaService;
     enabled_ = (enabled_ && cudaService->enabled());
     if(!enabled_) {
+      if(forced_) {
+        throw cms::Exception("LogicError") << "This module was forced to run on GPUCuda, but the device is not available.";
+      }
       return;
     }
 

--- a/HeterogeneousCore/Producer/README.md
+++ b/HeterogeneousCore/Producer/README.md
@@ -101,6 +101,10 @@ particular order).
 * Add fault tolerance
   - E.g. in a case of a GPU running out of memory continue with CPU
   - Should be configurable
+* Add support for multiple heterogeneous inputs for a module
+  - Currently the device scheduling is based only on the "first input"
+  - Clearly this is inadequate in general and needs to be improved
+  - Any better suggestions than taking `and` of all locations?
 * Improve resource monitoring
   - E.g. for CUDA device utilization
     * https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g540824faa6cef45500e0d1dc2f50b321
@@ -120,4 +124,345 @@ particular order).
 
 # HeterogeneousEDProducer
 
-To be written.
+`HeterogeneousEDProducer` is implemented as a `stream::EDProducer` using the
+[`ExternalWork` extension](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface#edm_ExternalWork).
+
+## Configuration
+
+`HeterogeneousEDProducer` requires `heterogeneousEnabled_` `cms.PSet`
+to be available in the module configuration. The `PSet` can be used to
+override module-by-module which devices can be used by that module.
+The structure of the `PSet` are shown in the following example
+
+```python
+process.foo = cms.EDModule("FooProducer",
+    a = cms.int32(1),
+    b = cms.VPSet(...),
+    ...
+    heterogeneousEnabled_ = cms.untracked.PSet(
+        GPUCuda = cms.untracked.bool(True),
+        FPGA = cms.untracked.bool(False),       # forbid the module from running on a device type (note that we don't support FPGA devices at the moment though)
+        force = cms.untracked.string("GPUCuda") # force the module to run on a specific device type
+    )
+)
+```
+
+The difference between the boolean flags and the `force` parameter is the following
+* The boolean flags control whether the algorithm can be scheduled on the individual device type or not
+* The `force` parameter implies that the algorithm is always scheduled on that device type no matter what. If the device type is not available on the machine, an exception is thrown.
+
+Currently, with only CUDA GPU and CPU support, this level of configurability is a bit overkill though.
+
+## Class declaration
+
+In order to use the `HeterogeneousEDProducer` the `EDProducer` class
+must inherit from `HeterogeneousEDProducer<...>`. The devices, which
+the `EDProducer` is supposed to support, are given as a template
+argument via `heterogeneous::HeterogeneousDevices<...>`. The usual
+[stream producer extensions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface#Template_Arguments)
+can be also passed via additional template arguments.
+
+```cpp
+#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
+#include "HeterogeneousCore/CUDACore/interface/GPUCuda.h" // needed for heterogeneous::GPUCuda
+
+class FooProducer: public HeterogeneousEDProducer<
+  heterogeneous::HeterogeneousDevices<
+    heterogeneous::GPUCuda,
+    heterogeneous::CPU
+  >
+  // here you can pass any stream producer extensions
+> {
+  ...
+
+```
+
+In this example the `FooProducer` declares that prodives
+implementations for CUDA GPU and CPU. Note that currently CPU is
+mandatory, and it has to be the last argument. The order of the
+devices dictates the order that the algorithm is scheduled to the
+devices. E.g. in this example, the system runs the algorithm in GPU if
+it can, and only if it can not, in CPU. For the list of supported
+device types, see the [list below](#devices).
+
+## Constructor
+
+`HeterogeneousEDProducer` needs access to the configuration, so it has
+to be passed to its constructor as in the following example
+
+```cpp
+FooProducer::FooProducer(edm::ParameterSet const& iConfig):
+  HeterogeneousEDProducer(iConfig),
+  ...
+```
+### Consumes
+
+If the `EDProducer` reads any `HeterogeneousProduct`'s
+([see more details](#heterogeneousproduct)), the `consumes()` call
+should be made along the following
+
+```cpp
+class FooProducer ... {
+  ...
+  EDGetTokenT<HeterogeneousProduct> token_;
+};
+...
+FooProducer::FooProducer(edm::ParameterSet const& iConfig):
+  ...
+  token_(consumesHeterogeneous(iConfig.getParameter<edm::InputTag>("..."))),
+  ...
+```
+
+so that `HeterogeneousEDProducer` can inspect the location of input
+heterogeneous products to decide on which device to run the algorithm
+([see more details](#device-scheduling)).
+
+### Produces
+
+If the `EDProducer` produces any `HeterogeneousProduct`'s
+([see more details](#heterogeneousproduct)), the `produces()` call
+should be made along the following (i.e. as usual)
+
+```cpp
+FooProducer::FooProducer(edm::ParameterSet const& iConfig) ... {
+  ...
+  produces<HeterogeneousEvent>();
+}
+```
+
+## fillDescriptions()
+
+`HeterogeneousEDProducer` provides a `fillPSetDescription()` function
+that can be called from the concrete `EDProducer`'s
+`fillDescriptions()` as in the following example
+
+```cpp
+void FooProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // fill desc for other parameters
+
+  HeterogeneousEDProducer::fillPSetDescription(desc);
+
+  descriptions.add("fooProducer", desc);
+}
+```
+
+## Device scheduling
+
+The per-event scheduling of algorithms is currently as follows
+1. If there are no `HeterogeneousProduct` inputs ([see more details](#heterogeneousproduct))
+   * Loop over the device types in the order specified in `heterogeneous::HeterogeneousDevices<...>` template arguments
+   * Run the algorithm on the first device that is enabled for that module (instance)
+2. If there are `HeterogeneousProduct` inputs
+   * Run the algorithm on **the device where the data of the first input resides**
+
+## HeterogeneousProduct
+
+The `HeterogeneousProduct` is a transient edm product with the following properties
+* placeholder for products (of arbitrary types) in all device types
+* tracks the location of the data
+* automatic, on-demand transfers from device to CPU 
+  - developer has to provide a function to do the transfer and possible data reorganiazation
+
+Some of the complexity exists to avoid ROOT dictionary generation of the concrete product types.
+
+## HeterogeneousEvent
+
+The `HeterogeneousEvent` is a wrapper on top of `edm::Event` to hide
+most of the complexity of `HeterogeneousProduct` to make its use look
+almost like standard products with `edm::Event`. Some part of the
+`edm::Event` interface is implemented (and delegated back to
+`edm::Event`) in order to get/put standard products as well.
+
+Here is a short example how to deal use `HeterogeneousProduct` with
+`HeterogeneousEvent` (using the same `FooProducer` example as before)
+
+```cpp
+class FooProducer ... {
+  ...
+  // in principle these definitions should be treated like DataFormats
+  struct CPUProduct {
+    std::vector<int> foo;
+  };
+  struct GPUProduct {
+    float *foo_d; // pointer to GPU memory
+  }
+
+  using InputType = HeterogeneousProductImpl<heterogeneous::CPUProduct<CPUProduct>,
+                                             heterogeneous::GPUProduct<GPUProduct>>;
+  using OutputType = InputType; // using same input and output only because of laziness
+  
+  void transferGPUtoCPU(GPUProduct const& gpu, CPUProduct& cpu) const;
+};
+
+void FooProducer::produceCPU(edm::HeterogeneousEvent const& iEvent, ...) {
+  edm::Handle<CPUProduct> hinput;
+  iEvent.getByToken<InputType>(token_, hinput); // note the InputType template argument
+
+  // do whatever you want with hinput->foo;
+
+  auto output = std::make_unique<CPUProduct>(...);
+  iEvent.put<OutputType>(std::move(output));    // note the OutputType template argument
+}
+
+void FooProducer::acquireGPUCuda(edm::HeterogeneousEvent const& iEvent, ...) {
+  edm::Handle<GPUProduct> hinput;
+  iEvent.getByToken<InputType>(token_, hinput); // note the InputType template argument
+
+  // do whatever you want with hinput->foo_d;
+
+  auto output = std::make_unique<GPUProduct>(...);
+  // For non-CPU products, a GPU->CPU transfer function must be provided
+  // In this example it is prodided as a lambda calling a member function, but this is not required
+  // The function can be anything assignable to std::function<void(GPUProduc const&, CPUProduct)>
+  iEvent.put<OutputType>(std::move(output), [this](GPUProduct const& gpu, CPUProduct& cpu) { // note the OutputType template argument
+    this->transferGPUtoCPU(gpu, cpu);
+  });
+  // It is also possible to disable the GPU->CPU transfer
+  // If the data resides on a GPU, and the corresponding CPU product is requested, an exception is thrown
+  //iEvent.put<OutputType>(std::move(output), heterogeneous::DisableTransfer); // note the OutputType template argument
+}
+
+```
+
+
+## Devices
+
+This section documents which functions the `EDProducer` can/has to
+implement for various devices.
+
+### CPU
+
+A CPU implementation is declared by giving `heterogeneous::CPU` as a
+template argument to `heterogeneous::HeterogeneousDevices`. Currently
+it is a mandatory argument, and has to be the last one (i.e. there
+must always be a CPU implementation, which is used as the last resort
+if there are no other devices).
+
+#### Optional functions
+
+There is one optional function
+
+```cpp
+void beginStreamCPU(edm::StreamID id);
+```
+
+which is called at the beginning of an `edm::Stream`. Usually there is
+no need to implement it, but the possibility is provided in case it is
+needed for something (as the `stream::EDProducer::beginStream()` is
+overridden by `HeterogeneousEDProducer`).
+
+#### Mandatory functions
+
+There is one mandatory function
+
+```cpp
+void produceCPU(edm::HeterogeneousEvent& iEvent, edm::EventSetup const& iSetup);
+```
+
+which is almost equal to the usual `stream::EDProducer::produce()`
+function. It is called from `HeterogeneousEDProducer::produce()` if
+the device scheduler decides that the algorithm should be run on CPU
+([see more details](#device-scheduling)). The first argument is
+`edm::HeterogeneousEvent` instead of the usual `edm::Event`
+([see more details](#heterogeneousevent)).
+
+The function should read its input, run the algorithm, and put the
+output to the event.
+
+### CUDA GPU
+
+A CUDA GPU implementation is declared by giving
+`heterogeneous::GPUCuda` as a template argument to
+`heterogeneous::HeterogeneousDevices`. The following `#include` is
+also needed
+```cpp
+#include "HeterogeneousCore/CUDACore/interface/GPUCuda.h"
+```
+#### Optional functions
+
+There is one optional function
+
+```cpp 
+void beginStreamGPUCuda(edm::StreamID id, cuda::stream_t<>& cudaStream);
+```
+
+which is called at the beginning of an `edm::Stream`. **If the
+algorithm has to allocate memory buffers for the duration of the whole
+job, the recommended place is here.** The current CUDA device is set
+by the framework before the call, and all asynchronous tasks should be
+enqueued to the CUDA stream given as an argument.
+
+Currently the very same CUDA stream object will be given to the
+`acquireGPUCuda()` and `produceGPUCuda()` for this `edm::Stream`. This
+may change in the future though, in which case it will still be
+guaranteed that the CUDA stream here will be synchronized before the
+first call to `acquireGPUCuda()`.
+
+#### Mandatory functions
+
+There are two mandatory functions:
+
+```cpp
+void acquireGPUCuda(edm::HeterogeneousEvent const& iEvent, edm::EventSetup const& iSetup, cuda::stream_t<>& cudaStream);
+```
+
+The `acquireGPUCuda()` is called from
+`HeterogeneousEDProducer::acquire()` if the device scheduler devices
+that the algorithm should be run on a CUDA GPU
+([see more details](#device-scheduling)). The function should read
+the necessary input (which may possibly be already on a GPU,
+([see more details](#heterogeneousproduct)), and enqueue the
+*asynchronous* work on the CUDA stream given as an argument. The
+current CUDA deviceis set by the framework before the call. After the
+`acquireGPUCuda()` returns, framework will itself enqueue a callback
+function to the CUDA stream that will call
+`edm::WaitingTaskWithArenaHolder::doneWaiting()` to signal to the
+framework that this `EDProducer` is ready to transition to
+`produce()`.
+
+Currently the very same CUDA stream will be given to the
+`produceGPUCuda()`.
+
+
+```cpp
+void produceGPUCuda(edm::HeterogeneousEvent& iEvent, edm::EventSetup const& iSetup, cuda::stream_t<>& cudaStream);
+```
+
+The `produceGPUCuda()` is called from
+`HeterogeneousEDProducer::produce()` if the algorithm was run on a
+CUDA GPU. The function should do any necessary GPU->CPU transfers,
+post-processing, and put the products to the event (for passing "GPU
+products" [see here](#heterogeneousproduct)).
+
+#### Memory allocations
+
+The `cudaMalloc()` is somewhat heavy function (synchronizing the whole
+device, among others). The current strategy (although not enforced by
+the framework) is to allocate memory buffers at the beginning of a
+job. It is recommended to do these allocations in the
+`beginStreamGPUCuda()`, as it is called exactly once per job per
+`stream::EDProducer` instance, and it is the earliest point in the
+framework where we have the concept of `edm::Stream` so that the
+framework can assign the `edm::Stream`s to CUDA devices
+([see more details](#multipledevices)).
+
+Freeing the GPU memory can be done in the destructor as it does not
+require any special support from the framework.
+
+#### Multiple devices
+
+Currently `edm::Stream`'s are statically assigned to CUDA devices in a
+round-robin fashion. The assignment is done at the `beginStream()`
+time before calling the `EDProducer` `beginStreamDevice()` functions.
+
+Technically "assigning `edm::Stream`" means that each relevant
+`EDProducer` instance of that `edm::Stream` will hold a device id of
+`streamId % numberOfDevices`.
+
+### Mock GPU
+
+The `GPUMock` is intended only for testing of the framework as a
+something requiring a GPU-like interface but still ran on the CPU. The
+documentation is left to be the code itself.


### PR DESCRIPTION
This PR adds more documentation (this time aimed for a user), and adds two sanity checks on GPUCuda.

Tested in 10_2_0_pre4.

@fwyzard @felicepantaleo @VinInn @rovere @vkhristenko