### PR TITLE
Remove all remaining calls to cudaStreamSynchronize()

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use   name="HeterogeneousCore/CUDACore"/>
 <use   name="cuda"/>
 <use   name="cuda-api-wrappers"/>
+<use   name="cub"/>
 <library   file="*.cc *.cu" name="RecoLocalTrackerSiPixelClusterizerPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -623,10 +623,19 @@ namespace pixelgpudetails {
 
     if (includeErrors) {
       cudaCheck(cudaMemcpyAsync(error_h, error_d, vsize, cudaMemcpyDefault, stream.id()));
-      cudaCheck(cudaStreamSynchronize(stream.id()));
-      error_h->set_data(data_h);
-      int size = error_h->size();
-      cudaCheck(cudaMemcpyAsync(data_h, data_d, size*esize, cudaMemcpyDefault, stream.id()));
+      cudaCheck(cudaMemcpyAsync(data_h, data_d, MAX_FED*pixelgpudetails::MAX_WORD*esize, cudaMemcpyDefault, stream.id()));
+      // If we want to transfer only the minimal amount of data, we
+      // need a synchronization point. A single ExternalWork (of
+      // SiPixelRawToClusterHeterogeneous) does not help because it is
+      // already used to synchronize the data movement. So we'd need
+      // two ExternalWorks (or explicit use of TBB tasks). The
+      // prototype of #100 would allow this easily (as there would be
+      // two ExternalWorks).
+      //
+      //error_h->set_data(data_h);
+      //cudaCheck(cudaStreamSynchronize(stream.id()));
+      //int size = error_h->size();
+      //cudaCheck(cudaMemcpyAsync(data_h, data_d, size*esize, cudaMemcpyDefault, stream.id()));
     }
     // End  of Raw2Digi and passing data for cluserisation
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -182,7 +182,8 @@ namespace pixelgpudetails {
         pdigi_h, rawIdArr_h, clus_h, adc_h, error_h,
         gpuProduct_d,
         xx_d, yy_d, adc_d, moduleInd_d, moduleStart_d,clus_d, clusInModule_d, moduleId_d,
-        nDigis, nModulesActive
+        clusModuleStart_d,
+        nDigis, nModulesActive, nClusters
       };
     }
 
