### PR TITLE
Speed up CPU side of GPU rechits

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -36,14 +36,28 @@ namespace pixelgpudetails {
                        pixelCPEforGPU::ParamsOnGPU const * cpeParams,
                        cuda::stream_t<>& stream);
 
-    std::unique_ptr<HitsOnCPU>&& getOutput(cuda::stream_t<>& stream);
+    HitsOnCPU getOutput() const {
+      return HitsOnCPU{
+        h_hitsModuleStart_, h_detInd_, h_charge_,
+        h_xl_, h_yl_, h_xe_, h_ye_, h_mr_, h_mc_,
+        gpu_d, nhits_
+      };
+    }
 
   private:
     HitsOnGPU * gpu_d;  // copy of the structure on the gpu itself: this is the "Product" 
     HitsOnGPU gpu_;
-    std::unique_ptr<HitsOnCPU> cpu_;
+    uint32_t nhits_ = 0;
     uint32_t *d_phase1TopologyLayerStart_ = nullptr;
     uint32_t *h_hitsModuleStart_ = nullptr;
+    uint16_t *h_detInd_ = nullptr;
+    int32_t *h_charge_ = nullptr;
+    float *h_xl_ = nullptr;
+    float *h_yl_ = nullptr;
+    float *h_xe_ = nullptr;
+    float *h_ye_ = nullptr;
+    uint16_t *h_mr_ = nullptr;
+    uint16_t *h_mc_ = nullptr;
 #ifdef GPU_DEBUG
     uint32_t *h_hitsLayerStart_ = nullptr;
 #endif

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -179,7 +179,7 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
 }
 
 void SiPixelRecHitHeterogeneous::produceGPUCuda(edm::HeterogeneousEvent& iEvent, const edm::EventSetup& iSetup, cuda::stream_t<>& cudaStream) {
-  auto output = gpuAlgo_->getOutput(cudaStream);
+  auto output = std::make_unique<GPUProduct>(gpuAlgo_->getOutput());
 
  // Need the CPU clusters to
   // - properly fill the output DetSetVector of hits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
@@ -36,30 +36,18 @@ namespace siPixelRecHitsHeterogeneousProduct {
   };
 
   struct HitsOnCPU {
-    HitsOnCPU() = default;
+    uint32_t const * hitsModuleStart = nullptr;
+    uint16_t const * detInd = nullptr;
+    int32_t const * charge = nullptr;
+    float const * xl = nullptr;
+    float const * yl = nullptr;
+    float const * xe = nullptr;
+    float const * ye = nullptr;
+    uint16_t const * mr = nullptr;
+    uint16_t const * mc = nullptr;
 
-    explicit HitsOnCPU(uint32_t nhits) :
-      detInd(nhits),
-      charge(nhits),
-      xl(nhits),
-      yl(nhits),
-      xe(nhits),
-      ye(nhits),
-      mr(nhits),
-      mc(nhits),
-      nHits(nhits)
-    { }
-
-    uint32_t hitsModuleStart[2001];
-    std::vector<uint16_t,  CUDAHostAllocator<uint16_t>> detInd;
-    std::vector<int32_t,  CUDAHostAllocator<int32_t>> charge;
-    std::vector<float,    CUDAHostAllocator<float>> xl, yl;
-    std::vector<float,    CUDAHostAllocator<float>> xe, ye;
-    std::vector<uint16_t, CUDAHostAllocator<uint16_t>> mr;
-    std::vector<uint16_t, CUDAHostAllocator<uint16_t>> mc;
-
-    uint32_t nHits;
     HitsOnGPU const * gpu_d = nullptr;
+    uint32_t nHits;
   };
 
   using GPUProduct = HitsOnCPU;  // FIXME fill cpu vectors on demand


### PR DESCRIPTION
`HitsOnCPU` allocates the (pinned) host memory on each event. Profiler shows that this is rather costly (more than half of the wall clock time spent in the kernels...). The first commit moves the allocations as the first action in the function, because I first saw a peculiar profile where one of the `cudaMallocHost` took very long time and delayed the queueing of the asynchronous memory copies, thus making the `acquire()` to occupy CPU.

Of course this didn't significantly improve the situation though, so the second commit changes the pattern to the same as in raw2cluster, i.e. allocate (also host side) buffers once per module (i.e. per job per EDM stream), and the event product just holds pointers to them. Not ideal, but faster (in a single event the wall clock time of `acquire()` reduces from ~240 us to ~170 us).

We can of course discuss whether this approach is what we really want (probably not), but at the moment it seems to be the fastest.

@fwyzard @VinInn @felicepantaleo 