### PR TITLE
Clean up `CAHitNtupletHeterogeneousEDProducer`

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -1,17 +1,16 @@
-<use   name="RecoTracker/TkTrackingRegions"/>
-<use   name="RecoPixelVertexing/PixelTriplets"/>
-<use   name="RecoTracker/TkSeedingLayers"/>
-<use   name="RecoPixelVertexing/PixelTrackFitting"/>
-<library   file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
-  <use   name="cuda"/>
-  <flags   EDM_PLUGIN="1"/>
-  <flags   CUDA_FLAGS="--expt-relaxed-constexpr"/>
-  <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
-  <use name="FWCore/ParameterSet"/>
-  <use name="HeterogeneousCore/Producer"/>
-  <use name="HeterogeneousCore/Product"/>
-  <use name="HeterogeneousCore/CUDACore"/>
-  <use name="cuda-api-wrappers"/>
+<use name="cuda"/>
+<use name="cuda-api-wrappers"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+<use name="HeterogeneousCore/CUDACore"/>
+<use name="HeterogeneousCore/Producer"/>
+<use name="HeterogeneousCore/Product"/>
+<use name="RecoPixelVertexing/PixelTrackFitting"/>
+<use name="RecoPixelVertexing/PixelTriplets"/>
+<use name="RecoTracker/TkSeedingLayers"/>
+<use name="RecoTracker/TkTrackingRegions"/>
+<library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
+  <flags EDM_PLUGIN="1"/>
 </library>
-<flags   CXXFLAGS="-Ofast -fno-math-errno"/>
+<flags CXXFLAGS="-Ofast -fno-math-errno"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -52,13 +52,12 @@ public:
     void initEvent(const edm::Event& ev, const edm::EventSetup& es);
 
     void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
-                     std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
-                     const SeedingLayerSetsHits& layers, const cudaStream_t& stream);
+                     const SeedingLayerSetsHits& layers, cudaStream_t stream);
     void fillResults(const IntermediateHitDoublets& regionDoublets,
                      std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
-                     const SeedingLayerSetsHits& layers, const cudaStream_t& stream);
+                     const SeedingLayerSetsHits& layers, cudaStream_t stream);
 
     void allocateOnGPU();
     void deallocateOnGPU();
@@ -132,12 +131,10 @@ private:
         const bool enabled_;
     };
 
-
-
-    void  launchKernels(const TrackingRegion &, int);
-    std::vector<std::array<std::pair<int,int> ,3 > > fetchKernelResult(int );
+    void  launchKernels(const TrackingRegion &, int, cudaStream_t);
+    std::vector<std::array<std::pair<int,int> ,3>> fetchKernelResult(int, cudaStream_t);
     const float extraHitRPhitolerance;
-    std::vector<std::vector<const HitDoublets *> > hitDoublets;
+    std::vector<std::vector<const HitDoublets *>> hitDoublets;
 
     const QuantityDependsPt maxChi2;
     const bool fitFastCircle;
@@ -147,8 +144,6 @@ private:
     const float caThetaCut = 0.00125f;
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
-
-    cudaStream_t cudaStream_;
 
     static constexpr int maxNumberOfQuadruplets_ = 10000;
     static constexpr int maxCellsPerHit_ = 512;
@@ -163,7 +158,6 @@ private:
     unsigned int numberOfLayerPairs_ = 0;
     unsigned int numberOfLayers_ = 0;
 
-
     GPULayerDoublets* h_doublets_;
     GPULayerHits* h_layers_;
 
@@ -175,13 +169,10 @@ private:
     GPULayerDoublets* d_doublets_;
     unsigned int* d_indices_;
     unsigned int* h_rootLayerPairs_;
-    std::vector< GPU::SimpleVector<Quadruplet>* > h_foundNtupletsVec_;
-    std::vector< Quadruplet* > h_foundNtupletsData_;
-
+    std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;
+    std::vector<Quadruplet*> h_foundNtupletsData_;
 
     std::vector<GPU::SimpleVector<Quadruplet>*> d_foundNtupletsVec_;
-    std::vector<GPU::SimpleVector<Quadruplet>*> tmp_foundNtupletsVec_;
-
     std::vector<Quadruplet*> d_foundNtupletsData_;
 
     GPUCACell* device_theCells_;
@@ -189,6 +180,6 @@ private:
 
     GPULayerHits* tmp_layers_;
     GPULayerDoublets* tmp_layerDoublets_;
-
 };
+
 #endif


### PR DESCRIPTION
Apply some clean up to the code and formatting of `CAHitNtupletHeterogeneousEDProducer` and `CAHitQuadrupletGeneratorGPU`, as suggested by @makortel during the review of #48:
  - clean up the `BuildFile.xml`
  - remove unused data members and arguments from function calls;
  - percolate the CUDA stream instead of storing it as a data member.

Also:
  - add `cudaCheck` calls around memory allocations and copies;
  - reduce the number of memory allocations used to set up the GPU state.