### PR TITLE
edm::Wrapper<> de/serialisation

### DIFF
--- a/HeterogeneousCore/MPICore/BuildFile.xml
+++ b/HeterogeneousCore/MPICore/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="root"/>
+<use name="FWCore/Framework"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousCore/MPICore/interface/WrapperHandle.h
+++ b/HeterogeneousCore/MPICore/interface/WrapperHandle.h
@@ -1,0 +1,290 @@
+#ifndef WrapperHandle_h
+#define WrapperHandle_h
+
+#include <cassert>
+#include <memory>
+#include <string>
+#include <typeinfo>
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/OrphanHandle.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+
+namespace edm {
+
+  // specialise Handle for a WrapperBase
+    
+  template <>
+  class Handle<WrapperBase> : public HandleBase {
+  public:
+    // default constructor
+    Handle() :
+      HandleBase(),
+      type_(nullptr)
+    { }
+
+    // throws exception if `type` is not a known C++ class type
+    Handle(std::string const& type) :
+      HandleBase(),
+      type_(& TypeWithDict::byName(type).typeInfo())
+    { }
+
+    Handle(WrapperBase const* wrapper, Provenance const* prov, std::string const& type) :
+      HandleBase(wrapper, prov),
+      type_(& TypeWithDict::byName(type).typeInfo())
+    { }
+
+    // throws exception if `type` is invalid
+    Handle(std::type_info const& type) :
+      HandleBase(),
+      type_(& type)
+    { }
+
+    Handle(WrapperBase const* wrapper, Provenance const* prov, std::type_info const& type) :
+      HandleBase(wrapper, prov),
+      type_(& type)
+    { }
+
+    // used when the attempt to get the data failed
+    Handle(std::shared_ptr<HandleExceptionFactory>&& whyFailed) :
+      HandleBase(std::move(whyFailed)),
+      type_(nullptr)
+    { }
+
+    // copiable and moveable
+    Handle(Handle<WrapperBase> const& h) = default;
+    Handle(Handle<WrapperBase> && h) = default;
+
+    Handle<WrapperBase> & operator=(Handle<WrapperBase> const& h) = default;
+    Handle<WrapperBase> & operator=(Handle<WrapperBase> && h) = default;
+
+    // (non-trivial) default destructor
+    ~Handle() = default;
+
+    // reimplement swap over HandleBase
+    // DO NOT swap with a HandleBase or with a different Handle<T>
+    void swap(Handle<WrapperBase> & other) {
+      HandleBase::swap(static_cast<HandleBase &>(other));
+      std::swap(type_, other.type_);
+    }
+
+    WrapperBase const* product() const {
+      return static_cast<WrapperBase const*>(productStorage());
+    }
+
+    WrapperBase const* operator->() const {
+      return product();
+    }
+
+    WrapperBase const& operator*() const {
+      return *product();
+    }
+
+    std::type_info const& typeInfo() const {
+      return *type_;
+    }
+
+  private:
+    std::type_info const* type_ = nullptr;
+  };
+
+
+  // swap free function
+
+  inline void swap(Handle<WrapperBase> & a, Handle<WrapperBase> & b)
+  {
+    a.swap(b);
+  }
+
+
+  // specialise the conversion from a BasicHandle into a Handle<WrapperBase>
+
+  template <>
+  inline
+  void convert_handle(BasicHandle && bh, Handle<WrapperBase>& result)
+  {
+    if (bh.failedToGet()) {
+      Handle<WrapperBase> h(std::move(bh.whyFailedFactory()));
+      result = std::move(h);
+      return;
+    }
+    WrapperBase const* wrapper = bh.wrapper();
+    if (wrapper == nullptr) {
+      handleimpl::throwInvalidReference();
+    }
+    if (not (wrapper->dynamicTypeInfo() == result.typeInfo())) {
+      handleimpl::throwConvertTypeError(result.typeInfo(), bh.wrapper()->dynamicTypeInfo());
+    }
+    Handle<WrapperBase> h(wrapper, bh.provenance(), result.typeInfo());
+    result = std::move(h);
+  }
+
+
+  // specialise OrphanHandle for a WrapperBase
+    
+  template <>
+  class OrphanHandle<WrapperBase> : public OrphanHandleBase {
+  public:
+    // default constructed handles are invalid
+    OrphanHandle() :
+      OrphanHandleBase(),
+      type_(nullptr)
+    { }
+
+    // does not take ownership of the WrapperBase
+    // throws an exception if `type` is an invalid or unknown C++ class type
+    OrphanHandle(WrapperBase const* wrapper, std::string const& type, ProductID const& id) :
+      OrphanHandleBase(wrapper, id),
+      type_(& TypeWithDict::byName(type).typeInfo())
+    { }
+
+    // does not take ownership of the WrapperBase
+    // assumes `type` to be a valid and known C++ type 
+    OrphanHandle(WrapperBase const* wrapper, std::type_info const& type, ProductID const& id) :
+      OrphanHandleBase(wrapper, id),
+      type_(& type)
+    { }
+
+    // copiable and moveable
+    OrphanHandle(OrphanHandle<WrapperBase> const& h) = default;
+    OrphanHandle(OrphanHandle<WrapperBase> && h) = default;
+
+    OrphanHandle<WrapperBase> & operator=(OrphanHandle<WrapperBase> const& h) = default;
+    OrphanHandle<WrapperBase> & operator=(OrphanHandle<WrapperBase> && h) = default;
+
+    // default destructor
+    ~OrphanHandle() = default;
+
+    // reimplement swap over OrphanHandleBase
+    // DO NOT swap with a OrphanHandleBase or with a different OrphanHandle<T>
+    void swap(OrphanHandle<WrapperBase> & other) {
+      OrphanHandleBase::swap(static_cast<OrphanHandleBase &>(other));
+      std::swap(type_, other.type_);
+    }
+
+    WrapperBase const* product() const {
+      return static_cast<WrapperBase const*>(productStorage());
+    }
+
+    WrapperBase const* operator->() const {
+      return product();
+    }
+
+    WrapperBase const& operator*() const {
+      return *product();
+    }
+
+    std::type_info const& typeInfo() const {
+      return *type_;
+    }
+
+  private:
+    std::type_info const* type_ = nullptr;
+  };
+
+
+  // swap free function
+
+  inline void swap(OrphanHandle<WrapperBase> & a, OrphanHandle<WrapperBase> & b) {
+    a.swap(b);
+  }
+
+  // specialise the Event methods for getting a WrapperBase
+
+  template <>
+  inline
+  bool Event::getByLabel(InputTag const& tag, Handle<WrapperBase>& result) const
+  {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.typeInfo()), tag, moduleCallingContext_);
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    addToGotBranchIDs(*result.provenance());
+    return true;
+  }
+
+  template <>
+  inline
+  bool Event::getByLabel(std::string const& label, std::string const& productInstanceName, Handle<WrapperBase>& result) const
+  {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.typeInfo()), label, productInstanceName, emptyString_, moduleCallingContext_);
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    addToGotBranchIDs(*result.provenance());
+    return true;
+  }
+
+  template <>
+  inline
+  bool Event::getByToken(EDGetToken token, Handle<WrapperBase>& result) const
+  {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(result.typeInfo()), PRODUCT_TYPE, token, moduleCallingContext_);
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    addToGotBranchIDs(*result.provenance());
+    return true;
+  }
+
+  template <>
+  inline
+  bool Event::getByToken(EDGetTokenT<WrapperBase> token, Handle<WrapperBase>& result) const
+  {
+    result.clear();
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(result.typeInfo()), PRODUCT_TYPE, token, moduleCallingContext_);
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
+      return false;
+    }
+    addToGotBranchIDs(*result.provenance());
+    return true;
+  }
+
+  // specialise the Event methods for putting a WrapperBase
+
+  template <>
+  inline
+  OrphanHandle<WrapperBase> Event::putImpl(EDPutToken::value_type index, std::unique_ptr<WrapperBase> product)
+  {
+    // the underlying collection `post_insert` is not called, as it is assumed
+    // it was done before creating the Wrapper
+    assert(index < putProducts().size());
+    //putProducts()[index] = std::move(product->wrapper());
+    putProducts()[index] = std::move(product);
+    WrapperBase const* prod = putProducts()[index].get();
+    auto const& prodType = prod->dynamicTypeInfo();
+    auto const& prodID   = provRecorder_.getProductID(index);
+    return OrphanHandle<WrapperBase>(prod, prodType, prodID);
+  }
+
+  template <>
+  inline
+  OrphanHandle<WrapperBase> Event::put(EDPutToken token, std::unique_ptr<WrapperBase> product)
+  {
+    auto const& typeInfo = product->dynamicTypeInfo();
+    if (UNLIKELY(product.get() == nullptr)) {
+      // null pointer is illegal
+      principal_get_adapter_detail::throwOnPutOfNullProduct("Event", TypeID(typeInfo), provRecorder_.productInstanceLabel(token));
+    }
+    if (UNLIKELY(token.isUninitialized())) {
+      principal_get_adapter_detail::throwOnPutOfUninitializedToken("Event", typeInfo);
+    }
+    if (UNLIKELY(provRecorder_.getTypeIDForPutTokenIndex(token.index()) != TypeID(typeInfo))) {
+      principal_get_adapter_detail::throwOnPutOfWrongType(typeInfo, provRecorder_.getTypeIDForPutTokenIndex(token.index()));
+    }
+    return putImpl(token.index(), std::move(product));
+  }
+
+}
+
+#endif // WrapperHandle_h

