### PR TITLE
Switch HLT cluster->TP associator back to the CPU one

### DIFF
--- a/Validation/RecoTrack/python/associators_cff.py
+++ b/Validation/RecoTrack/python/associators_cff.py
@@ -3,8 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #### TrackAssociation
 import SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi
 import SimTracker.TrackAssociatorProducers.trackAssociatorByPosition_cfi
-# from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import tpClusterProducer as _tpClusterProducer
-from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import tpClusterProducerHeterogeneous as _tpClusterProducer
+from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import tpClusterProducer as _tpClusterProducer
 from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import trackingParticleRecoTrackAsssociation as _trackingParticleRecoTrackAsssociation
 
 hltTPClusterProducer = _tpClusterProducer.clone(


### PR DESCRIPTION
Fixes #175. In standard workflows HLT is run in step2, and the validation in step3, so there should be no reason to use the heterogeneous/GPU associator.

@fwyzard @rovere 