### PR TITLE
Fix CA GPU destructor also when allocateOnGPU() is not called.

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -360,7 +360,7 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
   cudaFreeHost(h_y_);
   cudaFreeHost(h_z_);
   cudaFreeHost(h_rootLayerPairs_);
-  for (int i = 0; i < maxNumberOfRegions_; ++i)
+  for (size_t i = 0; i < h_foundNtupletsVec_.size(); ++i)
   {
     cudaFreeHost(h_foundNtupletsVec_[i]);
     cudaFreeHost(h_foundNtupletsData_[i]);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -373,6 +373,7 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
 
   cudaFree(d_indices_);
   cudaFree(d_doublets_);
+  cudaFree(d_layers_);
   cudaFree(d_x_);
   cudaFree(d_y_);
   cudaFree(d_z_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -158,28 +158,28 @@ private:
     unsigned int numberOfLayerPairs_ = 0;
     unsigned int numberOfLayers_ = 0;
 
-    GPULayerDoublets* h_doublets_;
-    GPULayerHits* h_layers_;
+    GPULayerDoublets* h_doublets_ = nullptr;
+    GPULayerHits* h_layers_ = nullptr;
 
-    unsigned int* h_indices_;
-    float *h_x_, *h_y_, *h_z_;
-    float *d_x_, *d_y_, *d_z_;
-    unsigned int* d_rootLayerPairs_;
+    unsigned int* h_indices_ = nullptr;
+    float *h_x_=nullptr, *h_y_=nullptr, *h_z_=nullptr;
+    float *d_x_=nullptr, *d_y_=nullptr, *d_z_=nullptr;
+    unsigned int* d_rootLayerPairs_ = nullptr;
     GPULayerHits* d_layers_;
     GPULayerDoublets* d_doublets_;
-    unsigned int* d_indices_;
-    unsigned int* h_rootLayerPairs_;
+    unsigned int* d_indices_ = nullptr;
+    unsigned int* h_rootLayerPairs_ = nullptr;
     std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;
     std::vector<Quadruplet*> h_foundNtupletsData_;
 
     std::vector<GPU::SimpleVector<Quadruplet>*> d_foundNtupletsVec_;
     std::vector<Quadruplet*> d_foundNtupletsData_;
 
-    GPUCACell* device_theCells_;
-    GPU::VecArray< unsigned int, maxCellsPerHit_>* device_isOuterHitOfCell_;
+    GPUCACell* device_theCells_ = nullptr;
+    GPU::VecArray< unsigned int, maxCellsPerHit_>* device_isOuterHitOfCell_ = nullptr;
 
-    GPULayerHits* tmp_layers_;
-    GPULayerDoublets* tmp_layerDoublets_;
+    GPULayerHits* tmp_layers_ = nullptr;
+    GPULayerDoublets* tmp_layerDoublets_ = nullptr;
 };
 
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -165,8 +165,8 @@ private:
     float *h_x_=nullptr, *h_y_=nullptr, *h_z_=nullptr;
     float *d_x_=nullptr, *d_y_=nullptr, *d_z_=nullptr;
     unsigned int* d_rootLayerPairs_ = nullptr;
-    GPULayerHits* d_layers_;
-    GPULayerDoublets* d_doublets_;
+    GPULayerHits* d_layers_ = nullptr;
+    GPULayerDoublets* d_doublets_ = nullptr;
     unsigned int* d_indices_ = nullptr;
     unsigned int* h_rootLayerPairs_ = nullptr;
     std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;


### PR DESCRIPTION
`CAHitQuadrupletGeneratorGPU` calls `deallocateOnGPU()` from its destructor. When `CAHitNtupletHeterogeneousEDProducer` is forced to run on CPU, the `deallocateOnGPU()` gets called without a call to `allocateOnGPU()` first. This PR initializes the pointer members to `nullptr` so that `cudaFree(Host)` won't try to free them, and loops over the vectors of pointers by using the actual size of the vectors.

Alternatively we could
* destructor could be made not to call `deallocateOnGPU()`
* make `CAHitQuadrupletGeneratorGPU` to follow RAII and construct it in `beginStreamGPU()` (this is the pattern I've used)

Tested in 10_2_0_pre5_Patatrack, no changes expected.

@felicepantaleo @fwyzard 