### PR TITLE
HeterogeneousEvent::put() returns OrphanHandle

### DIFF
--- a/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
+++ b/HeterogeneousCore/Producer/interface/HeterogeneousEvent.h
@@ -79,7 +79,7 @@ namespace edm {
     }
 
     template <typename Product, typename Type, typename F>
-    void put(std::unique_ptr<Type> product, F transferToCPU) {
+    auto put(std::unique_ptr<Type> product, F transferToCPU) {
       std::unique_ptr<HeterogeneousProduct> prod;
 #define CASE(ENUM) case ENUM: this->template make<ENUM, Product>(prod, std::move(product), std::move(transferToCPU), 0); break
       switch(location().deviceType()) {
@@ -89,7 +89,7 @@ namespace edm {
         throw cms::Exception("LogicError") << "edm::HeterogeneousEvent::put(): no case statement for device " << static_cast<unsigned int>(location().deviceType());
       }
 #undef CASE
-      event_->put(std::move(prod));
+      return event_->put(std::move(prod));
     }
 
   private:


### PR DESCRIPTION
I needed the OprhanHandle for private testing, so why not putting it here as well.

The result of the test was that from
1. conversion from CPU SOA to CPU legacy
2. copying CPU legacy from `HeterogeneousEvent` to "standard product"

it is 1 which costs more (takes about 10x time wrt. 2 for clusters and rechits).