### PR TITLE
Customize function to provide a minimal configuration for profiling

### DIFF
--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+def customizePixelTracksForProfiling(process):
+    process.out = cms.OutputModule("AsciiOutputModule",
+        outputCommands = cms.untracked.vstring(
+            "keep *_pixelTracks_*_*",
+        ),
+        verbosity = cms.untracked.uint32(0),
+    )
+    process.outPath = cms.EndPath(process.out)
+
+    process.schedule = cms.Schedule(process.raw2digi_step,process.reconstruction_step,process.outPath)
+
+    return process

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksForProfiling.py
@@ -7,8 +7,9 @@ def customizePixelTracksForProfiling(process):
         ),
         verbosity = cms.untracked.uint32(0),
     )
+    
     process.outPath = cms.EndPath(process.out)
 
-    process.schedule = cms.Schedule(process.raw2digi_step,process.reconstruction_step,process.outPath)
+    process.schedule = cms.Schedule(process.raw2digi_step, process.reconstruction_step, process.outPath)
 
     return process


### PR DESCRIPTION
Resolves #70.

Can be included with the following snippet in the configuration
```python
from RecoPixelVertexing.Configuration.customizePixelTracksForProfiling import customizePixelTracksForProfiling
process = customizePixelTracksForProfiling(process)
```
Essentially removes validation, DQM, and output modules. As suggested in https://github.com/cms-patatrack/cmssw/issues/70#issuecomment-394407583, an `AsciiOutputModule` is used to require the `pixelTracks` (with output suppressed by the configuration).

@fwyzard @felicepantaleo @VinInn @rovere 

