### PR TITLE
Doublets on GPU

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
@@ -95,8 +95,11 @@ template <class T, int maxSize> struct VecArray {
 
   __inline__ constexpr void resize(int size) { m_size = size; }
 
+  __inline__ constexpr bool empty() const { return 0==m_size;}
 
-  int m_size;
+  __inline__ constexpr bool full() const { return maxSize==m_size;}       
+
+  int m_size=0;
 
   T m_data[maxSize];
 };

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -127,6 +127,7 @@ namespace pixelgpudetails {
     HitsOnCPU hoc(nhits);
     hoc.gpu_d = gpu_d;
     memcpy(hoc.hitsModuleStart, hitsModuleStart_, (gpuClustering::MaxNumModules+1) * sizeof(uint32_t));
+    cudaCheck(cudaMemcpyAsync(hoc.detInd.data(), gpu_.detInd_d, nhits*sizeof(int16_t), cudaMemcpyDefault, stream.id()));
     cudaCheck(cudaMemcpyAsync(hoc.charge.data(), gpu_.charge_d, nhits*sizeof(int32_t), cudaMemcpyDefault, stream.id()));
     cudaCheck(cudaMemcpyAsync(hoc.xl.data(), gpu_.xl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));
     cudaCheck(cudaMemcpyAsync(hoc.yl.data(), gpu_.yl_d, nhits*sizeof(float), cudaMemcpyDefault, stream.id()));

--- a/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
@@ -38,6 +38,7 @@ namespace siPixelRecHitsHeterogeneousProduct {
     HitsOnCPU() = default;
 
     explicit HitsOnCPU(uint32_t nhits) :
+      detInd(nhits),
       charge(nhits),
       xl(nhits),
       yl(nhits),
@@ -49,6 +50,7 @@ namespace siPixelRecHitsHeterogeneousProduct {
     { }
 
     uint32_t hitsModuleStart[2001];
+    std::vector<int16_t> detInd;
     std::vector<int32_t> charge;
     std::vector<float> xl, yl;
     std::vector<float> xe, ye;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
@@ -132,7 +132,7 @@ void CAHitNtupletHeterogeneousEDProducer::acquireGPUCuda(
         << " regions, and " << regionDoublets.layerPairsSize()
         << " layer pairs";
 
-  GPUGenerator_.hitNtuplets(region, iSetup, cudaStream.id());
+  GPUGenerator_.hitNtuplets(region, gHits, iSetup, cudaStream.id());
   
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
@@ -122,7 +122,7 @@ void CAHitNtupletHeterogeneousEDProducer::acquireGPUCuda(
   auto const & gHits = *gh;
 //  auto nhits = gHits.nHits;
 
-  GPUGenerator_.buildDoublets(gHits,0.06f,cudaStream.id());
+  GPUGenerator_.buildDoublets(gHits,cudaStream.id());
 
   if (regionDoublets.empty()) {
     emptyRegionDoublets = true;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
@@ -145,9 +145,9 @@ void CAHitNtupletHeterogeneousEDProducer::produceGPUCuda(
     iEvent.getByToken(doubletToken_, hdoublets);
     const auto &regionDoublets = *hdoublets;
 
-    edm::Handle<siPixelRecHitsHeterogeneousProduct::CPUProduct> gh;
-    iEvent.getByToken<siPixelRecHitsHeterogeneousProduct::HeterogeneousPixelRecHit>(tGpuHits, gh);
-    auto const & recHits = (*gh).collection;
+    edm::Handle<HeterogeneousProduct> gh;
+    iEvent.getByToken(tGpuHits, gh);
+    auto const & rechits = gh->get<siPixelRecHitsHeterogeneousProduct::HeterogeneousPixelRecHit>().getProduct<HeterogeneousDevice::kCPU>();
 
     std::vector<OrderedHitSeeds> ntuplets(regionDoublets.regionSize());
     for (auto &ntuplet : ntuplets) ntuplet.reserve(localRA_.upper());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
@@ -98,45 +98,42 @@ void CAHitNtupletHeterogeneousEDProducer::beginStreamGPUCuda(
 void CAHitNtupletHeterogeneousEDProducer::acquireGPUCuda(
     const edm::HeterogeneousEvent &iEvent, const edm::EventSetup &iSetup,
     cuda::stream_t<> &cudaStream) {
+
+  seedingHitSets_ = std::make_unique<RegionsSeedingHitSets>();
+
+
+  // FIXME: move directly to region or similar...
   edm::Handle<IntermediateHitDoublets> hdoublets;
   iEvent.getByToken(doubletToken_, hdoublets);
   const auto &regionDoublets = *hdoublets;
+  assert(regionDoublets.regionSize()<=1);
 
-  const SeedingLayerSetsHits &seedingLayerHits =
-      regionDoublets.seedingLayerHits();
-  if (seedingLayerHits.numberOfLayersInSet() <
-      CAHitQuadrupletGeneratorGPU::minLayers) {
-    throw cms::Exception("LogicError")
-        << "CAHitNtupletHeterogeneousEDProducer expects "
-           "SeedingLayerSetsHits::numberOfLayersInSet() to be >= "
-        << CAHitQuadrupletGeneratorGPU::minLayers << ", got "
-        << seedingLayerHits.numberOfLayersInSet()
-        << ". This is likely caused by a configuration error of this module, "
-           "HitPairEDProducer, or SeedingLayersEDProducer.";
+  if (regionDoublets.empty()) {
+    emptyRegionDoublets = true;
+    return;
   }
 
-  seedingHitSets_ = std::make_unique<RegionsSeedingHitSets>();
+  const TrackingRegion &region = (*regionDoublets.begin()).region();
+
 
   edm::Handle<siPixelRecHitsHeterogeneousProduct::GPUProduct> gh;
   iEvent.getByToken<siPixelRecHitsHeterogeneousProduct::HeterogeneousPixelRecHit>(tGpuHits, gh);
   auto const & gHits = *gh;
 //  auto nhits = gHits.nHits;
 
+  // move inside hitNtuplets???
   GPUGenerator_.buildDoublets(gHits,cudaStream.id());
 
-  if (regionDoublets.empty()) {
-    emptyRegionDoublets = true;
-  } else {
-    seedingHitSets_->reserve(regionDoublets.regionSize(), localRA_.upper());
-    GPUGenerator_.initEvent(iEvent.event(), iSetup);
+  seedingHitSets_->reserve(regionDoublets.regionSize(), localRA_.upper());
+  GPUGenerator_.initEvent(iEvent.event(), iSetup);
 
-    LogDebug("CAHitNtupletHeterogeneousEDProducer")
+  LogDebug("CAHitNtupletHeterogeneousEDProducer")
         << "Creating ntuplets for " << regionDoublets.regionSize()
         << " regions, and " << regionDoublets.layerPairsSize()
         << " layer pairs";
 
-    GPUGenerator_.hitNtuplets(regionDoublets, iSetup, seedingLayerHits, cudaStream.id());
-  }
+  GPUGenerator_.hitNtuplets(region, iSetup, cudaStream.id());
+  
 }
 
 void CAHitNtupletHeterogeneousEDProducer::produceGPUCuda(
@@ -147,16 +144,18 @@ void CAHitNtupletHeterogeneousEDProducer::produceGPUCuda(
     edm::Handle<IntermediateHitDoublets> hdoublets;
     iEvent.getByToken(doubletToken_, hdoublets);
     const auto &regionDoublets = *hdoublets;
-    const SeedingLayerSetsHits &seedingLayerHits =
-        regionDoublets.seedingLayerHits();
-    int index = 0;
+
+    edm::Handle<siPixelRecHitsHeterogeneousProduct::CPUProduct> gh;
+    iEvent.getByToken<siPixelRecHitsHeterogeneousProduct::HeterogeneousPixelRecHit>(tGpuHits, gh);
+    auto const & recHits = (*gh).collection;
+
     std::vector<OrderedHitSeeds> ntuplets(regionDoublets.regionSize());
-    for (auto &ntuplet : ntuplets)
-      ntuplet.reserve(localRA_.upper());
+    for (auto &ntuplet : ntuplets) ntuplet.reserve(localRA_.upper());
+    int index = 0;
     for (const auto &regionLayerPairs : regionDoublets) {
       const TrackingRegion &region = regionLayerPairs.region();
       auto seedingHitSetsFiller = seedingHitSets_->beginRegion(&region);
-      GPUGenerator_.fillResults(regionDoublets, ntuplets, iSetup, seedingLayerHits, cudaStream.id());
+      GPUGenerator_.fillResults(region, ntuplets, iSetup, cudaStream.id());
       fillNtuplets(seedingHitSetsFiller, ntuplets[index]);
       ntuplets[index].clear();
       index++;
@@ -188,6 +187,7 @@ void CAHitNtupletHeterogeneousEDProducer::produceCPU(
     iEvent.put(std::move(seedingHitSets));
     return;
   }
+
   seedingHitSets->reserve(regionDoublets.regionSize(), localRA_.upper());
   CPUGenerator_.initEvent(iEvent.event(), iSetup);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletHeterogeneousEDProducer.cc
@@ -155,7 +155,7 @@ void CAHitNtupletHeterogeneousEDProducer::produceGPUCuda(
     for (const auto &regionLayerPairs : regionDoublets) {
       const TrackingRegion &region = regionLayerPairs.region();
       auto seedingHitSetsFiller = seedingHitSets_->beginRegion(&region);
-      GPUGenerator_.fillResults(region, ntuplets, iSetup, cudaStream.id());
+      GPUGenerator_.fillResults(region, rechits.collection, ntuplets, iSetup, cudaStream.id());
       fillNtuplets(seedingHitSetsFiller, ntuplets[index]);
       ntuplets[index].clear();
       index++;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -96,8 +96,9 @@ void CAHitQuadrupletGeneratorGPU::hitNtuplets(
     const edm::EventSetup &es,
     cudaStream_t cudaStream) {
     hitsOnCPU = &hh;
+
     int index = 0;
-    launchKernels(region, index, cudaStream);
+    launchKernels(region, index, hh, cudaStream);
 
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -110,12 +110,19 @@ void CAHitQuadrupletGeneratorGPU::fillResults(
     auto const & rcs = rechits.data();
     for (auto const & h : rcs) hitmap_.add(h,&h);
 
+    assert(hitsOnCPU);
+    auto nhits = hitsOnCPU->nHits;
 
+    std::cout << nhits << " hits on GPU" << std::endl;
+    std::cout << rcs.size() << " hits on CPU" << std::endl;
 
     int index = 0;
 
-      auto foundQuads = fetchKernelResult(index, cudaStream);
+      auto const & foundQuads = fetchKernelResult(index, cudaStream);
       unsigned int numberOfFoundQuadruplets = foundQuads.size();
+     
+      std::cout << "found " << foundQuads.size() << " quadruplets on GPU" << std::endl;
+      
       // const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
 
       // re-used thoughout
@@ -135,6 +142,8 @@ void CAHitQuadrupletGeneratorGPU::fillResults(
         bool bad = false; 
         for (unsigned int i = 0; i < 4; ++i) {
            auto k = foundQuads[quadId][i];
+           if (k>=int(nhits)) std::cout << "BAD INDEX " << k << " at " << quadId <<':'<< i << std::endl;
+           assert(k<int(nhits));
            auto hp = hitmap_.get((*hitsOnCPU).detInd[k],(*hitsOnCPU).mr[k], (*hitsOnCPU).mc[k]);
            if (hp==nullptr) { 
              bad=true;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -90,250 +90,25 @@ CAHitQuadrupletGeneratorGPU::~CAHitQuadrupletGeneratorGPU() {
     deallocateOnGPU();
 }
 
-namespace {
-void createGraphStructure(const SeedingLayerSetsHits &layers, CAGraph &g,
-                          GPULayerHits *h_layers_, unsigned int maxNumberOfHits_,
-                          float *h_x_, float *h_y_, float *h_z_) {
-  for (unsigned int i = 0; i < layers.size(); i++) {
-    for (unsigned int j = 0; j < 4; ++j) {
-      auto vertexIndex = 0;
-      auto foundVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
-                                   layers[i][j].name());
-      if (foundVertex == g.theLayers.end()) {
-        g.theLayers.emplace_back(layers[i][j].name(),
-                                 layers[i][j].hits().size());
-        vertexIndex = g.theLayers.size() - 1;
-
-      } else {
-        vertexIndex = foundVertex - g.theLayers.begin();
-      }
-      if (j == 0) {
-
-        if (std::find(g.theRootLayers.begin(), g.theRootLayers.end(),
-                      vertexIndex) == g.theRootLayers.end()) {
-          g.theRootLayers.emplace_back(vertexIndex);
-        }
-      }
-    }
-  }
-}
-void clearGraphStructure(const SeedingLayerSetsHits &layers, CAGraph &g) {
-  g.theLayerPairs.clear();
-  for (unsigned int i = 0; i < g.theLayers.size(); i++) {
-    g.theLayers[i].theInnerLayers.clear();
-    g.theLayers[i].theInnerLayerPairs.clear();
-    g.theLayers[i].theOuterLayers.clear();
-    g.theLayers[i].theOuterLayerPairs.clear();
-    for (auto &v : g.theLayers[i].isOuterHitOfCell)
-      v.clear();
-  }
-}
-void fillGraph(const SeedingLayerSetsHits &layers,
-               const IntermediateHitDoublets::RegionLayerSets &regionLayerPairs,
-               CAGraph &g, std::vector<const HitDoublets *> &hitDoublets) {
-
-  for (unsigned int i = 0; i < layers.size(); i++) {
-    for (unsigned int j = 0; j < 4; ++j) {
-      auto vertexIndex = 0;
-      auto foundVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
-                                   layers[i][j].name());
-      if (foundVertex == g.theLayers.end()) {
-        vertexIndex = g.theLayers.size() - 1;
-      } else {
-        vertexIndex = foundVertex - g.theLayers.begin();
-      }
-
-      if (j > 0) {
-        auto innerVertex = std::find(g.theLayers.begin(), g.theLayers.end(),
-                                     layers[i][j - 1].name());
-
-        CALayerPair tmpInnerLayerPair(innerVertex - g.theLayers.begin(),
-                                      vertexIndex);
-
-        if (std::find(g.theLayerPairs.begin(), g.theLayerPairs.end(),
-                      tmpInnerLayerPair) == g.theLayerPairs.end()) {
-          auto found = std::find_if(
-              regionLayerPairs.begin(), regionLayerPairs.end(),
-              [&](const IntermediateHitDoublets::LayerPairHitDoublets &pair) {
-                return pair.innerLayerIndex() == layers[i][j - 1].index() &&
-                       pair.outerLayerIndex() == layers[i][j].index();
-              });
-          if (found != regionLayerPairs.end()) {
-            hitDoublets.emplace_back(&(found->doublets()));
-            g.theLayerPairs.push_back(tmpInnerLayerPair);
-            g.theLayers[vertexIndex].theInnerLayers.push_back(
-                innerVertex - g.theLayers.begin());
-            innerVertex->theOuterLayers.push_back(vertexIndex);
-            g.theLayers[vertexIndex].theInnerLayerPairs.push_back(
-                g.theLayerPairs.size() - 1);
-            innerVertex->theOuterLayerPairs.push_back(g.theLayerPairs.size() -
-                                                      1);
-          }
-        }
-      }
-    }
-  }
-
-}
-} // namespace
-
 void CAHitQuadrupletGeneratorGPU::hitNtuplets(
-    const IntermediateHitDoublets &regionDoublets,
+    const TrackingRegion &region,
     const edm::EventSetup &es,
-    const SeedingLayerSetsHits &layers, cudaStream_t cudaStream) {
-  CAGraph g;
+    cudaStream_t cudaStream) {
 
-  hitDoublets.resize(regionDoublets.regionSize());
-
-  for (unsigned int lpIdx = 0; lpIdx < maxNumberOfLayerPairs_; ++lpIdx) {
-    h_doublets_[lpIdx].size = 0;
-  }
-  numberOfRootLayerPairs_ = 0;
-  numberOfLayerPairs_ = 0;
-  numberOfLayers_ = 0;
-
-  for (unsigned int layerIdx = 0; layerIdx < maxNumberOfLayers_; ++layerIdx) {
-    h_layers_[layerIdx].size = 0;
-  }
-
-  int index = 0;
-  for (const auto &regionLayerPairs : regionDoublets) {
-    const TrackingRegion &region = regionLayerPairs.region();
-    hitDoublets[index].clear();
-    if (index == 0) {
-      createGraphStructure(layers, g, h_layers_, maxNumberOfHits_, h_x_, h_y_, h_z_);
-    } else {
-      clearGraphStructure(layers, g);
-    }
-
-    fillGraph(layers, regionLayerPairs, g, hitDoublets[index]);
-    numberOfLayers_ = g.theLayers.size();
-    numberOfLayerPairs_ = hitDoublets[index].size();
-    std::vector<bool> layerAlreadyParsed(g.theLayers.size(), false);
-
-    for (unsigned int i = 0; i < numberOfLayerPairs_; ++i) {
-      h_doublets_[i].size = hitDoublets[index][i]->size();
-      h_doublets_[i].innerLayerId = g.theLayerPairs[i].theLayers[0];
-      h_doublets_[i].outerLayerId = g.theLayerPairs[i].theLayers[1];
-
-      if (layerAlreadyParsed[h_doublets_[i].innerLayerId] == false) {
-        layerAlreadyParsed[h_doublets_[i].innerLayerId] = true;
-        h_layers_[h_doublets_[i].innerLayerId].size =
-            hitDoublets[index][i]->innerLayer().hits().size();
-        h_layers_[h_doublets_[i].innerLayerId].layerId =
-            h_doublets_[i].innerLayerId;
-
-        for (unsigned int l = 0; l < h_layers_[h_doublets_[i].innerLayerId].size;
-             ++l) {
-          auto hitId =
-              h_layers_[h_doublets_[i].innerLayerId].layerId * maxNumberOfHits_ +
-              l;
-          h_x_[hitId] =
-              hitDoublets[index][i]->innerLayer().hits()[l]->globalPosition().x();
-          h_y_[hitId] =
-              hitDoublets[index][i]->innerLayer().hits()[l]->globalPosition().y();
-          h_z_[hitId] =
-              hitDoublets[index][i]->innerLayer().hits()[l]->globalPosition().z();
-        }
-      }
-      if (layerAlreadyParsed[h_doublets_[i].outerLayerId] == false) {
-        layerAlreadyParsed[h_doublets_[i].outerLayerId] = true;
-        h_layers_[h_doublets_[i].outerLayerId].size =
-            hitDoublets[index][i]->outerLayer().hits().size();
-        h_layers_[h_doublets_[i].outerLayerId].layerId =
-            h_doublets_[i].outerLayerId;
-        for (unsigned int l = 0; l < h_layers_[h_doublets_[i].outerLayerId].size;
-             ++l) {
-          auto hitId =
-              h_layers_[h_doublets_[i].outerLayerId].layerId * maxNumberOfHits_ +
-              l;
-          h_x_[hitId] =
-              hitDoublets[index][i]->outerLayer().hits()[l]->globalPosition().x();
-          h_y_[hitId] =
-              hitDoublets[index][i]->outerLayer().hits()[l]->globalPosition().y();
-          h_z_[hitId] =
-              hitDoublets[index][i]->outerLayer().hits()[l]->globalPosition().z();
-        }
-      }
-
-      for (unsigned int rl : g.theRootLayers) {
-        if (rl == h_doublets_[i].innerLayerId) {
-          auto rootlayerPairId = numberOfRootLayerPairs_;
-          h_rootLayerPairs_[rootlayerPairId] = i;
-          numberOfRootLayerPairs_++;
-        }
-      }
-      auto numberOfDoublets = hitDoublets[index][i]->size();
-      if(numberOfDoublets > maxNumberOfDoublets_)
-      {
-          edm::LogError("CAHitQuadrupletGeneratorGPU")<<" too many doublets: " << numberOfDoublets << " max is " <<  maxNumberOfDoublets_;
-          return;
-      }
-      for (unsigned int l = 0; l < numberOfDoublets; ++l) {
-        auto hitId = i * maxNumberOfDoublets_ * 2 + 2 * l;
-        h_indices_[hitId] = hitDoublets[index][i]->innerHitId(l);
-        h_indices_[hitId + 1] = hitDoublets[index][i]->outerHitId(l);
-      }
-    }
-
-
-
-    for (unsigned int j = 0; j < numberOfLayerPairs_; ++j) {
-      tmp_layerDoublets_[j] = h_doublets_[j];
-      tmp_layerDoublets_[j].indices = &d_indices_[j * maxNumberOfDoublets_ * 2];
-      cudaMemcpyAsync(&d_indices_[j * maxNumberOfDoublets_ * 2],
-                      &h_indices_[j * maxNumberOfDoublets_ * 2],
-                      tmp_layerDoublets_[j].size * 2 * sizeof(int),
-                      cudaMemcpyHostToDevice, cudaStream);
-    }
-
-    for (unsigned int j = 0; j < numberOfLayers_; ++j) {
-        if(h_layers_[j].size > maxNumberOfHits_)
-        {
-            edm::LogError("CAHitQuadrupletGeneratorGPU")<<" too many hits: " << h_layers_[j].size << " max is " << maxNumberOfHits_;
-            return;
-        }
-      tmp_layers_[j] = h_layers_[j];
-      tmp_layers_[j].x = &d_x_[maxNumberOfHits_ * j];
-
-      cudaMemcpyAsync(&d_x_[maxNumberOfHits_ * j], &h_x_[j * maxNumberOfHits_],
-                      tmp_layers_[j].size * sizeof(float),
-                      cudaMemcpyHostToDevice, cudaStream);
-
-      tmp_layers_[j].y = &d_y_[maxNumberOfHits_ * j];
-      cudaMemcpyAsync(&d_y_[maxNumberOfHits_ * j], &h_y_[j * maxNumberOfHits_],
-                      tmp_layers_[j].size * sizeof(float),
-                      cudaMemcpyHostToDevice, cudaStream);
-
-      tmp_layers_[j].z = &d_z_[maxNumberOfHits_ * j];
-
-      cudaMemcpyAsync(&d_z_[maxNumberOfHits_ * j], &h_z_[j * maxNumberOfHits_],
-                      tmp_layers_[j].size * sizeof(float),
-                      cudaMemcpyHostToDevice, cudaStream);
-    }
-
-    cudaMemcpyAsync(d_rootLayerPairs_, h_rootLayerPairs_,
-                    numberOfRootLayerPairs_ * sizeof(unsigned int),
-                    cudaMemcpyHostToDevice, cudaStream);
-    cudaMemcpyAsync(d_doublets_, tmp_layerDoublets_,
-                    numberOfLayerPairs_ * sizeof(GPULayerDoublets),
-                    cudaMemcpyHostToDevice, cudaStream);
-    cudaMemcpyAsync(d_layers_, tmp_layers_, numberOfLayers_ * sizeof(GPULayerHits),
-                    cudaMemcpyHostToDevice, cudaStream);
-
+    int index = 0;
     launchKernels(region, index, cudaStream);
-  }
+
 }
 
 void CAHitQuadrupletGeneratorGPU::fillResults(
-    const IntermediateHitDoublets &regionDoublets,
+    const TrackingRegion &region,
     std::vector<OrderedHitSeeds> &result, const edm::EventSetup &es,
-    const SeedingLayerSetsHits &layers, cudaStream_t cudaStream)
+    cudaStream_t cudaStream)
 {
+
+ /*
     int index = 0;
 
-    for (const auto &regionLayerPairs : regionDoublets) {
-      const TrackingRegion &region = regionLayerPairs.region();
       auto foundQuads = fetchKernelResult(index, cudaStream);
       unsigned int numberOfFoundQuadruplets = foundQuads.size();
       const QuantityDependsPtEval maxChi2Eval = maxChi2.evaluator(es);
@@ -440,6 +215,5 @@ void CAHitQuadrupletGeneratorGPU::fillResults(
             hitDoublets[index][foundQuads[quadId][2].first]->hit(
                 foundQuads[quadId][2].second, HitDoublets::outer));
       }
-      index++;
-  }
+  */
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -214,5 +214,5 @@ void CAHitQuadrupletGeneratorGPU::fillResults(
         result[index].emplace_back(phits[0],phits[1],phits[2],phits[3]);
 
       } // end loop over quads
-
+      std::cout << "final quads " << result[index].size() << std::endl;
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -101,10 +101,14 @@ void CAHitQuadrupletGeneratorGPU::hitNtuplets(
 }
 
 void CAHitQuadrupletGeneratorGPU::fillResults(
-    const TrackingRegion &region,
+    const TrackingRegion &region, SiPixelRecHitCollectionNew const & rechits,
     std::vector<OrderedHitSeeds> &result, const edm::EventSetup &es,
     cudaStream_t cudaStream)
 {
+    hitmap_.clear(); 
+    auto const & rcs = rechits.data();
+    for (auto const & h : rcs) hitmap_.add(h,&h);
+
 
  /*
     int index = 0;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -49,7 +49,7 @@ __global__ void kernel_find_ntuplets(
   GPU::VecArray<unsigned int, 3> stack;
   thisCell.find_ntuplets(cells, foundNtuplets, stack, minHitsPerNtuplet);
 
-  printf("in %d found quadruplets: %d\n", cellIndex, foundNtuplets->size());
+  // printf("in %d found quadruplets: %d\n", cellIndex, foundNtuplets->size());
 }
 
 template <int maxNumberOfDoublets_>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -5,6 +5,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "CAHitQuadrupletGeneratorGPU.h"
 #include "GPUCACell.h"
+#include "gpuPixelDoublets.h"
 
 __global__ void
 kernel_connect(GPUCACell *cells, uint32_t const * nCells,
@@ -37,7 +38,7 @@ kernel_connect(GPUCACell *cells, uint32_t const * nCells,
 __global__ void kernel_find_ntuplets(
     GPUCACell *cells, uint32_t const * nCells,
     GPU::SimpleVector<Quadruplet> *foundNtuplets,
-    unsigned int *rootLayerPairs, unsigned int minHitsPerNtuplet,
+    unsigned int minHitsPerNtuplet,
     unsigned int maxNumberOfDoublets_)
 {
 
@@ -48,30 +49,25 @@ __global__ void kernel_find_ntuplets(
   GPU::VecArray<unsigned int, 3> stack;
   thisCell.find_ntuplets(cells, foundNtuplets, stack, minHitsPerNtuplet);
 
-  printf("in %d found quadruplets: %d", cellIndex, foundNtuplets->size());
+  printf("in %d found quadruplets: %d\n", cellIndex, foundNtuplets->size());
 }
 
 template <int maxNumberOfDoublets_>
 __global__ void
 kernel_print_found_ntuplets(GPU::SimpleVector<Quadruplet> *foundNtuplets) {
   for (int i = 0; i < foundNtuplets->size(); ++i) {
-    printf("\nquadruplet %d: %d %d, %d %d, %d %d\n", i,
+    printf("\nquadruplet %d: %d %d %d %d\n", i,
            (*foundNtuplets)[i].hitId[0],
            (*foundNtuplets)[i].hitId[1],
            (*foundNtuplets)[i].hitId[2],
-           (*foundNtuplets)[i].hitId[3],
-
+           (*foundNtuplets)[i].hitId[3]
+          );
+         
   }
 }
 
 void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
 {
-  cudaFreeHost(h_indices_);
-  cudaFreeHost(h_doublets_);
-  cudaFreeHost(h_x_);
-  cudaFreeHost(h_y_);
-  cudaFreeHost(h_z_);
-  cudaFreeHost(h_rootLayerPairs_);
   for (size_t i = 0; i < h_foundNtupletsVec_.size(); ++i)
   {
     cudaFreeHost(h_foundNtupletsVec_[i]);
@@ -79,17 +75,7 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
     cudaFree(d_foundNtupletsVec_[i]);
     cudaFree(d_foundNtupletsData_[i]);
   }
-  cudaFreeHost(tmp_layers_);
-  cudaFreeHost(tmp_layerDoublets_);
-  cudaFreeHost(h_layers_);
 
-  cudaFree(d_indices_);
-  cudaFree(d_doublets_);
-  cudaFree(d_layers_);
-  cudaFree(d_x_);
-  cudaFree(d_y_);
-  cudaFree(d_z_);
-  cudaFree(d_rootLayerPairs_);
   cudaFree(device_theCells_);
   cudaFree(device_isOuterHitOfCell_);
   cudaFree(device_nCells_);
@@ -97,21 +83,6 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
 
 void CAHitQuadrupletGeneratorGPU::allocateOnGPU()
 {
-  cudaCheck(cudaMallocHost(&h_doublets_, maxNumberOfLayerPairs_ * sizeof(GPULayerDoublets)));
-  cudaCheck(cudaMallocHost(&h_indices_, maxNumberOfLayerPairs_ * maxNumberOfDoublets_ * 2 * sizeof(int)));
-  cudaCheck(cudaMallocHost(&h_x_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMallocHost(&h_y_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMallocHost(&h_z_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMallocHost(&h_rootLayerPairs_, maxNumberOfRootLayerPairs_ * sizeof(int)));
-
-  cudaCheck(cudaMalloc(&d_indices_, maxNumberOfLayerPairs_ * maxNumberOfDoublets_ * 2 * sizeof(int)));
-  cudaCheck(cudaMalloc(&d_doublets_, maxNumberOfLayerPairs_ * sizeof(GPULayerDoublets)));
-  cudaCheck(cudaMalloc(&d_layers_, maxNumberOfLayers_ * sizeof(GPULayerHits)));
-  cudaCheck(cudaMalloc(&d_x_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&d_y_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&d_z_, maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(float)));
-  cudaCheck(cudaMalloc(&d_rootLayerPairs_, maxNumberOfRootLayerPairs_ * sizeof(unsigned int)));
-
   //////////////////////////////////////////////////////////
   // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)
   //////////////////////////////////////////////////////////
@@ -142,26 +113,13 @@ void CAHitQuadrupletGeneratorGPU::allocateOnGPU()
     cudaCheck(cudaMemcpy(d_foundNtupletsVec_[i], & tmp_foundNtuplets, sizeof(GPU::SimpleVector<Quadruplet>), cudaMemcpyDefault));
   }
 
-  cudaCheck(cudaMallocHost(&tmp_layers_, maxNumberOfLayers_ * sizeof(GPULayerHits)));
-  cudaCheck(cudaMallocHost(&tmp_layerDoublets_,maxNumberOfLayerPairs_ * sizeof(GPULayerDoublets)));
-  cudaCheck(cudaMallocHost(&h_layers_, maxNumberOfLayers_ * sizeof(GPULayerHits)));
 }
 
 void CAHitQuadrupletGeneratorGPU::launchKernels(const TrackingRegion &region,
                                                 int regionIndex, cudaStream_t cudaStream)
 {
   assert(regionIndex < maxNumberOfRegions_);
-  dim3 numberOfBlocks_create(64, numberOfLayerPairs_);
-//  dim3 numberOfBlocks_connect(32, numberOfLayerPairs_);
-  dim3 numberOfBlocks_find(16, numberOfRootLayerPairs_);
   h_foundNtupletsVec_[regionIndex]->reset();
-  /*
-  kernel_create<<<numberOfBlocks_create, 32, 0, cudaStream>>>(
-      numberOfLayerPairs_, d_doublets_, d_layers_, device_theCells_,
-      device_isOuterHitOfCell_, d_foundNtupletsVec_[regionIndex],
-      region.origin().x(), region.origin().y(), maxNumberOfDoublets_,
-      maxNumberOfHits_);
-  */
 
   auto numberOfBlocks = (maxNumberOfDoublets_ + 512 - 1)/512;
   kernel_connect<<<numberOfBlocks, 512, 0, cudaStream>>>(
@@ -175,7 +133,7 @@ void CAHitQuadrupletGeneratorGPU::launchKernels(const TrackingRegion &region,
   kernel_find_ntuplets<<<numberOfBlocks, 512, 0, cudaStream>>>(
       device_theCells_, device_nCells_,
       d_foundNtupletsVec_[regionIndex],
-      d_rootLayerPairs_, 4, maxNumberOfDoublets_);
+      4, maxNumberOfDoublets_);
 
   cudaCheck(cudaMemcpyAsync(h_foundNtupletsVec_[regionIndex], d_foundNtupletsVec_[regionIndex],
                             sizeof(GPU::SimpleVector<Quadruplet>),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -496,7 +496,7 @@ void CAHitQuadrupletGeneratorGPU::buildDoublets(HitsOnCPU const & hh, float phic
 
   float phiCut=0.06;
   int threadsPerBlock = 256;
-  int blocks = (nhits + threadsPerBlock - 1) / threadsPerBlock;
+  int blocks = (3*nhits + threadsPerBlock - 1) / threadsPerBlock;
 
   gpuPixelDoublets::getDoubletsFromHisto<<<blocks, threadsPerBlock, 0, stream>>>(hh.gpu_d,phiCut);
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -10,7 +10,7 @@
 __global__ void
 kernel_connect(GPU::SimpleVector<Quadruplet> *foundNtuplets,
                GPUCACell *cells, uint32_t const * nCells,
-               GPU::VecArray< unsigned int, 512> *isOuterHitOfCell,
+               GPU::VecArray< unsigned int, 2048> *isOuterHitOfCell,
                float ptmin, 
                float region_origin_radius, const float thetaCut,
                const float phiCut, const float hardPtCut,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -381,6 +381,7 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU()
   cudaFree(d_rootLayerPairs_);
   cudaFree(device_theCells_);
   cudaFree(device_isOuterHitOfCell_);
+  cudaFree(device_nCells_);
 }
 
 void CAHitQuadrupletGeneratorGPU::allocateOnGPU()
@@ -406,6 +407,7 @@ void CAHitQuadrupletGeneratorGPU::allocateOnGPU()
 
   cudaCheck(cudaMalloc(&device_theCells_,
              maxNumberOfLayerPairs_ * maxNumberOfDoublets_ * sizeof(GPUCACell)));
+  cudaCheck(cudaMalloc(&device_nCells_,sizeof(uint32_t)));
 
   cudaCheck(cudaMalloc(&device_isOuterHitOfCell_,
              maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(GPU::VecArray<unsigned int, maxCellsPerHit_>)));
@@ -498,5 +500,6 @@ void CAHitQuadrupletGeneratorGPU::buildDoublets(HitsOnCPU const & hh, float phic
   int threadsPerBlock = 256;
   int blocks = (3*nhits + threadsPerBlock - 1) / threadsPerBlock;
 
-  gpuPixelDoublets::getDoubletsFromHisto<<<blocks, threadsPerBlock, 0, stream>>>(hh.gpu_d,phiCut);
+  cudaCheck(cudaMemset(device_nCells_,0,sizeof(uint32_t)));
+  gpuPixelDoublets::getDoubletsFromHisto<<<blocks, threadsPerBlock, 0, stream>>>(device_theCells_,device_nCells_,hh.gpu_d,phiCut);
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -137,7 +137,7 @@ private:
     };
 
     void  launchKernels(const TrackingRegion &, int, cudaStream_t);
-    std::vector<std::array<std::pair<int,int> ,3>> fetchKernelResult(int, cudaStream_t);
+    std::vector<std::array<int,4>> fetchKernelResult(int, cudaStream_t);
     const float extraHitRPhitolerance;
     std::vector<std::vector<const HitDoublets *>> hitDoublets;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -20,10 +20,8 @@
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 
 #include "GPUCACell.h"
-#include "GPUHitsAndDoublets.h"
 
 class TrackingRegion;
-class SeedingLayerSetsHits;
 
 namespace edm {
     class Event;
@@ -36,8 +34,6 @@ public:
 
     using HitsOnGPU = siPixelRecHitsHeterogeneousProduct::HitsOnGPU;
     using HitsOnCPU = siPixelRecHitsHeterogeneousProduct::HitsOnCPU;
-
-    typedef LayerHitMapCache LayerCacheType;
 
     static constexpr unsigned int minLayers = 4;
     typedef OrderedHitSeeds ResultType;
@@ -56,19 +52,19 @@ public:
 
     void buildDoublets(HitsOnCPU const & hh, cudaStream_t stream);
 
-    void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
+    void hitNtuplets(const TrackingRegion &region,
                      const edm::EventSetup& es,
-                     const SeedingLayerSetsHits& layers, cudaStream_t stream);
-    void fillResults(const IntermediateHitDoublets& regionDoublets,
+                     cudaStream_t stream);
+    void fillResults(const TrackingRegion &region,
                      std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
-                     const SeedingLayerSetsHits& layers, cudaStream_t stream);
+                     cudaStream_t stream);
 
     void allocateOnGPU();
     void deallocateOnGPU();
 
 private:
-    LayerCacheType theLayerCache;
+//    LayerCacheType theLayerCache;
 
     std::unique_ptr<SeedComparitor> theComparitor;
 
@@ -139,7 +135,6 @@ private:
     void  launchKernels(const TrackingRegion &, int, cudaStream_t);
     std::vector<std::array<int,4>> fetchKernelResult(int, cudaStream_t);
     const float extraHitRPhitolerance;
-    std::vector<std::vector<const HitDoublets *>> hitDoublets;
 
     const QuantityDependsPt maxChi2;
     const bool fitFastCircle;
@@ -166,14 +161,6 @@ private:
     GPULayerDoublets* h_doublets_ = nullptr;
     GPULayerHits* h_layers_ = nullptr;
 
-    unsigned int* h_indices_ = nullptr;
-    float *h_x_=nullptr, *h_y_=nullptr, *h_z_=nullptr;
-    float *d_x_=nullptr, *d_y_=nullptr, *d_z_=nullptr;
-    unsigned int* d_rootLayerPairs_ = nullptr;
-    GPULayerHits* d_layers_ = nullptr;
-    GPULayerDoublets* d_doublets_ = nullptr;
-    unsigned int* d_indices_ = nullptr;
-    unsigned int* h_rootLayerPairs_ = nullptr;
     std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;
     std::vector<Quadruplet*> h_foundNtupletsData_;
 
@@ -185,7 +172,6 @@ private:
     uint32_t* device_nCells_ = nullptr;
 
     GPULayerHits* tmp_layers_ = nullptr;
-    GPULayerDoublets* tmp_layerDoublets_ = nullptr;
 };
 
 #endif // RecoPixelVertexing_PixelTriplets_plugins_CAHitQuadrupletGeneratorGPU_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -54,7 +54,7 @@ public:
 
     void initEvent(const edm::Event& ev, const edm::EventSetup& es);
 
-    void buildDoublets(HitsOnCPU const & hh, float phicut, cudaStream_t stream);
+    void buildDoublets(HitsOnCPU const & hh, cudaStream_t stream);
 
     void hitNtuplets(const IntermediateHitDoublets& regionDoublets,
                      const edm::EventSetup& es,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -182,6 +182,7 @@ private:
 
     GPUCACell* device_theCells_ = nullptr;
     GPU::VecArray< unsigned int, maxCellsPerHit_>* device_isOuterHitOfCell_ = nullptr;
+    uint32_t* device_nCells_ = nullptr;
 
     GPULayerHits* tmp_layers_ = nullptr;
     GPULayerDoublets* tmp_layerDoublets_ = nullptr;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -149,14 +149,13 @@ private:
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
 
-    static constexpr int maxNumberOfQuadruplets_ = 10000;
+    static constexpr int maxNumberOfQuadruplets_ = 50000;
     static constexpr int maxCellsPerHit_ = 512;
     static constexpr int maxNumberOfLayerPairs_ = 13;
-    static constexpr unsigned int maxNumberOfRootLayerPairs_ = 13;
     static constexpr int maxNumberOfLayers_ = 10;
     static constexpr int maxNumberOfDoublets_ = 262144;
     static constexpr int maxNumberOfHits_ = 10000;
-    static constexpr int maxNumberOfRegions_ = 30;
+    static constexpr int maxNumberOfRegions_ = 2;
 
 
     std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -18,6 +18,8 @@
 #include "RecoTracker/TkSeedGenerator/interface/FastCircleFit.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
+#include "RecoPixelVertexing/PixelTriplets/plugins/RecHitsMap.h"
+
 
 #include "GPUCACell.h"
 
@@ -55,7 +57,7 @@ public:
     void hitNtuplets(const TrackingRegion &region,
                      const edm::EventSetup& es,
                      cudaStream_t stream);
-    void fillResults(const TrackingRegion &region,
+    void fillResults(const TrackingRegion &region, SiPixelRecHitCollectionNew const & rechits,
                      std::vector<OrderedHitSeeds>& result,
                      const edm::EventSetup& es,
                      cudaStream_t stream);
@@ -134,6 +136,8 @@ private:
 
     void  launchKernels(const TrackingRegion &, int, cudaStream_t);
     std::vector<std::array<int,4>> fetchKernelResult(int, cudaStream_t);
+
+
     const float extraHitRPhitolerance;
 
     const QuantityDependsPt maxChi2;
@@ -154,12 +158,6 @@ private:
     static constexpr int maxNumberOfHits_ = 10000;
     static constexpr int maxNumberOfRegions_ = 30;
 
-    unsigned int numberOfRootLayerPairs_ = 0;
-    unsigned int numberOfLayerPairs_ = 0;
-    unsigned int numberOfLayers_ = 0;
-
-    GPULayerDoublets* h_doublets_ = nullptr;
-    GPULayerHits* h_layers_ = nullptr;
 
     std::vector<GPU::SimpleVector<Quadruplet>*> h_foundNtupletsVec_;
     std::vector<Quadruplet*> h_foundNtupletsData_;
@@ -171,7 +169,8 @@ private:
     GPU::VecArray< unsigned int, maxCellsPerHit_>* device_isOuterHitOfCell_ = nullptr;
     uint32_t* device_nCells_ = nullptr;
 
-    GPULayerHits* tmp_layers_ = nullptr;
+    RecHitsMap<TrackingRecHit const *> hitmap_ = RecHitsMap<TrackingRecHit const *>(nullptr);
+
 };
 
 #endif // RecoPixelVertexing_PixelTriplets_plugins_CAHitQuadrupletGeneratorGPU_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -54,7 +54,7 @@ public:
 
     void buildDoublets(HitsOnCPU const & hh, cudaStream_t stream);
 
-    void hitNtuplets(const TrackingRegion &region,
+    void hitNtuplets(const TrackingRegion &region, HitsOnCPU const & hh,
                      const edm::EventSetup& es,
                      cudaStream_t stream);
     void fillResults(const TrackingRegion &region, SiPixelRecHitCollectionNew const & rechits,
@@ -168,6 +168,8 @@ private:
     GPUCACell* device_theCells_ = nullptr;
     GPU::VecArray< unsigned int, maxCellsPerHit_>* device_isOuterHitOfCell_ = nullptr;
     uint32_t* device_nCells_ = nullptr;
+
+    HitsOnCPU const * hitsOnCPU=nullptr;
 
     RecHitsMap<TrackingRecHit const *> hitmap_ = RecHitsMap<TrackingRecHit const *>(nullptr);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -150,11 +150,11 @@ private:
     const float caHardPtCut = 0.f;
 
     static constexpr int maxNumberOfQuadruplets_ = 50000;
-    static constexpr int maxCellsPerHit_ = 512;
+    static constexpr int maxCellsPerHit_ = 2048; // 512;
     static constexpr int maxNumberOfLayerPairs_ = 13;
     static constexpr int maxNumberOfLayers_ = 10;
     static constexpr int maxNumberOfDoublets_ = 262144;
-    static constexpr int maxNumberOfHits_ = 10000;
+    static constexpr int maxNumberOfHits_ = 20000;
     static constexpr int maxNumberOfRegions_ = 2;
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -134,7 +134,7 @@ private:
         const bool enabled_;
     };
 
-    void  launchKernels(const TrackingRegion &, int, cudaStream_t);
+    void  launchKernels(const TrackingRegion &, int, HitsOnCPU const & hh, cudaStream_t);
     std::vector<std::array<int,4>> fetchKernelResult(int, cudaStream_t);
 
 
@@ -149,7 +149,7 @@ private:
     const float caPhiCut = 0.1f;
     const float caHardPtCut = 0.f;
 
-    static constexpr int maxNumberOfQuadruplets_ = 50000;
+    static constexpr int maxNumberOfQuadruplets_ = 10000;
     static constexpr int maxCellsPerHit_ = 2048; // 512;
     static constexpr int maxNumberOfLayerPairs_ = 13;
     static constexpr int maxNumberOfLayers_ = 10;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -5,6 +5,7 @@
 #define GPU_CACELL_H_
 
 #include "GPUHitsAndDoublets.h"
+#include "RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 #include <cuda.h>
@@ -15,6 +16,29 @@ struct Quadruplet {
 class GPUCACell {
 public:
   __host__ __device__  GPUCACell() {}
+
+
+__host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp,
+                              int layerPairId, int doubletId, int innerHitId,int outerHitId) {
+    auto const & hh = *hhp;
+    theInnerHitId = innerHitId;
+    theOuterHitId = outerHitId;
+    theDoubletId = doubletId;
+    theLayerPairId = layerPairId;
+    theInnerX = hh.xg_d[innerHitId];
+    theOuterX = hh.xg_d[outerHitId];
+
+    theInnerY = hh.yg_d[innerHitId];
+    theOuterY = hh.yg_d[outerHitId];
+
+    theInnerZ = hh.zg_d[innerHitId];
+    theOuterZ = hh.zg_d[outerHitId];
+    theInnerR = hh.rg_d[innerHitId];
+    theOuterR = hh.rg_d[outerHitId];
+    theOuterNeighbors.reset();
+  }
+
+
 
   __host__ __device__ void init(const GPULayerDoublets *doublets,
                                 const GPULayerHits *hitsOnLayer,

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -18,9 +18,8 @@ public:
   __host__ __device__  GPUCACell() {}
 
 
-__host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp,
+__host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU const & hh,
                               int layerPairId, int doubletId, int innerHitId,int outerHitId) {
-    auto const & hh = *hhp;
     theInnerHitId = innerHitId;
     theOuterHitId = outerHitId;
     theDoubletId = doubletId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -9,9 +9,6 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 #include <cuda.h>
-struct QuadrupletOnCPU {
-  int2 layerPairsAndCellId[3];
-};
 
 struct Quadruplet {
   int hitId[4];
@@ -43,32 +40,6 @@ __host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU cons
   }
 
 
-
-  __host__ __device__ void init(const GPULayerDoublets *doublets,
-                                const GPULayerHits *hitsOnLayer,
-                                int layerPairId, int doubletId, int innerHitId,
-                                int outerHitId, float regionX, float regionY) {
-
-    theInnerHitId = innerHitId;
-    theOuterHitId = outerHitId;
-    theDoubletId = doubletId;
-    theLayerPairId = layerPairId;
-
-    auto innerLayerId = doublets->innerLayerId;
-    auto outerLayerId = doublets->outerLayerId;
-
-    theInnerX = hitsOnLayer[innerLayerId].x[innerHitId];
-    theOuterX = hitsOnLayer[outerLayerId].x[outerHitId];
-
-    theInnerY = hitsOnLayer[innerLayerId].y[innerHitId];
-    theOuterY = hitsOnLayer[outerLayerId].y[outerHitId];
-
-    theInnerZ = hitsOnLayer[innerLayerId].z[innerHitId];
-    theOuterZ = hitsOnLayer[outerLayerId].z[outerHitId];
-    theInnerR = hypot(theInnerX - regionX, theInnerY - regionY);
-    theOuterR = hypot(theOuterX - regionX, theOuterY - regionY);
-    theOuterNeighbors.reset();
-  }
 
   constexpr float get_inner_x() const { return theInnerX; }
   constexpr float get_outer_x() const { return theOuterX; }
@@ -251,36 +222,8 @@ __host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU cons
   }
 
 #endif
-  template <int maxNumberOfQuadruplets>
-  __host__ inline void find_ntuplets_host(
-      const GPUCACell *cells,
-      GPU::VecArray<QuadrupletOnCPU, maxNumberOfQuadruplets> *foundNtuplets,
-      GPU::VecArray<unsigned int, 3> &tmpNtuplet,
-      const unsigned int minHitsPerNtuplet) const {
 
-    QuadrupletOnCPU tmpQuadruplet;
-    if (tmpNtuplet.size() >= minHitsPerNtuplet - 1) {
-      for (int i = 0; i < minHitsPerNtuplet - 1; ++i) {
-        tmpQuadruplet.layerPairsAndCellId[i].x =
-            cells[tmpNtuplet[i]].theLayerPairId;
 
-        tmpQuadruplet.layerPairsAndCellId[i].y = tmpNtuplet[i];
-      }
-      foundNtuplets->push_back(tmpQuadruplet);
-
-    }
-
-    else {
-      for (int j = 0; j < theOuterNeighbors.size(); ++j) {
-        auto otherCell = theOuterNeighbors[j];
-        tmpNtuplet.push_back_unsafe(otherCell);
-        cells[otherCell].find_ntuplets_host(cells, foundNtuplets, tmpNtuplet,
-                                            minHitsPerNtuplet);
-
-        tmpNtuplet.pop_back();
-      }
-    }
-  }
   GPU::VecArray< unsigned int, 40> theOuterNeighbors;
 
   int theDoubletId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -26,6 +26,7 @@ __host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU cons
     theOuterHitId = outerHitId;
     theDoubletId = doubletId;
     theLayerPairId = layerPairId;
+
     theInnerX = hh.xg_d[innerHitId];
     theOuterX = hh.xg_d[outerHitId];
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -201,6 +201,7 @@ __host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU cons
     // than a threshold
 
     tmpNtuplet.push_back_unsafe(theInnerHitId);
+    assert(tmpNtuplet.size()<=3);
 
     if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet-1) {
       Quadruplet tmpQuadruplet;
@@ -218,7 +219,7 @@ __host__ __device__ void init(siPixelRecHitsHeterogeneousProduct::HitsOnGPU cons
       }
     }
     tmpNtuplet.pop_back();
-
+    assert(tmpNtuplet.size()<3);
   }
 
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/RecHitsMap.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/RecHitsMap.h
@@ -1,0 +1,77 @@
+#ifndef RecHitsMap_H
+#define RecHitsMap_H
+  // store T for each cluster...
+
+#include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
+#include <cstdint>
+#include <unordered_map>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
+//FIXME move it to a better place...
+template<typename T>
+class RecHitsMap {
+public: 
+
+     explicit RecHitsMap(T const & d=T()) : dummy(d){}
+
+     void clear() {m_map.clear();}
+
+     void error(const GeomDetUnit& gd) const {edm::LogError("RecHitMap") << "hit not found in det " << gd.index();  }
+     void error(uint32_t ind) const {edm::LogError("RecHitMap") << "hit not found in det " << ind;  }
+
+     // does not work for matched hits... (easy to extend)
+     void add(TrackingRecHit const & hit, T const & v) {
+       auto const & thit = static_cast<BaseTrackerRecHit const&>(hit);
+       auto const & clus = thit.firstClusterRef();
+
+       if (clus.isPixel()) 
+          add(clus.pixelCluster(), *thit.detUnit(),v);
+       else
+          add(clus.stripCluster(), *thit.detUnit(),v);
+     }
+
+     template<typename Cluster>
+     void add(const Cluster& cluster, const GeomDetUnit& gd, T const & v) { m_map[encode(cluster,gd)] = v; }
+
+     template<typename Cluster>
+     T const & get(const Cluster& cluster, const GeomDetUnit& gd) const {
+       auto p = m_map.find(encode(cluster,gd));
+       if (p!=m_map.end()) { return (*p).second; }
+       error(gd);
+       return dummy;
+     }
+
+     T const & get(uint32_t ind, uint16_t mr, uint16_t mc) const {
+       auto p = m_map.find(encode(ind,mr,mc));
+       if (p!=m_map.end()) { return (*p).second; }
+       error(ind);
+       return dummy;
+     }
+
+     static uint64_t encode(uint32_t ind, uint16_t mr, uint16_t mc) {
+          uint64_t u1 = ind;                            
+          uint64_t u2 = mr;
+          uint64_t u3 = mc;
+          return (u1<<32) | (u2<<16) | u3;
+     }
+
+     static uint64_t encode(const SiPixelCluster& cluster, const GeomDetUnit& det) {
+          uint64_t u1 = det.index();
+          uint64_t u2 = cluster.minPixelRow();
+          uint64_t u3 = cluster.minPixelCol();
+          return (u1<<32) | (u2<<16) | u3;
+     }
+     static uint64_t encode(const SiStripCluster& cluster, const GeomDetUnit& det) {
+          uint64_t u1 = det.index();
+          uint64_t u2 = cluster.firstStrip();
+       	  return (u1<<32) | u2;
+     }
+
+
+     std::unordered_map<uint64_t, T > m_map;
+     T dummy;
+  };
+
+#endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -11,107 +11,17 @@
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h"
 
+#include "GPUCACell.h"
+
 namespace gpuPixelDoublets {
 
-  __device__
-  std::pair<int,int>
-  findPhiLimits(int16_t phiMe, int16_t * iphi, uint16_t * index, uint16_t size, int16_t iphicut) {
-
-  assert(iphicut>0);
-
-  // find extreemes in top
-  int16_t minPhi = phiMe-iphicut;
-  int16_t maxPhi = phiMe+iphicut;
-
-  // std::cout << "\n phi min/max " << phiMe << ' ' << minPhi << ' ' << maxPhi << std::endl;
-
-  // guess and adjust
-  auto findLimit = [&](int16_t mPhi) {
-    int jm = float(0.5f*size)*(1.f+float(mPhi)/float(std::numeric_limits<short>::max()));
-    // std::cout << "jm for " << mPhi << ' ' << jm << std::endl;
-    jm = std::min(size-1,std::max(0,jm));
-    bool notDone=true;
-    while(jm>0 && mPhi<iphi[index[--jm]]){notDone=false;}
-    if (notDone) while(jm<size && mPhi>iphi[index[++jm]]){}
-    jm = std::min(size-1,std::max(0,jm));
-    return jm;
-  };
-
-  auto jmin = findLimit(minPhi);
-  auto jmax = findLimit(maxPhi);
-
-
-  /*
-  std::cout << "j min/max " << jmin << ' ' << jmax << std::endl;
-  std::cout << "found min/max " << iphi[index[jmin]] << ' ' << iphi[index[jmax]] << std::endl;
-  std::cout << "found min/max +1 " << iphi[index[jmin+1]] << ' ' << iphi[index[jmax+1]] << std::endl;
-  std::cout << "found min/max -1 " << iphi[index[jmin-1]] << ' ' << iphi[index[jmax-1]] << std::endl;
-  */
-
-  return std::make_pair(jmin,jmax);
-  }
-
-
-  __global__
-  void getDoubletsFromSorted(int16_t * iphi, uint16_t * index, uint32_t * offsets, float phiCut) {
-    auto iphicut = phi2short(phiCut);
-    auto i = blockIdx.x*blockDim.x + threadIdx.x;
-    if (i>=offsets[9]) {
-      // get rid of last layer
-      return;
-    }
-
-    assert(0==offsets[0]);
-    int top = (i>offsets[5]) ? 5: 0;
-    while (i>=offsets[++top]){};
-    assert(top<10);
-    auto bottom = top-1;
-    if (bottom == 3 or bottom == 6) {
-      // do not have UP... (9 we got rid already)
-      return;
-    }
-    assert(i >= offsets[bottom]);
-    assert(i < offsets[top]);
-
-    if (index[i]>= (offsets[top]-offsets[bottom])) {
-      printf("index problem: %d %d %d %d %d\n",i, offsets[top], offsets[bottom], offsets[top]-offsets[bottom], index[i]);
-      return;
-    }
-
-    assert(index[i]<offsets[top]-offsets[bottom]);
-
-    int16_t phiMe = iphi[offsets[bottom]+index[i]];
-
-    auto size = offsets[top+1] - offsets[top];
-    assert(size<std::numeric_limits<uint16_t>::max());
-
-    auto jLimits = findPhiLimits(phiMe, iphi+offsets[top],index+offsets[top],size,iphicut);
-
-    auto slidingWindow = [&](uint16_t mysize, uint16_t mymin,uint16_t mymax) {
-      auto topPhi = iphi+offsets[top];
-      uint16_t imax =  std::numeric_limits<uint16_t>::max();
-      uint16_t offset = (mymin>mymax) ? imax-(mysize-1) : 0;
-      int n=0;
-      for (uint16_t i = mymin+offset; i!=mymax; i++) {
-        assert(i<=imax);
-        uint16_t k = (i>mymax) ? i-offset : i;
-        assert(k<mysize);
-        assert(k>=mymin || k<mymax);
-        if (int16_t(topPhi[k]-phiMe)>2*iphicut && int16_t(phiMe-topPhi[k])>2*iphicut)
-          printf("deltaPhi problem: %d %d %d %d, deltas %d:%d cut %d\n",i,k,phiMe,topPhi[k],int16_t(topPhi[k]-phiMe),int16_t(phiMe-topPhi[k]),iphicut);
-        n++;
-      }
-      int tot = (mymin>mymax) ? (mysize-mymin)+mymax : mymax-mymin;
-      assert(n==tot);
-    };
-
-    slidingWindow(size,jLimits.first,jLimits.second);
-  }
+  constexpr uint32_t MaxNumOfDoublets = 1024*1024*256;
 
   template<typename Hist>
   __device__
-  void doubletsFromHisto(uint8_t const * layerPairs, uint32_t nPairs, 
-                         int16_t const * iphi, Hist const * hist, uint32_t const * offsets, float phiCut) {
+  void doubletsFromHisto(uint8_t const * layerPairs, uint32_t nPairs, GPUCACell * cells, uint32_t * nCells,
+                         int16_t const * iphi, Hist const * hist, uint32_t const * offsets, float phiCut,
+                         siPixelRecHitsHeterogeneousProduct::HitsOnGPU const & hh) {
     auto iphicut = phi2short(phiCut);
 
     auto idx = blockIdx.x*blockDim.x + threadIdx.x;
@@ -130,20 +40,20 @@ namespace gpuPixelDoublets {
     if (idx>=ntot) return;  // will move to for(auto j=idx;j<ntot;j+=blockDim.x*gridDim.x) {
     auto j = idx; 
 
-    uint32_t innerLayerId=0;
-    while(j>=innerLayerCumulaliveSize[innerLayerId++]);  --innerLayerId; // move to lower_bound ??
+    uint32_t pairLayerId=0;
+    while(j>=innerLayerCumulaliveSize[pairLayerId++]);  --pairLayerId; // move to lower_bound ??
 
-    assert(innerLayerId<nPairs);
-    assert(j<innerLayerCumulaliveSize[innerLayerId]);
-    assert(0==innerLayerId || j>=innerLayerCumulaliveSize[innerLayerId-1]);
+    assert(pairLayerId<nPairs);
+    assert(j<innerLayerCumulaliveSize[pairLayerId]);
+    assert(0==pairLayerId || j>=innerLayerCumulaliveSize[pairLayerId-1]);
 
-    uint8_t inner = layerPairs[2*innerLayerId];
-    uint8_t outer = layerPairs[2*innerLayerId+1];
+    uint8_t inner = layerPairs[2*pairLayerId];
+    uint8_t outer = layerPairs[2*pairLayerId+1];
 
-    auto i = (0==innerLayerId) ? 0 :  j-innerLayerCumulaliveSize[innerLayerId-1];
+    auto i = (0==pairLayerId) ? 0 :  j-innerLayerCumulaliveSize[pairLayerId-1];
     i += offsets[inner];
 
-    // printf("Hit in Layer %d %d %d %d\n", i, inner, innerLayerId, j);
+    // printf("Hit in Layer %d %d %d %d\n", i, inner, pairLayerId, j);
 
     assert(i>=offsets[inner]);
     assert(i<offsets[inner+1]);
@@ -164,6 +74,9 @@ namespace gpuPixelDoublets {
       for (auto p=hist[outer].begin(kk); p<hist[outer].end(kk); ++p) {
         if (std::min(std::abs(int16_t(iphi[*p]-mep)), std::abs(int16_t(mep-iphi[*p]))) > iphicut)
           continue;
+        auto ind = atomicInc(nCells,MaxNumOfDoublets);
+        // int layerPairId, int doubletId, int innerHitId,int outerHitId)
+        cells[ind].init(hh,pairLayerId,ind,i,*p);
         ++tot;
       }
     }
@@ -171,16 +84,19 @@ namespace gpuPixelDoublets {
     // look in spill bin as well....
   }
 
+  /*
   __global__
-  void getDoubletsFromHisto(uint8_t const * layerPairs, uint32_t nPairs, 
+  void getDoubletsFromHisto(uint8_t const * layerPairs, uint32_t nPairs, GPUCACell * cells, uint32_t * nCells,
                             siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp, float phiCut) {
     auto const & hh = *hhp;
-    doubletsFromHisto(layerPairs, nPairs, hh.iphi_d,hh.hist_d,hh.hitsLayerStart_d,phiCut);
+    doubletsFromHisto(layerPairs, nPairs, cells, nCells, 
+                      hh.iphi_d,hh.hist_d,hh.hitsLayerStart_d,phiCut, hh);
   }
+ */
 
 
   __global__
-  void getDoubletsFromHisto( siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp, float phiCut) {
+  void getDoubletsFromHisto(GPUCACell * cells, uint32_t * nCells, siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp, float phiCut) {
 
     uint8_t const layerPairs[2*13] = {0,1 ,1,2 ,2,3 
                                      ,0,4 ,1,4 ,2,4 ,4,5 ,5,6  
@@ -188,7 +104,8 @@ namespace gpuPixelDoublets {
                                      };
 
     auto const & hh = *hhp;
-    doubletsFromHisto(layerPairs, 13, hh.iphi_d,hh.hist_d,hh.hitsLayerStart_d,phiCut);
+    doubletsFromHisto(layerPairs, 13, cells, nCells, 
+                      hh.iphi_d,hh.hist_d,hh.hitsLayerStart_d,phiCut,hh);
   }
 
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -132,6 +132,7 @@ namespace gpuPixelDoublets {
 
     uint32_t innerLayerId=0;
     while(j>=innerLayerCumulaliveSize[innerLayerId++]);  --innerLayerId; // move to lower_bound ??
+
     assert(innerLayerId<nPairs);
     assert(j<innerLayerCumulaliveSize[innerLayerId]);
     assert(0==innerLayerId || j>=innerLayerCumulaliveSize[innerLayerId-1]);
@@ -139,7 +140,10 @@ namespace gpuPixelDoublets {
     uint8_t inner = layerPairs[2*innerLayerId];
     uint8_t outer = layerPairs[2*innerLayerId+1];
 
-    auto i = j-innerLayerCumulaliveSize[innerLayerId] + offsets[inner];
+    auto i = (0==innerLayerId) ? 0 :  j-innerLayerCumulaliveSize[innerLayerId-1];
+    i += offsets[inner];
+
+    // printf("Hit in Layer %d %d %d %d\n", i, inner, innerLayerId, j);
 
     assert(i>=offsets[inner]);
     assert(i<offsets[inner+1]);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -26,8 +26,6 @@ namespace gpuPixelDoublets {
                          GPU::VecArray< unsigned int, 2048>  * isOuterHitOfCell,
                          int16_t const * phicuts, float const * minz, float const * maxz, float const * maxr) {
 
-    auto idx = blockIdx.x*blockDim.x + threadIdx.x;
-
     auto layerSize = [=](uint8_t li) { return offsets[li+1]-offsets[li]; };
 
     // to be optimized later
@@ -39,7 +37,10 @@ namespace gpuPixelDoublets {
     }
 
     auto ntot = innerLayerCumulaliveSize[nPairs-1];
-    if (idx>=ntot) return;  // will move to for(auto j=idx;j<ntot;j+=blockDim.x*gridDim.x) {
+
+
+    auto idx = blockIdx.x*blockDim.x + threadIdx.x;
+  for(auto j=idx;j<ntot;j+=blockDim.x*gridDim.x) {
     auto j = idx; 
 
     uint32_t pairLayerId=0;
@@ -51,6 +52,7 @@ namespace gpuPixelDoublets {
 
     uint8_t inner = layerPairs[2*pairLayerId];
     uint8_t outer = layerPairs[2*pairLayerId+1];
+    assert(outer>inner);
 
     auto i = (0==pairLayerId) ? j :  j-innerLayerCumulaliveSize[pairLayerId-1];
     i += offsets[inner];
@@ -72,6 +74,15 @@ namespace gpuPixelDoublets {
         hh.rg_d[j]-mer > maxr[pairLayerId];
     };
 
+    constexpr float z0cut = 12.f;
+    auto z0cutoff = [&](int j) {
+      auto zo =	hh.zg_d[j];
+      auto ro = hh.rg_d[j]; 
+      auto dr = ro-mer;
+      return dr > maxr[pairLayerId] || 
+             dr<0 || std::abs((mez*ro - mer*zo)) > z0cut*dr;
+    };
+
     auto iphicut = phicuts[pairLayerId];
 
     auto kl = hist[outer].bin(int16_t(mep-iphicut));
@@ -86,30 +97,40 @@ namespace gpuPixelDoublets {
     for (auto kk=kl; kk!=khh; incr(kk)) {
       if (kk!=kl && kk!=kh) nmin+=hist[outer].size(kk);
       for (auto p=hist[outer].begin(kk); p<hist[outer].end(kk); ++p) {
-        if (std::min(std::abs(int16_t(iphi[*p]-mep)), std::abs(int16_t(mep-iphi[*p]))) > iphicut)
+        auto oi=*p;
+        assert(oi>=offsets[outer]);
+        assert(oi<offsets[outer+1]);
+
+        if (std::min(std::abs(int16_t(iphi[oi]-mep)), std::abs(int16_t(mep-iphi[oi]))) > iphicut)
           continue;
-        if (cutoff(*p)) continue;
+        if (z0cutoff(oi)) continue;
         auto ind = atomicInc(nCells,MaxNumOfDoublets);
         // int layerPairId, int doubletId, int innerHitId,int outerHitId)
-        cells[ind].init(hh,pairLayerId,ind,i,*p);
-        isOuterHitOfCell[*p].push_back(ind);
-        if (isOuterHitOfCell[*p].size()==isOuterHitOfCell[*p].capacity()) ++tooMany;
+        cells[ind].init(hh,pairLayerId,ind,i,oi);
+        isOuterHitOfCell[oi].push_back(ind);
+        if (isOuterHitOfCell[oi].full()) ++tooMany;
         ++tot;
       }
     }
     if (tooMany>0) printf("OuterHitOfCell full for %d in layer %d/%d, %d:%d   %d,%d\n", i, inner,outer, kl,kh,nmin,tot);
 
+    if (hist[outer].nspills>0)
+      printf("spill bin to be checked in %d %d\n",outer,hist[outer].nspills);
+
     // if (0==hist[outer].nspills) assert(tot>=nmin);
     // look in spill bin as well....
-  }
 
+
+  }  // loop in block...
+  }
   __global__
   void getDoubletsFromHisto(GPUCACell * cells, uint32_t * nCells, siPixelRecHitsHeterogeneousProduct::HitsOnGPU const * hhp,                
                             GPU::VecArray< unsigned int, 2048> *isOuterHitOfCell) {
 
     uint8_t const layerPairs[2*13] = {0,1 ,1,2 ,2,3 
-                                     ,0,4 ,1,4 ,2,4 ,4,5 ,5,6  
+                                     // ,0,4 ,1,4 ,2,4 ,4,5 ,5,6  
                                      ,0,7 ,1,7 ,2,7 ,7,8 ,8,9
+                                     ,0,4 ,1,4 ,2,4 ,4,5 ,5,6
                                      };
 
     const int16_t phi0p05 = phi2short(0.05);
@@ -117,8 +138,8 @@ namespace gpuPixelDoublets {
     const int16_t phi0p07 = phi2short(0.07);
 
     int16_t const phicuts[13] { phi0p05, phi0p05, phi0p06
-                               ,phi0p06, phi0p06, phi0p06, phi0p05, phi0p05
-                               ,phi0p06, phi0p06, phi0p06, phi0p05, phi0p05 
+                               ,phi0p07, phi0p06, phi0p06, phi0p05, phi0p05
+                               ,phi0p07, phi0p06, phi0p06, phi0p05, phi0p05
                               };
 
     float const minz[13] = { 0., 0., 0.
@@ -126,14 +147,14 @@ namespace gpuPixelDoublets {
       	       	       	    ,0., 0., 0., 0., 0.
                            };
 
-    float const	maxz[13] = { 10.,10.,12.
-                            ,30.,20.,15., 50., 50.
-       	       	       	    ,30.,20.,15., 50., 50.
+    float const	maxz[13] = { 20.,15.,12.
+                            ,30.,20.,20., 50., 50.
+       	       	       	    ,30.,20.,20., 50., 50.
                            };
 
     float const maxr[13] = { 20., 20., 20.
-                            ,12., 10., 6., 20., 20.
-      	       	       	    ,12., 10., 6., 20., 20.
+                            ,9., 7., 6., 5., 5.
+      	       	       	    ,9., 7., 6., 5., 5.
                            };
 
 


### PR DESCRIPTION
With this PR doublets (actually CACells) are created on GPU and fed to CA.
the whole workflow up to quadruplets candidates is now fully on GPU.

besides various goodies it sports a rechit map based on "first digi" that can be useful in many other cases...


some re-engineering will be welcome.
some printouts need to be removed.

cut tuning can be beneficial (although not essential)


results with ttbar PU50 realistic

![image](https://user-images.githubusercontent.com/4143702/43774799-af0de304-9a4a-11e8-87b0-8461d2a32bf4.png)




does not Merge ok...
will be redone....
