### PR TITLE
Fix uninitialized memory access in GPU CellularAutomaton

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cu
@@ -120,7 +120,8 @@ void CAHitQuadrupletGeneratorGPU::allocateOnGPU()
 
   cudaCheck(cudaMalloc(&device_theCells_,
              maxNumberOfLayerPairs_ * maxNumberOfDoublets_ * sizeof(GPUCACell)));
-  cudaCheck(cudaMalloc(&device_nCells_,sizeof(uint32_t)));
+  cudaCheck(cudaMalloc(&device_nCells_, sizeof(uint32_t)));
+  cudaCheck(cudaMemset(device_nCells_, 0, sizeof(uint32_t)));
 
   cudaCheck(cudaMalloc(&device_isOuterHitOfCell_,
              maxNumberOfLayers_ * maxNumberOfHits_ * sizeof(GPU::VecArray<unsigned int, maxCellsPerHit_>)));


### PR DESCRIPTION
Spotted by `cuda-memcheck`, see e.g. [this report](https://fwyzard.web.cern.ch/fwyzard/patatrack/pulls/69d06614f3760eb09149dfa7d549610d586ef703/RelValZMM_13-CMSSW_10_2_1-102X_upgrade2018_realistic_v9_gcc7-v1/testing-10824.8-cuda-initcheck.log).