### PR TITLE
Move cluster parameters to global memory

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -80,8 +80,8 @@ namespace pixelCPEforGPU {
   };
 
 
-  constexpr uint32_t MaxClusInModule=256;
-  using ClusParams = ClusParamsT<256>;
+  constexpr uint32_t MaxClusInModule = 256;
+  using ClusParams = ClusParamsT<MaxClusInModule>;
 
   constexpr inline
   void computeAnglesFromDet(DetParams const & __restrict__ detParams, float const x, float const y, float & cotalpha, float & cotbeta) {

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -1,16 +1,15 @@
 #ifndef RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
 #define RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
 
-#include "RecoLocalTracker/SiPixelClusterizer/plugins/siPixelRawToClusterHeterogeneousProduct.h"
-#include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusteringConstants.h"
-
-#include <cuda/api_wrappers.h>
-
 #include <cstdint>
 #include <vector>
 
-#include "RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h" 
+#include <cuda/api_wrappers.h>
 
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusteringConstants.h"
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/siPixelRawToClusterHeterogeneousProduct.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
+#include "siPixelRecHitsHeterogeneousProduct.h"
 
 namespace pixelCPEforGPU {
   struct ParamsOnGPU;
@@ -46,8 +45,9 @@ namespace pixelgpudetails {
     }
 
   private:
-    HitsOnGPU * gpu_d;  // copy of the structure on the gpu itself: this is the "Product" 
+    HitsOnGPU * gpu_d;  // copy of the structure on the gpu itself: this is the "Product"
     HitsOnGPU gpu_;
+    pixelCPEforGPU::ClusParams * clusterParams_;
     uint32_t nhits_ = 0;
     uint32_t *d_phase1TopologyLayerStart_ = nullptr;
     uint32_t *h_hitsModuleStart_ = nullptr;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -11,44 +11,37 @@
 
 namespace gpuPixelRecHits {
 
-
-
-
   // to be moved in common namespace...
   constexpr uint16_t InvId=9999; // must be > MaxNumModules
 
-
   constexpr uint32_t MaxClusInModule = pixelCPEforGPU::MaxClusInModule;
 
-  using ClusParams = pixelCPEforGPU::ClusParams;
-
-
   __global__ void getHits(pixelCPEforGPU::ParamsOnGPU const * __restrict__  cpeParams,
-                          float const * __restrict__  bs,
+                          float    const * __restrict__  bs,
                           uint16_t const * __restrict__  id,
-			  uint16_t const * __restrict__  x,
-			  uint16_t const * __restrict__  y,
-			  uint16_t const * __restrict__  adc,
-			  uint32_t const * __restrict__  digiModuleStart,
-			  uint32_t const * __restrict__  clusInModule,
-			  uint32_t const * __restrict__  moduleId,
-			  int32_t  const * __restrict__  clus,
-			  int numElements,
-			  uint32_t const * __restrict__  hitsModuleStart,
-                          int32_t * chargeh,
+                          uint16_t const * __restrict__  x,
+                          uint16_t const * __restrict__  y,
+                          uint16_t const * __restrict__  adc,
+                          uint32_t const * __restrict__  digiModuleStart,
+                          uint32_t const * __restrict__  clusInModule,
+                          uint32_t const * __restrict__  moduleId,
+                          int32_t  const * __restrict__  clus,
+                          int numElements,
+                          uint32_t const * __restrict__  hitsModuleStart,
+                          int32_t  * chargeh,
                           uint16_t * detInd,
-			  float * xg, float * yg, float * zg, float * rg, int16_t * iph,
+                          float * xg, float * yg, float * zg, float * rg, int16_t * iph,
                           float * xl, float * yl,
                           float * xe, float * ye, 
-                          uint16_t * mr, uint16_t * mc)
+                          uint16_t * mr,
+                          uint16_t * mc,
+                          pixelCPEforGPU::ClusParams * clusterParams )
   {
-    // as usual one block per module
-    __shared__ ClusParams clusParams;
-
     auto first = digiModuleStart[1 + blockIdx.x];
     auto me = id[first];
     assert(moduleId[blockIdx.x] == me);
     auto nclus = clusInModule[me];
+    pixelCPEforGPU::ClusParams & clusParams = clusterParams[blockIdx.x];
 
 #ifdef GPU_DEBUG
     if (me%100==1)


### PR DESCRIPTION
This eliminates the use of shared memory, allowing more concurrent blocks to run.