### PR TITLE
Call cuInit() in a separate thread, with a timeout

### DIFF
--- a/HeterogeneousCore/CUDAServices/interface/cuInitAsync.h
+++ b/HeterogeneousCore/CUDAServices/interface/cuInitAsync.h
@@ -1,0 +1,8 @@
+#ifndef HeterogeneousCore_CUDAServices_cuInitAsync_h 
+#define HeterogeneousCore_CUDAServices_cuInitAsync_h
+
+#include <cuda.h>
+
+CUresult cuInitAsync(unsigned int flags, double timeout);
+
+#endif // HeterogeneousCore_CUDAServices_cuInitAsync_h

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -1,43 +1,51 @@
-#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-
 #include <cuda.h>
 #include <cuda/api_wrappers.h>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAServices/interface/cuInitAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/getCudaDrvErrorString.h"
 
-#include <dlfcn.h>
-
 CUDAService::CUDAService(edm::ParameterSet const& iConfig, edm::ActivityRegistry& iRegistry) {
-  bool configEnabled = iConfig.getUntrackedParameter<bool>("enabled");
-  if(!configEnabled) {
+  bool enabled = iConfig.getUntrackedParameter<bool>("enabled");
+  double timeout = iConfig.getUntrackedParameter<double>("timeout");
+
+  if (not enabled) {
     edm::LogInfo("CUDAService") << "CUDAService disabled by configuration";
     return;
   }
 
-  auto ret = cuInit(0);
-  if(CUDA_SUCCESS != ret) {
+  // Call cuInit() in a separate thread, and fail if it does not manage to initialise the CUDA driver before the timeout.
+  // This may happen e.g. if the CUDA driver is blocked by a running cuda-gdb.
+  // Use the driver API rather than the runtime API because calls to `cudaGetErrorName()` and `cudaGetErrorString()` will
+  // also block, while calls to `cuGetErrorName()` and `cuGetErrorString()` will work.
+  auto ret = cuInitAsync(0, timeout);
+  if (CUDA_ERROR_NOT_INITIALIZED == ret) {
+    edm::LogWarning("CUDAService") << "Time out after " << timeout << "s while trying to initialize the CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
+    return;
+  }
+  if (CUDA_SUCCESS != ret) {
     edm::LogWarning("CUDAService") << "Failed to initialize the CUDA driver API by calling cuInit, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
     return;
   }
   edm::LogInfo("CUDAService") << "cuInit succeeded";
 
   ret = cuDeviceGetCount(&numberOfDevices_);
-  if(CUDA_SUCCESS != ret) {
+  if (CUDA_SUCCESS != ret) {
     edm::LogWarning("CUDAService") << "Failed to call cuDeviceGetCount from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
     return;
   }
   edm::LogInfo("CUDAService") << "cuDeviceGetCount succeeded, found " << numberOfDevices_ << " devices";
-  if(numberOfDevices_ < 1) {
+  if (numberOfDevices_ < 1) {
     edm::LogWarning("CUDAService") << "Number of devices < 1, disabling CUDAService";
     return;
   }
 
   auto numberOfStreamsPerDevice = iConfig.getUntrackedParameter<unsigned int>("numberOfStreamsPerDevice");
-  if(numberOfStreamsPerDevice > 0) {
+  if (numberOfStreamsPerDevice > 0) {
     numberOfStreamsTotal_ = numberOfStreamsPerDevice * numberOfDevices_;
     edm::LogSystem("CUDAService") << "Number of edm::Streams per CUDA device has been set to " << numberOfStreamsPerDevice << ". With " << numberOfDevices_ << " CUDA devices, this means total of " << numberOfStreamsTotal_ << " edm::Streams for all CUDA devices."; // TODO: eventually silence to LogDebug
   }
@@ -46,12 +54,12 @@ CUDAService::CUDAService(edm::ParameterSet const& iConfig, edm::ActivityRegistry
   for(int i=0; i<numberOfDevices_; ++i) {
     int major, minor;
     ret = cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, i);
-    if(CUDA_SUCCESS != ret) {
+    if (CUDA_SUCCESS != ret) {
       edm::LogWarning("CUDAService") << "Failed to call cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR) for device " << i << " from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
       return;
     }
     ret = cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, i);
-    if(CUDA_SUCCESS != ret) {
+    if (CUDA_SUCCESS != ret) {
       edm::LogWarning("CUDAService") << "Failed to call cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR) for device " << i << " from CUDA driver API, return value " << ret << " ("<< getCudaDrvErrorString(ret) << "), disabling CUDAService";
       return;
     }
@@ -66,7 +74,8 @@ CUDAService::CUDAService(edm::ParameterSet const& iConfig, edm::ActivityRegistry
 
 void CUDAService::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<bool>("enabled", true);
+  desc.addUntracked<bool>("enabled", true)->setComment("Enable the CUDAService.");
+  desc.addUntracked<double>("timeout", 1.)->setComment("Seconds after which the initialisation will time out, and disable the CUDAService.");
   desc.addUntracked<unsigned int>("numberOfStreamsPerDevice", 0)->setComment("Upper limit of the number of edm::Streams that will run on a single CUDA GPU device. The remaining edm::Streams will be run only on other devices (for time being this means CPU in practice). The value '0' means 'unlimited', a value >= 1 imposes the limit.");
 
   descriptions.add("CUDAService", desc);
@@ -86,7 +95,7 @@ int CUDAService::deviceWithMostFreeMemory() const {
     cudaMemGetInfo(&free, &tot);
     auto mem = free;
     edm::LogPrint("CUDAService") << "Device " << i << " free memory " << mem;
-    if(mem > freeMem) {
+    if (mem > freeMem) {
       freeMem = mem;
       devId = i;
     }

--- a/HeterogeneousCore/CUDAServices/src/cuInitAsync.cc
+++ b/HeterogeneousCore/CUDAServices/src/cuInitAsync.cc
@@ -1,0 +1,24 @@
+#include <chrono>
+#include <thread>
+#include <future>
+
+#include "HeterogeneousCore/CUDAServices/interface/cuInitAsync.h"
+
+CUresult cuInitAsync(unsigned int flags, double timeout) {
+    std::promise<CUresult> handle;
+    std::thread worker([&handle, flags]() {
+        // call cuInit() in a separate thread
+        handle.set_value(cuInit(flags));
+    });
+    auto result = handle.get_future();
+    auto status = result.wait_for(std::chrono::duration<double>(timeout));
+    if (status == std::future_status::ready) {
+        // wait for the worker thread to complete
+        worker.join();
+        return result.get();
+    } else {
+        // let the worker thread sleep (or busy-wait) as long as the CUDA subsystem is busy
+        worker.detach();
+        return CUDA_ERROR_NOT_INITIALIZED;
+    }
+}


### PR DESCRIPTION
Call `cuInit()` in a separate thread, and fail if it does not manage to initialise the CUDA driver before a timeout. This may happen e.g. if the CUDA driver is blocked by a running cuda-gdb.

Use the driver API rather than the runtime API because calls to `cudaGetErrorName()` and `cudaGetErrorString()` will also block, while calls to `cuGetErrorName()` and `cuGetErrorString()` will work.