--- a/HeterogeneousCore/MPICore/interface/serialization.h
+++ b/HeterogeneousCore/MPICore/interface/serialization.h
@@ -1,0 +1,99 @@
+#ifndef HeterogeneousCore_MPICore_interface_serialization_h
+#define HeterogeneousCore_MPICore_interface_serialization_h
+
+#include <cstddef>
+#include <iomanip>
+#include <memory>
+#include <ostream>
+#include <utility>
+
+#include "DataFormats/Common/interface/WrapperBase.h"
+
+namespace io {
+
+  // io::unique_buffer manages a memory buffer of run-time fixed size;
+  // the underlying memory is release when the io::unique_buffer is destroyed.
+  class unique_buffer {
+  public:
+    // default constructor
+    unique_buffer();
+
+    // allocate a new buffer of the specified size
+    unique_buffer(size_t size);
+
+    // adopt an existing memory buffer of the specified size
+    unique_buffer(std::byte* data, size_t size);
+    unique_buffer(std::unique_ptr<std::byte> && data, size_t size);
+
+    // default copy and move constructors and assignment operators
+    unique_buffer(unique_buffer const&) = default;
+    unique_buffer(unique_buffer &&) = default;
+    unique_buffer& operator=(unique_buffer const&) = default;
+    unique_buffer& operator=(unique_buffer &&) = default;
+
+    // default destructor, releasing the owned memory
+    ~unique_buffer() = default;
+
+    // access to the underlying memory
+    std::byte const * data() const;
+    std::byte * data();
+
+    // release ownership of the underlying memory
+    std::byte * release();
+
+    // return the size of of the buffer
+    size_t size() const;
+
+  private:
+    std::unique_ptr<std::byte> data_;
+    size_t size_;
+  };
+
+  // dump the content of a buffer, using the same format as `hd`
+  template <typename T>
+  T& operator<<(T& out, unique_buffer const& buffer)
+  {
+    auto data = reinterpret_cast<const char*>(buffer.data());
+    auto size = buffer.size();
+    unsigned int l = 0;
+    for (; l < size / 16; ++l) {
+      out << std::setw(8) << std::setfill('0') << std::hex << l*16 << std::dec;
+      for (unsigned int i = l*16; i < (l+1)*16; ++i) {
+        out << ((i % 8 == 0) ? "  " : " ");
+        out << std::setw(2) << std::setfill('0') << std::hex << (((int) data[i]) & 0xff) << std::dec;
+      }
+      out << "  |";
+      for (unsigned int i = l*16; i < (l+1)*16; ++i) {
+        out << (char) (std::isprint(data[i]) ? data[i] : '.');
+      }
+      out << "|\n";
+    }
+    if (size % 16 != 0) {
+      out << std::setw(8) << std::setfill('0') << std::hex << l*16 << std::dec;
+      for (unsigned int i = l*16; i < size; ++i) {
+        out << ((i % 8 == 0) ? "  " : " ");
+        out << std::setw(2) << std::setfill('0') << std::hex << (((int) data[i]) & 0xff) << std::dec;
+      }
+      for (unsigned int i = size; i < (l+1)*16; ++i) {
+        out << ((i % 8 == 0) ? "    " : "   ");
+      }
+      out << "  |";
+      for (unsigned int i = l*16; i < size; ++i) {
+        out << (char) (std::isprint(data[i]) ? data[i] : '.');
+      }
+      out << "|\n";
+    }
+    out << std::setw(8) << std::setfill('0') << std::hex << size << std::dec << '\n';
+    return out;
+  }
+
+
+  // serialise a Wrapper<T> into an io::unique_buffer
+  io::unique_buffer serialize(edm::WrapperBase const& wrapper);
+
+  // deserialise a Wrapper<T> from an io::unique_buffer and store it in a unique_ptr<WrapperBase>
+  std::unique_ptr<edm::WrapperBase> deserialize(io::unique_buffer const& buffer);
+
+}
+
+#endif // HeterogeneousCore_MPICore_interface_serialization_h

