### PR TITLE
Fix deprecation warning in CUDAService

### DIFF
--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -39,11 +39,17 @@ CUDAService::CUDAService(edm::ParameterSet const& iConfig, edm::ActivityRegistry
   computeCapabilities_.reserve(numberOfDevices_);
   for(int i=0; i<numberOfDevices_; ++i) {
     int major, minor;
-    ret = cuDeviceComputeCapability(&major, &minor, i);
+    ret = cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, i);
     if(CUDA_SUCCESS != ret) {
-      edm::LogWarning("CUDAService") << "Failed to call cuDeviceComputeCapability for device " << i << " from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
+      edm::LogWarning("CUDAService") << "Failed to call cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR) for device " << i << " from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
       return;
     }
+    ret = cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, i);
+    if(CUDA_SUCCESS != ret) {
+      edm::LogWarning("CUDAService") << "Failed to call cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR) for device " << i << " from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
+      return;
+    }
+
     edm::LogInfo("CUDAService") << "Device " << i << " compute capability major " << major << " minor " << minor;
     computeCapabilities_.emplace_back(major, minor);
   }

--- a/HeterogeneousCore/CUDAServices/test/testCUDAServiceDrv.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAServiceDrv.cpp
@@ -85,14 +85,23 @@ int main()
       char deviceName[256];
       for( CUdevice i=0; i<deviceCount; ++i )
       {
-	ret = cuDeviceComputeCapability(&major, &minor, i);
+	ret = cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, i);
 	if( ret != CUDA_SUCCESS )
 	{
 	  std::ostringstream errstr;
-	  errstr << "Unable to query the device " << i << " compute capability using the CUDA driver API: ("
+	  errstr << "Unable to query the device " << i << " compute capability major using the CUDA driver API: ("
 		 << ret << ") " << getCudaDrvErrorString( ret );
 	  throw cms::Exception( "CUDAService", errstr.str() );
 	}
+	ret = cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, i);
+	if( ret != CUDA_SUCCESS )
+	{
+	  std::ostringstream errstr;
+	  errstr << "Unable to query the device " << i << " compute capability minor using the CUDA driver API: ("
+		 << ret << ") " << getCudaDrvErrorString( ret );
+	  throw cms::Exception( "CUDAService", errstr.str() );
+	}
+
         ret = cuDeviceGetName( deviceName, 256, i );
         if( ret != CUDA_SUCCESS )
 	{


### PR DESCRIPTION
`cuDeviceComputeCapability` was deprecated in CUDA 5.0, and gcc7 warns about that. This PR replaces the calls with `cuDeviceGetAttribute()`.

Tested in 10_2_0_pre4_Patatrack, no changes expected.