@@ -205,6 +206,7 @@ namespace pixelgpudetails {
 
     uint32_t nDigis = 0;
     uint32_t nModulesActive = 0;
+    uint32_t nClusters = 0;
 
     // scratch memory buffers
     uint32_t * word_d;
@@ -224,6 +226,11 @@ namespace pixelgpudetails {
     int32_t *  clus_d;
     uint32_t * clusInModule_d;
     uint32_t * moduleId_d;
+
+    // originally in rechit, moved here
+    uint32_t *clusModuleStart_d = nullptr;
+    void *tempScanStorage_d = nullptr;
+    size_t tempScanStorageSize = 0;
   };
 
   // configuration and memory buffers alocated on the GPU

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -170,14 +170,14 @@ namespace pixelgpudetails {
 
     void initializeWordFed(int fedId, unsigned int wordCounterGPU, const cms_uint32_t *src, unsigned int length);
 
-    // Not really very async yet...
     void makeClustersAsync(const SiPixelFedCablingMapGPU *cablingMap, const unsigned char *modToUnp,
                            const SiPixelGainForHLTonGPU *gains,
                            const uint32_t wordCounter, const uint32_t fedCounter, bool convertADCtoElectrons,
                            bool useQualityInfo, bool includeErrors, bool debug,
                            cuda::stream_t<>& stream);
 
-    auto getProduct() const {
+    auto getProduct() {
+      error_h->set_data(data_h);
       return siPixelRawToClusterHeterogeneousProduct::GPUProduct{
         pdigi_h, rawIdArr_h, clus_h, adc_h, error_h,
         gpuProduct_d,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/siPixelRawToClusterHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/siPixelRawToClusterHeterogeneousProduct.h
@@ -57,8 +57,12 @@ namespace siPixelRawToClusterHeterogeneousProduct {
     uint32_t const * clusInModule_d;
     uint32_t const * moduleId_d;
 
+    // originally from rechits
+    uint32_t const * clusModuleStart_d;
+
     uint32_t nDigis;
     uint32_t nModules;
+    uint32_t nClusters;
   };
 
   using HeterogeneousDigiCluster = HeterogeneousProductImpl<heterogeneous::CPUProduct<CPUProduct>,

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -8,6 +8,5 @@
 <library file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
   <use name="cuda"/>
   <use name="cuda-api-wrappers"/>
-  <use name="cub"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -8,5 +8,6 @@
 <library file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
   <use name="cuda"/>
   <use name="cuda-api-wrappers"/>
+  <use name="cub"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -5,9 +5,6 @@
 // CUDA runtime
 #include <cuda_runtime.h>
 
-// headers
-#include <cub/cub.cuh>
-
 // CMSSW headers
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
@@ -33,7 +30,6 @@ namespace pixelgpudetails {
   PixelRecHitGPUKernel::PixelRecHitGPUKernel(cuda::stream_t<>& cudaStream) {
 
     cudaCheck(cudaMalloc((void**) & gpu_.bs_d,3*sizeof(float)));
-    cudaCheck(cudaMalloc((void**) & gpu_.hitsModuleStart_d,(gpuClustering::MaxNumModules+1)*sizeof(uint32_t)));
     cudaCheck(cudaMalloc((void**) & gpu_.hitsLayerStart_d,(11)*sizeof(uint32_t)));
     cudaCheck(cudaMalloc((void**) & gpu_.charge_d,(gpuClustering::MaxNumModules*256)*sizeof(float)));
     cudaCheck(cudaMalloc((void**) & gpu_.detInd_d,(gpuClustering::MaxNumModules*256)*sizeof(uint16_t)));
@@ -54,10 +50,6 @@ namespace pixelgpudetails {
     gpu_.me_d = gpu_d;
     cudaCheck(cudaMemcpyAsync(gpu_d, &gpu_, sizeof(HitsOnGPU), cudaMemcpyDefault,cudaStream.id()));
 
-    uint32_t *tmp = nullptr;
-    cudaCheck(cub::DeviceScan::InclusiveSum(nullptr, tempScanStorageSize_, tmp, tmp, gpuClustering::MaxNumModules));
-    cudaCheck(cudaMalloc(&tempScanStorage_, tempScanStorageSize_));
-
     // Feels a bit dumb but constexpr arrays are not supported for device code
     // TODO: should be moved to EventSetup (or better ideas?)
     // Would it be better to use "constant memory"?
@@ -66,7 +58,6 @@ namespace pixelgpudetails {
   }
 
   PixelRecHitGPUKernel::~PixelRecHitGPUKernel() {
-    cudaCheck(cudaFree(gpu_.hitsModuleStart_d));
     cudaCheck(cudaFree(gpu_.charge_d));
     cudaCheck(cudaFree(gpu_.detInd_d));
     cudaCheck(cudaFree(gpu_.xg_d));
@@ -84,8 +75,6 @@ namespace pixelgpudetails {
     cudaCheck(cudaFree(gpu_.hist_d));
     cudaCheck(cudaFree(gpu_d));
 
-    cudaCheck(cudaFree(tempScanStorage_));
-
     cudaCheck(cudaFree(d_phase1TopologyLayerStart_));
   }
 
@@ -93,15 +82,9 @@ namespace pixelgpudetails {
                                            float const * bs,
                                            pixelCPEforGPU::ParamsOnGPU const * cpeParams,
                                            cuda::stream_t<>& stream) {
-
    cudaCheck(cudaMemcpyAsync(gpu_.bs_d, bs, 3*sizeof(float), cudaMemcpyDefault, stream.id()));
-
-    // Set first the first element to 0
-    cudaCheck(cudaMemsetAsync(gpu_.hitsModuleStart_d, 0, sizeof(uint32_t), stream.id()));
-    // Then use inclusive_scan to get the partial sum to the rest
-    cudaCheck(cub::DeviceScan::InclusiveSum(tempScanStorage_, tempScanStorageSize_,
-                                            input.clusInModule_d, &gpu_.hitsModuleStart_d[1], gpuClustering::MaxNumModules,
-                                            stream.id()));
+   gpu_.hitsModuleStart_d = input.clusModuleStart_d;
+   cudaCheck(cudaMemcpyAsync(gpu_d, &gpu_, sizeof(HitsOnGPU), cudaMemcpyDefault, stream.id()));
 
     int threadsPerBlock = 256;
     int blocks = input.nModules; // active modules (with digis)
@@ -130,6 +113,15 @@ namespace pixelgpudetails {
     // needed only if hits on CPU are required...
     cudaCheck(cudaMemcpyAsync(hitsModuleStart_, gpu_.hitsModuleStart_d, (gpuClustering::MaxNumModules+1) * sizeof(uint32_t), cudaMemcpyDefault, stream.id()));
     cudaCheck(cudaMemcpyAsync(hitsLayerStart_, gpu_.hitsLayerStart_d, 11*sizeof(uint32_t), cudaMemcpyDefault, stream.id()));
+    auto nhits = input.nClusters;
+    cpu_ = std::make_unique<HitsOnCPU>(nhits);
+    cudaCheck(cudaMemcpyAsync(cpu_->charge.data(), gpu_.charge_d, nhits*sizeof(int32_t), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->xl.data(), gpu_.xl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->yl.data(), gpu_.yl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->xe.data(), gpu_.xerr_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->ye.data(), gpu_.yerr_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->mr.data(), gpu_.mr_d, nhits*sizeof(uint16_t), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(cpu_->mc.data(), gpu_.mc_d, nhits*sizeof(uint16_t), cudaMemcpyDefault, stream.id()));
 
 #ifdef GPU_DEBUG
     cudaStreamSynchronize(stream.id());
@@ -147,21 +139,9 @@ namespace pixelgpudetails {
     cudautils::fillManyFromVector(gpu_.hist_d,10,gpu_.iphi_d, gpu_.hitsLayerStart_d, nhits,256,stream.id());
   }
 
-  HitsOnCPU PixelRecHitGPUKernel::getOutput(cuda::stream_t<>& stream) const {
-    // needed only if hits on CPU are required...
-    auto nhits = hitsModuleStart_[gpuClustering::MaxNumModules];
-
-    HitsOnCPU hoc(nhits);
-    hoc.gpu_d = gpu_d;
-    memcpy(hoc.hitsModuleStart, hitsModuleStart_, (gpuClustering::MaxNumModules+1) * sizeof(uint32_t));
-    cudaCheck(cudaMemcpyAsync(hoc.charge.data(), gpu_.charge_d, nhits*sizeof(int32_t), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.xl.data(), gpu_.xl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.yl.data(), gpu_.yl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.xe.data(), gpu_.xerr_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.ye.data(), gpu_.yerr_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.mr.data(), gpu_.mr_d, nhits*sizeof(uint16_t), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaMemcpyAsync(hoc.mc.data(), gpu_.mc_d, nhits*sizeof(uint16_t), cudaMemcpyDefault, stream.id()));
-    cudaCheck(cudaStreamSynchronize(stream.id()));
-    return hoc;
+  std::unique_ptr<HitsOnCPU>&& PixelRecHitGPUKernel::getOutput(cuda::stream_t<>& stream) {
+    cpu_->gpu_d = gpu_d;
+    memcpy(cpu_->hitsModuleStart, hitsModuleStart_, (gpuClustering::MaxNumModules+1) * sizeof(uint32_t));
+    return std::move(cpu_);
   }
 }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -105,7 +105,9 @@ namespace pixelgpudetails {
     // needed only if hits on CPU are required...
     cudaCheck(cudaMemcpyAsync(hitsModuleStart_, gpu_.hitsModuleStart_d, (gpuClustering::MaxNumModules+1) * sizeof(uint32_t), cudaMemcpyDefault, stream.id()));
 
-    // to be moved to gpu?
+    cudaStreamSynchronize(stream.id());
+
+    // to be moved to gpu? YES, to get rid of the cudaStreamSynchronize above...
     auto nhits = hitsModuleStart_[gpuClustering::MaxNumModules];
     for (int i=0;i<10;++i) hitsLayerStart_[i]=hitsModuleStart_[phase1PixelTopology::layerStart[i]];
     hitsLayerStart_[10]=nhits;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -41,6 +41,8 @@ namespace pixelgpudetails {
   private:
     HitsOnGPU * gpu_d;  // copy of the structure on the gpu itself: this is the "Product" 
     HitsOnGPU gpu_;
+    void *tempScanStorage_ = nullptr;
+    size_t tempScanStorageSize_ = 0;
     uint32_t hitsModuleStart_[gpuClustering::MaxNumModules+1];
     uint32_t hitsLayerStart_[11];
   };

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -36,13 +36,12 @@ namespace pixelgpudetails {
                        pixelCPEforGPU::ParamsOnGPU const * cpeParams,
                        cuda::stream_t<>& stream);
 
-    HitsOnCPU getOutput(cuda::stream_t<>& stream) const;
+    std::unique_ptr<HitsOnCPU>&& getOutput(cuda::stream_t<>& stream);
 
   private:
     HitsOnGPU * gpu_d;  // copy of the structure on the gpu itself: this is the "Product" 
     HitsOnGPU gpu_;
-    void *tempScanStorage_ = nullptr;
-    size_t tempScanStorageSize_ = 0;
+    std::unique_ptr<HitsOnCPU> cpu_;
     uint32_t *d_phase1TopologyLayerStart_ = nullptr;
     uint32_t hitsModuleStart_[gpuClustering::MaxNumModules+1];
     uint32_t hitsLayerStart_[11];

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -43,6 +43,7 @@ namespace pixelgpudetails {
     HitsOnGPU gpu_;
     void *tempScanStorage_ = nullptr;
     size_t tempScanStorageSize_ = 0;
+    uint32_t *d_phase1TopologyLayerStart_ = nullptr;
     uint32_t hitsModuleStart_[gpuClustering::MaxNumModules+1];
     uint32_t hitsLayerStart_[11];
   };

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -179,7 +179,7 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
 }
 
 void SiPixelRecHitHeterogeneous::produceGPUCuda(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, cuda::stream_t<>& cudaStream) {
-  auto output = std::make_unique<GPUProduct>(gpuAlgo_->getOutput(cudaStream));
+  auto output = gpuAlgo_->getOutput(cudaStream);
 
  // Need the CPU clusters to
   // - properly fill the output DetSetVector of hits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
@@ -16,7 +16,7 @@ namespace siPixelRecHitsHeterogeneousProduct {
 
   struct HitsOnGPU{
      float * bs_d;
-     uint32_t * hitsModuleStart_d;
+     const uint32_t * hitsModuleStart_d; // forwarded from clusters
      uint32_t * hitsLayerStart_d;
      int32_t  * charge_d;
      uint16_t * detInd_d;


### PR DESCRIPTION
This PR removes all of the remaining calls to `cudaStreamSynchronize()`:
* Replaced `thrust::inclusive_scan` with `cub::DeviceScan::InclusiveSum` in rechits (though moved to raw2cluster within the last bullet)
   * This required allocating a temporary buffer in device memory for the algorithm, but it is done once per EDProducer instance
   * On the other hand, the `thrust::inclusive_scan` seems to use the `cub` algorithm internally, and in addition to the implicit `cudaStreamSynchronize()` it also allocates+frees the buffer on each call (!)
      * it's visible in the profiles
* In Raw2Cluster transfer the errors for the maximum number of modules
   * Relatively small number so doesn't make much of a difference
* In rechits, replaced the calculation of total number of hits by calculating the total number of clusters in the raw2cluster
   * The total number of hits is used to both the host side memory allocation and memory transfers, so with @felicepantaleo we felt that it could be better to try rearrange calculations

In addition, I noticed that rechits was accessing a host memory after a `cudaMemcpyAsync` to there without synchronization. First I added the synchronization, and then (following a comment) moved the number shuffling to GPU. It feels a bit dumb though to transfer the 11 elements of a `constexpr uint32_t` array to device memory, but apparently something like that is needed.

Resolves #79.

No changes expected.

@fwyzard @felicepantaleo @VinInn 