--- a/HeterogeneousCore/MPICore/src/serialization.cc
+++ b/HeterogeneousCore/MPICore/src/serialization.cc
@@ -1,0 +1,101 @@
+#include <memory>
+#include <utility>
+
+#include <TClass.h>
+#include <TBufferFile.h>
+
+#include "HeterogeneousCore/MPICore/interface/serialization.h"
+
+namespace io {
+
+  // default constructor
+  unique_buffer::unique_buffer() :
+    data_(nullptr),
+    size_(0)
+  {
+  }
+
+  // allocate a new buffer of the specified size
+  unique_buffer::unique_buffer(size_t size) :
+    data_(new std::byte[size]),
+    size_(size)
+  {
+  }
+
+  // adopt an existing memory buffer of the specified size
+  unique_buffer::unique_buffer(std::byte* data, size_t size) :
+    data_(data),
+    size_(size)
+  {
+  }
+
+  // adopt an existing memory buffer of the specified size
+  unique_buffer::unique_buffer(std::unique_ptr<std::byte> && data, size_t size) :
+    data_(std::move(data)),
+    size_(size)
+  {
+  }
+
+  // access to the underlying memory
+  std::byte const * unique_buffer::data() const
+  {
+    return data_.get();
+  }
+
+  // access to the underlying memory
+  std::byte * unique_buffer::data()
+  {
+    return data_.get();
+  }
+
+  // release ownership of the underlying memory
+  std::byte * unique_buffer::release()
+  {
+    return data_.release();
+  }
+
+  // return the size of of the buffer
+  size_t unique_buffer::size() const
+  {
+    return size_;
+  }
+
+
+  // serialise a Wrapper<T> into a char[] via a TBufferFile
+  unique_buffer serialize(edm::WrapperBase const& wrapper)
+  {
+    /* TODO
+     * construct the buffer with an initial size based on the wrapped class size ?
+     * take into account any offset to/from the edm::WrapperBase base class ?
+     */ 
+    TBufferFile serializer(TBuffer::kWrite);
+    serializer.WriteObjectAny(& wrapper, TClass::GetClass(wrapper.wrappedTypeInfo()));
+
+    size_t      size = serializer.Length();
+    std::byte * data = reinterpret_cast<std::byte *>(serializer.Buffer());
+    serializer.DetachBuffer();
+
+    return unique_buffer(data, size);
+  }
+
+  std::unique_ptr<edm::WrapperBase> deserialize(unique_buffer const& buffer)
+  {
+    TBufferFile deserializer(TBuffer::kRead, buffer.size(), (void *) buffer.data(), false);
+
+    /* TODO try different versions:
+     * does not work ?
+    return std::unique_ptr<edm::WrapperBase>(reinterpret_cast<edm::WrapperBase *>(deserializer.ReadObjectAny(edmWrapperBaseClass)));
+     * works but maybe not always ?
+    return std::unique_ptr<edm::WrapperBase>(reinterpret_cast<edm::WrapperBase *>(deserializer.ReadObjectAny(nullptr)));
+     * not useful ?
+    return std::unique_ptr<edm::WrapperBase>(reinterpret_cast<edm::WrapperBase *>(deserializer.ReadObjectAny(rootType)));
+     * not useful ?
+    static TClass const* edmWrapperBaseClass = TClass::GetClass(typeid(edm::WrapperBase));
+    TClass * rootType = wrappedType.getClass();
+    int offset = rootType->GetBaseClassOffset(edmWrapperBaseClass);
+    return std::unique_ptr<edm::WrapperBase>(reinterpret_cast<edm::WrapperBase *>(reinterpret_cast<char *>(deserializer.ReadObjectAny(rootType)) + offset));
+     */
+    return std::unique_ptr<edm::WrapperBase>(reinterpret_cast<edm::WrapperBase *>(deserializer.ReadObjectAny(nullptr)));
+  }
+
+}


### PR DESCRIPTION
Implement the ability to get, serialise, deserialise and put in the Event an arbitrary collection, handling it as an opaque type via its edm::Wrapper<T>.