### PR TITLE
Make all device->host cudaMemcpyAsync's to use pinned memory

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -183,7 +183,7 @@ namespace pixelgpudetails {
         gpuProduct_d,
         xx_d, yy_d, adc_d, moduleInd_d, moduleStart_d,clus_d, clusInModule_d, moduleId_d,
         clusModuleStart_d,
-        nDigis, nModulesActive, nClusters
+        nDigis, *nModulesActive, *nClusters
       };
     }
 
@@ -205,8 +205,8 @@ namespace pixelgpudetails {
     GPU::SimpleVector<pixelgpudetails::error_obj> *error_h_tmp = nullptr;
 
     uint32_t nDigis = 0;
-    uint32_t nModulesActive = 0;
-    uint32_t nClusters = 0;
+    uint32_t *nModulesActive = nullptr;
+    uint32_t *nClusters = nullptr;
 
     // scratch memory buffers
     uint32_t * word_d;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -43,8 +43,10 @@ namespace pixelgpudetails {
     HitsOnGPU gpu_;
     std::unique_ptr<HitsOnCPU> cpu_;
     uint32_t *d_phase1TopologyLayerStart_ = nullptr;
-    uint32_t hitsModuleStart_[gpuClustering::MaxNumModules+1];
-    uint32_t hitsLayerStart_[11];
+    uint32_t *h_hitsModuleStart_ = nullptr;
+#ifdef GPU_DEBUG
+    uint32_t *h_hitsLayerStart_ = nullptr;
+#endif
   };
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
@@ -7,6 +7,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "HeterogeneousCore/Product/interface/HeterogeneousProduct.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAHostAllocator.h"
 
 namespace siPixelRecHitsHeterogeneousProduct {
 
@@ -49,11 +50,11 @@ namespace siPixelRecHitsHeterogeneousProduct {
     { }
 
     uint32_t hitsModuleStart[2001];
-    std::vector<int32_t> charge;
-    std::vector<float> xl, yl;
-    std::vector<float> xe, ye;
-    std::vector<uint16_t> mr;
-    std::vector<uint16_t> mc;
+    std::vector<int32_t,  CUDAHostAllocator<int32_t>> charge;
+    std::vector<float,    CUDAHostAllocator<float>> xl, yl;
+    std::vector<float,    CUDAHostAllocator<float>> xe, ye;
+    std::vector<uint16_t, CUDAHostAllocator<uint16_t>> mr;
+    std::vector<uint16_t, CUDAHostAllocator<uint16_t>> mc;
 
     uint32_t nHits;
     HitsOnGPU const * gpu_d = nullptr;


### PR DESCRIPTION
As noticed in the comments of #109, the in order for device->host `cudaMemcpyAsync()` to really be asynchronous, the target host memory must be pinned. This PR does that for raw2cluster and rechits (CA was already fine). This time I really checked with `nvprof` that the `acquire()` returns before the asynchronous work finishes.

@fwyzard @VinInn @felicepantaleo @rovere 
