### PR TITLE
[Do not merge] Customize offline pixelTracks to the online config

### DIFF
--- a/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
+++ b/EventFilter/SiPixelRawToDigi/python/SiPixelRawToDigi_cfi.py
@@ -19,6 +19,9 @@ siPixelDigis.UsePhase1 = cms.bool(False)
 siPixelDigis.Regions = cms.PSet( ) 
 siPixelDigis.CablingMapLabel = cms.string("")
 
+# adjustment to online
+siPixelDigis.UserErrorList = []
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigis, UsePhase1=True)
 
@@ -27,4 +30,3 @@ _siPixelDigis_gpu.includeErrors = cms.bool(True)
 
 from Configuration.ProcessModifiers.gpu_cff import gpu
 gpu.toReplaceWith(siPixelDigis, _siPixelDigis_gpu)
-

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -45,6 +45,11 @@ phase1Pixel.toModify(siPixelClusters,
 
 )
 
+# Adjustment to online
+siPixelClusters.ChannelThreshold = 1000
+siPixelClusters.maxNumberOfClusters = 40000
+
+
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siPixelClusters, # FIXME

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersHeterogeneous_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersHeterogeneous_cfi.py
@@ -35,3 +35,10 @@ phase1Pixel.toModify(siPixelClustersHeterogeneous,
 
 # The following is copied from SiPixelRawToDigi_cfi
 phase1Pixel.toModify(siPixelClustersHeterogeneous, UsePhase1=True)
+
+# Adjustment to online
+# digi
+siPixelClustersHeterogeneous.UserErrorList = []
+# clusters
+siPixelClustersHeterogeneous.ChannelThreshold = 1000
+# there is no equivalent of maxNumberOfClusters

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -32,7 +32,11 @@ from RecoTracker.IterativeTracking.InitialStep_cff import initialStepSeedLayers,
 # TrackingRegion
 pixelTracksTrackingRegions = _globalTrackingRegion.clone()
 trackingLowPU.toReplaceWith(pixelTracksTrackingRegions, _globalTrackingRegionFromBeamSpot.clone())
-
+# adjustment to online
+pixelTracksTrackingRegions = _globalTrackingRegionFromBeamSpot.clone(RegionPSet = dict(
+    originRadius = 0.02,
+    ptMin = 0.8,
+))
 
 # Pixel Quadruplets Tracking
 pixelTracksSeedLayers = initialStepSeedLayers.clone(
@@ -52,6 +56,8 @@ pixelTracksHitQuadruplets = _initialStepCAHitQuadruplets.clone(
 )
 from Configuration.ProcessModifiers.gpu_cff import gpu
 gpu.toModify(pixelTracksHitQuadruplets, trackingRegions = "pixelTracksTrackingRegions")
+# adjustment to online
+pixelTracksHitQuadruplets.CAThetaCut = 0.002
 
 # for trackingLowPU
 pixelTracksHitTriplets = _pixelTripletHLTEDProducer.clone(


### PR DESCRIPTION
This PR customizes the offline configuration to correspond to the (or in case of GPU as close as possible) HLT configuration. For now it is intended only for performance testing (so do not merge).

Of course nothing prevents us from merging it in our fork, but maybe the customizations should be better decorated then (or even changed to be done via a yet another modifier?)?

@fwyzard 