### PR TITLE
Cleanup defines, includes, file names, and debug messages

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h
@@ -1,6 +1,7 @@
+#ifndef HeterogeneousCore_CUDAUtilities_interface_GPUSimpleVector_h
+#define HeterogeneousCore_CUDAUtilities_interface_GPUSimpleVector_h
+
 //  author: Felice Pantaleo, CERN, 2018
-#ifndef HeterogeneousCore_CUDAUtilities_GPUSimpleVector_h
-#define HeterogeneousCore_CUDAUtilities_GPUSimpleVector_h
 
 #include <type_traits>
 #include <utility>
@@ -8,16 +9,18 @@
 #include <cuda.h>
 
 namespace GPU {
+
 template <class T> struct SimpleVector {
   // Constructors
   constexpr SimpleVector(int capacity, T *data) // ownership of m_data stays within the caller
-      : m_size(0), m_capacity(capacity), m_data(data) {
+      : m_size(0), m_capacity(capacity), m_data(data)
+  {
     static_assert(std::is_trivially_destructible<T>::value);
   }
 
   constexpr SimpleVector() : SimpleVector(0) {}
 
-  __inline__ constexpr int push_back_unsafe(const T &element) {
+  inline constexpr int push_back_unsafe(const T &element) {
     auto previousSize = m_size;
     m_size++;
     if (previousSize < m_capacity) {
@@ -41,7 +44,7 @@ template <class T> struct SimpleVector {
     }
   }
 
-  __inline__ constexpr T & back() const {
+  inline constexpr T & back() const {
 
     if (m_size > 0) {
       return m_data[m_size - 1];
@@ -49,9 +52,11 @@ template <class T> struct SimpleVector {
       return T(); //undefined behaviour
   }
 
-#if defined(__NVCC__) || defined(__CUDACC__)
+#ifdef __CUDACC__
+
   // thread-safe version of the vector, when used in a CUDA kernel
-  __device__ int push_back(const T &element) {
+  __device__
+  int push_back(const T &element) {
     auto previousSize = atomicAdd(&m_size, 1);
     if (previousSize < m_capacity) {
       m_data[previousSize] = element;
@@ -62,7 +67,9 @@ template <class T> struct SimpleVector {
     }
   }
 
-  template <class... Ts> __device__ int emplace_back(Ts &&... args) {
+  template <class... Ts>
+  __device__
+  int emplace_back(Ts &&... args) {
     auto previousSize = atomicAdd(&m_size, 1);
     if (previousSize < m_capacity) {
       (new (&m_data[previousSize]) T(std::forward<Ts>(args)...));
@@ -72,22 +79,17 @@ template <class T> struct SimpleVector {
       return -1;
     }
   }
-#endif
 
-  __inline__ constexpr T& operator[](int i) { return m_data[i]; }
-  __inline__ constexpr const T& operator[](int i) const { return m_data[i]; }
-  __inline__ constexpr void reset() { m_size = 0; }
+#endif // __CUDACC__
 
-  __inline__ constexpr int size() const { return m_size; }
-
-  __inline__ constexpr int capacity() const { return m_capacity; }
-
-  __inline__ constexpr T *data() const { return m_data; }
-
-  __inline__ constexpr void resize(int size) { m_size = size; }
-
-  __inline__ constexpr void set_data(T * data) { m_data = data; }
-
+  inline constexpr T& operator[](int i) { return m_data[i]; }
+  inline constexpr const T& operator[](int i) const { return m_data[i]; }
+  inline constexpr void reset() { m_size = 0; }
+  inline constexpr int size() const { return m_size; }
+  inline constexpr int capacity() const { return m_capacity; }
+  inline constexpr T *data() const { return m_data; }
+  inline constexpr void resize(int size) { m_size = size; }
+  inline constexpr void set_data(T * data) { m_data = data; }
 
 private:
   int m_size;
@@ -95,6 +97,7 @@ private:
 
   T *m_data;
 };
+
 } // namespace GPU
 
-#endif // HeterogeneousCore_CUDAUtilities_GPUSimpleVector_h
+#endif // HeterogeneousCore_CUDAUtilities_interface_GPUSimpleVector_h

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
@@ -1,25 +1,19 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h"
-
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+#include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
-#include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
 
 inline float sqr(float x) { return x*x; }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/LowPtClusterShapeSeedComparitor.cc
@@ -1,32 +1,24 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
+#include <cmath>
 
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-
-#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
-
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-
+#include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
-#include "DataFormats/GeometryVector/interface/Basic2DVector.h"
-
-#include<cmath>
-
-
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 
 namespace {
   typedef Basic2DVector<float>   Vector2D;

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ThirdHitPrediction.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ThirdHitPrediction.cc
@@ -1,19 +1,14 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h"
-
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
-#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "TrackingTools/DetLayers/interface/DetLayer.h"
-
-#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
-
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/ThirdHitPrediction.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 inline float sqr(float x) { return x*x; }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TrackFitter.cc
@@ -1,37 +1,29 @@
-#include "RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
-
-#include "TrackingTools/DetLayers/interface/DetLayer.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
-
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-
 #include "CommonTools/Statistics/interface/LinearFit.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
-
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
-#include "RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoPixelVertexing/PixelLowPtUtilities/interface/TrackFitter.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackBuilder.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 
 using namespace std;
-#include "CommonTools/Utils/interface/DynArray.h"
-
 
 namespace {
+
 int getCharge
   (const DynArray<GlobalPoint> & points)
 {
@@ -42,8 +34,6 @@ int getCharge
    while (dphi < -M_PI) dphi += 2*M_PI;
    return (dphi > 0) ? -1 : 1;
 }
-
-
 
 }
 

--- a/RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h
@@ -1,5 +1,5 @@
-#ifndef CircleFromThreePoints_H
-#define CircleFromThreePoints_H
+#ifndef RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
+#define RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
@@ -60,4 +60,4 @@ private:
 	     const Vector2D& offset, double precision);
 };
 
-#endif 
+#endif  // RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h

--- a/RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/CircleFromThreePoints.cc
@@ -1,4 +1,4 @@
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 
 CircleFromThreePoints::CircleFromThreePoints( const GlobalPoint& inner,
                                     const GlobalPoint& mid,

--- a/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/KFBasedPixelFitter.cc
@@ -24,7 +24,7 @@
 
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoUtilities.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -25,7 +25,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
-#include "CircleFromThreePoints.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/CircleFromThreePoints.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackBuilder.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackErrorParam.h"
 #include "DataFormats/GeometryVector/interface/Pi.h"

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstructionGPU.cu
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstructionGPU.cu
@@ -4,11 +4,14 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstructionGPU.h"
 
-#define DEBUG 0
+#ifndef GPU_DEBUG
+#define GPU_DEBUG 0
+#endif // GPU_DEBUG
 
 using namespace Eigen;
 
-__global__ void KernelFullFitAllHits(float * hits_and_covariances,
+__global__
+void KernelFullFitAllHits(float * hits_and_covariances,
     int hits_in_fit,
     int cumulative_size,
     double B,
@@ -26,10 +29,10 @@ __global__ void KernelFullFitAllHits(float * hits_and_covariances,
     return;
   }
 
-  if (DEBUG) {
-    printf("BlockDim.x: %d, BlockIdx.x: %d, threadIdx.x: %d, start: %d, cumulative_size: %d\n",
-        blockDim.x, blockIdx.x, threadIdx.x, start, cumulative_size);
-  }
+#if GPU_DEBUG
+  printf("BlockDim.x: %d, BlockIdx.x: %d, threadIdx.x: %d, start: %d, cumulative_size: %d\n",
+      blockDim.x, blockIdx.x, threadIdx.x, start, cumulative_size);
+#endif
 
   Rfit::Matrix3xNd hits(3,hits_in_fit);
   Rfit::Matrix3Nd hits_cov(3 * hits_in_fit, 3 * hits_in_fit);
@@ -48,36 +51,37 @@ __global__ void KernelFullFitAllHits(float * hits_and_covariances,
     }
   }
 
-  if (DEBUG) {
-    printf("KernelFullFitAllHits hits(0,0): %d\t%f\n", helix_start, hits(0,0));
-    printf("KernelFullFitAllHits hits(0,1): %d\t%f\n", helix_start, hits(0,1));
-    printf("KernelFullFitAllHits hits(0,2): %d\t%f\n", helix_start, hits(0,2));
-    printf("KernelFullFitAllHits hits(0,3): %d\t%f\n", helix_start, hits(0,3));
-    printf("KernelFullFitAllHits hits(1,0): %d\t%f\n", helix_start, hits(1,0));
-    printf("KernelFullFitAllHits hits(1,1): %d\t%f\n", helix_start, hits(1,1));
-    printf("KernelFullFitAllHits hits(1,2): %d\t%f\n", helix_start, hits(1,2));
-    printf("KernelFullFitAllHits hits(1,3): %d\t%f\n", helix_start, hits(1,3));
-    printf("KernelFullFitAllHits hits(2,0): %d\t%f\n", helix_start, hits(2,0));
-    printf("KernelFullFitAllHits hits(2,1): %d\t%f\n", helix_start, hits(2,1));
-    printf("KernelFullFitAllHits hits(2,2): %d\t%f\n", helix_start, hits(2,2));
-    printf("KernelFullFitAllHits hits(2,3): %d\t%f\n", helix_start, hits(2,3));
-    Rfit::printIt(&hits);
-    Rfit::printIt(&hits_cov);
-  }
+#if GPU_DEBUG
+  printf("KernelFullFitAllHits hits(0,0): %d\t%f\n", helix_start, hits(0,0));
+  printf("KernelFullFitAllHits hits(0,1): %d\t%f\n", helix_start, hits(0,1));
+  printf("KernelFullFitAllHits hits(0,2): %d\t%f\n", helix_start, hits(0,2));
+  printf("KernelFullFitAllHits hits(0,3): %d\t%f\n", helix_start, hits(0,3));
+  printf("KernelFullFitAllHits hits(1,0): %d\t%f\n", helix_start, hits(1,0));
+  printf("KernelFullFitAllHits hits(1,1): %d\t%f\n", helix_start, hits(1,1));
+  printf("KernelFullFitAllHits hits(1,2): %d\t%f\n", helix_start, hits(1,2));
+  printf("KernelFullFitAllHits hits(1,3): %d\t%f\n", helix_start, hits(1,3));
+  printf("KernelFullFitAllHits hits(2,0): %d\t%f\n", helix_start, hits(2,0));
+  printf("KernelFullFitAllHits hits(2,1): %d\t%f\n", helix_start, hits(2,1));
+  printf("KernelFullFitAllHits hits(2,2): %d\t%f\n", helix_start, hits(2,2));
+  printf("KernelFullFitAllHits hits(2,3): %d\t%f\n", helix_start, hits(2,3));
+  Rfit::printIt(&hits);
+  Rfit::printIt(&hits_cov);
+#endif
 
   // Perform actual fit
   Vector4d fast_fit = Rfit::Fast_fit(hits);
 
-  if (DEBUG) {
-    printf("KernelFullFitAllHits fast_fit(0): %d %f\n", helix_start, fast_fit(0));
-    printf("KernelFullFitAllHits fast_fit(1): %d %f\n", helix_start, fast_fit(1));
-    printf("KernelFullFitAllHits fast_fit(2): %d %f\n", helix_start, fast_fit(2));
-    printf("KernelFullFitAllHits fast_fit(3): %d %f\n", helix_start, fast_fit(3));
-  }
+#if GPU_DEBUG
+  printf("KernelFullFitAllHits fast_fit(0): %d %f\n", helix_start, fast_fit(0));
+  printf("KernelFullFitAllHits fast_fit(1): %d %f\n", helix_start, fast_fit(1));
+  printf("KernelFullFitAllHits fast_fit(2): %d %f\n", helix_start, fast_fit(2));
+  printf("KernelFullFitAllHits fast_fit(3): %d %f\n", helix_start, fast_fit(3));
+#endif
 
   u_int n = hits.cols();
-  if (DEBUG)
-    printf("KernelFullFitAllHits using %d hits: %d\n", n, helix_start);
+#if GPU_DEBUG
+  printf("KernelFullFitAllHits using %d hits: %d\n", n, helix_start);
+#endif
 
   Rfit::VectorNd rad = (hits.block(0, 0, 2, n).colwise().norm());
 
@@ -85,11 +89,11 @@ __global__ void KernelFullFitAllHits(float * hits_and_covariances,
     Rfit::Circle_fit(hits.block(0,0,2,n), hits_cov.block(0, 0, 2 * n, 2 * n),
       fast_fit, rad, B, true, true);
 
-  if (DEBUG) {
-    printf("KernelFullFitAllHits circle.par(0): %d %f\n", helix_start, circle.par(0));
-    printf("KernelFullFitAllHits circle.par(1): %d %f\n", helix_start, circle.par(1));
-    printf("KernelFullFitAllHits circle.par(2): %d %f\n", helix_start, circle.par(2));
-  }
+#if GPU_DEBUG
+  printf("KernelFullFitAllHits circle.par(0): %d %f\n", helix_start, circle.par(0));
+  printf("KernelFullFitAllHits circle.par(1): %d %f\n", helix_start, circle.par(1));
+  printf("KernelFullFitAllHits circle.par(2): %d %f\n", helix_start, circle.par(2));
+#endif
 
   Rfit::line_fit line = Rfit::Line_fit(hits, hits_cov, circle, fast_fit, true);
 
@@ -118,4 +122,3 @@ void PixelTrackReconstructionGPU::launchKernelFit(float * hits_and_covariancesGP
   KernelFullFitAllHits<<<num_blocks, threads_per_block>>>(hits_and_covariancesGPU, hits_in_fit, cumulative_size, B, results);
   cudaCheck(cudaGetLastError());
 }
-

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstructionGPU.cu
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstructionGPU.cu
@@ -76,7 +76,7 @@ __global__ void KernelFullFitAllHits(float * hits_and_covariances,
   }
 
   u_int n = hits.cols();
-  if (true)
+  if (DEBUG)
     printf("KernelFullFitAllHits using %d hits: %d\n", n, helix_start);
 
   Rfit::VectorNd rad = (hits.block(0, 0, 2, n).colwise().norm());

--- a/RecoPixelVertexing/PixelTrackFitting/test/test_common.h
+++ b/RecoPixelVertexing/PixelTrackFitting/test/test_common.h
@@ -2,21 +2,24 @@
 #define RecoPixelVertexing__PixelTrackFitting__test_common_h
 
 #include <algorithm>
-#include <random>
 #include <cassert>
+#include <random>
 
-#define NODEBUG 1
+#ifndef TEST_DEBUG
+#define TEST_DEBUG 0
+#endif
 
 template<class C>
-__host__ __device__ void printIt(C * m) {
-  if (!NODEBUG) {
-    printf("\nMatrix %dx%d\n", (int)m->rows(), (int)m->cols());
-    for (u_int r = 0; r < m->rows(); ++r) {
-      for (u_int c = 0; c < m->cols(); ++c) {
-        printf("Matrix(%d,%d) = %f\n", r, c, (*m)(r,c));
-      }
+__host__ __device__
+void printIt(C * m) {
+#if TEST_DEBUG
+  printf("\nMatrix %dx%d\n", (int)m->rows(), (int)m->cols());
+  for (u_int r = 0; r < m->rows(); ++r) {
+    for (u_int c = 0; c < m->cols(); ++c) {
+      printf("Matrix(%d,%d) = %f\n", r, c, (*m)(r,c));
     }
   }
+#endif
 }
 
 template<class C>

--- a/RecoPixelVertexing/PixelTriplets/interface/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CACell.h
@@ -1,14 +1,13 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CACELL_h
+#ifndef RecoPixelVertexing_PixelTriplets_interface_CACell_h
+#define RecoPixelVertexing_PixelTriplets_interface_CACell_h
 
-#include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
-#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include <array>
+#include <cmath>
 
 #include "DataFormats/Math/interface/deltaPhi.h"
-
-#include <cmath>
-#include <array>
+#include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 class CACellStatus {
 
@@ -298,4 +297,4 @@ private:
 };
 
 
-#endif /*CACELL_H_ */
+#endif // RecoPixelVertexing_PixelTriplets_interface_CACell_h

--- a/RecoPixelVertexing/PixelTriplets/interface/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CAGraph.h
@@ -1,5 +1,5 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAGRAPH_H_
+#ifndef RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
+#define RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
 
 #include <array>
 #include <string>
@@ -52,4 +52,4 @@ struct CAGraph {
   std::vector<int> theRootLayers;
 };
 
-#endif /* CAGRAPH_H_ */
+#endif // RecoPixelVertexing_PixelTriplets_interface_CAGraph_h

--- a/RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h
@@ -1,20 +1,21 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_PLUGINS_CELLULARAUTOMATON_H_
+#ifndef RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h
+#define RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h
+
 #include <array>
-#include "CACell.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
+#include "RecoPixelVertexing/PixelTriplets/interface/CACell.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
-#include "CAGraph.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
 class CellularAutomaton
 {
 public:
   CellularAutomaton(CAGraph& graph)
     : theLayerGraph(graph)
-  {
-    
-  }
+  { }
   
-  std::vector<CACell> & getAllCells() { return allCells;}
+  std::vector<CACell> & getAllCells() { return allCells; }
   
   void createAndConnectCells(const std::vector<const HitDoublets *>&,
 			     const TrackingRegion&, const float, const float, const float);
@@ -35,4 +36,4 @@ private:
   
 };
 
-#endif 
+#endif // RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -11,8 +11,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
-#include "RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 
 #include "CAHitQuadrupletGeneratorGPU.h"

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
@@ -1,35 +1,25 @@
-#include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
-
-#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
-
-#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-
-
-#include "CAGraph.h"
-#include "CellularAutomaton.h"
+#include <functional>
 
 #include "CommonTools/Utils/interface/DynArray.h"
-
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-
-#include <functional>
+#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 
 namespace
 {
-
   template <typename T>
   T sqr(T x)
   {
-    return x*x;
+    return x * x;
   }
 }
-
-
 
 using namespace std;
 

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
@@ -1,31 +1,25 @@
 #include <unordered_map>
 
-#include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
-
-#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
-
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CommonTools/Utils/interface/DynArray.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "DataFormats/Common/interface/Handle.h"
-
-#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
-#include "CAGraph.h"
-#include "CellularAutomaton.h"
-
-#include "CommonTools/Utils/interface/DynArray.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
+#include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 
 namespace
 {
-
-template<typename T>
-T sqr(T x)
-{
-	return x * x;
-}
+  template <typename T>
+  T sqr(T x)
+  {
+    return x * x;
+  }
 }
 
 using namespace std;

--- a/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
@@ -1,6 +1,6 @@
-#include "CellularAutomaton.h"
-
 #include <queue>
+
+#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
 
 void CellularAutomaton::createAndConnectCells(
     const std::vector<const HitDoublets *> &hitDoublets,


### PR DESCRIPTION
Do not #ifdef on `__NVCC__`: to protect CUDA-aware code sections, check if the `__CUDACC__` symbol is defined. The symbol `__NVCC__` is defined when building with nvcc, but not when building CUDA code with clang.

Move header files referenced from outside their directory to the interface/ directory, and update the include guards accordingly.

Include `<cuda_runtime.h>` instead of `<cuda.h>` to handle the CUDA attributes in non-CUDA compilations.

Rename `PixelTrackReconstructionGPU_impl.cu` to `PixelTrackReconstructionGPU.cu`.

Other cleanup: #defines, debug messages, change `__inline__` to `inline`, fix include guards, whitespaces, etc.