### PR TITLE
Move CPU-CA internal headers back to src

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -11,7 +11,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 

--- a/RecoPixelVertexing/PixelTriplets/src/CACell.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CACell.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_interface_CACell_h
-#define RecoPixelVertexing_PixelTriplets_interface_CACell_h
+#ifndef RecoPixelVertexing_PixelTriplets_src_CACell_h
+#define RecoPixelVertexing_PixelTriplets_src_CACell_h
 
 #include <array>
 #include <cmath>
@@ -297,4 +297,4 @@ private:
 };
 
 
-#endif // RecoPixelVertexing_PixelTriplets_interface_CACell_h
+#endif // RecoPixelVertexing_PixelTriplets_src_CACell_h

--- a/RecoPixelVertexing/PixelTriplets/src/CAGraph.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CAGraph.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
-#define RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
+#ifndef RecoPixelVertexing_PixelTriplets_src_CAGraph_h
+#define RecoPixelVertexing_PixelTriplets_src_CAGraph_h
 
 #include <array>
 #include <string>
@@ -52,4 +52,4 @@ struct CAGraph {
   std::vector<int> theRootLayers;
 };
 
-#endif // RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
+#endif // RecoPixelVertexing_PixelTriplets_src_CAGraph_h

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitQuadrupletGenerator.cc
@@ -6,11 +6,12 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CAHitQuadrupletGenerator.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
+#include "CAGraph.h"
+#include "CellularAutomaton.h"
 
 namespace
 {

--- a/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CAHitTripletGenerator.cc
@@ -6,12 +6,13 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CAHitTripletGenerator.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
+
+#include "CAGraph.h"
+#include "CellularAutomaton.h"
 
 namespace
 {

--- a/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.cc
@@ -1,6 +1,6 @@
 #include <queue>
 
-#include "RecoPixelVertexing/PixelTriplets/interface/CellularAutomaton.h"
+#include "CellularAutomaton.h"
 
 void CellularAutomaton::createAndConnectCells(
     const std::vector<const HitDoublets *> &hitDoublets,

--- a/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.h
+++ b/RecoPixelVertexing/PixelTriplets/src/CellularAutomaton.h
@@ -1,12 +1,13 @@
-#ifndef RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h
-#define RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h
+#ifndef RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
+#define RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
 
 #include <array>
 
-#include "RecoPixelVertexing/PixelTriplets/interface/CACell.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/CAGraph.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
+
+#include "CACell.h"
+#include "CAGraph.h"
 
 class CellularAutomaton
 {
@@ -36,4 +37,4 @@ private:
   
 };
 
-#endif // RecoPixelVertexing_PixelTriplets_interface_CellularAutomaton_h
+#endif // RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h


### PR DESCRIPTION
They were moved to `interface` in #122 because `CAHitQuadrupletGeneratorGPU.cc` included `CellularAutomaton.h` (and all CUDA code went to `plugins` in #123). The include was, however, unnecessary, so I moved the CPU-CA internal headers back to `src`.