### PR TITLE
Disable vertex reconstruction on GPU

### DIFF
--- a/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoPixelVertexing/Configuration/python/RecoPixelVertexing_cff.py
@@ -4,6 +4,6 @@ from RecoPixelVertexing.PixelTrackFitting.PixelTracks_cff import *
 #
 # for STARTUP ONLY use try and use Offline 3D PV from pixelTracks, with adaptive vertex
 #
-from RecoPixelVertexing.PixelVertexFinding.PixelVertexes_cff import *
-# from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
+#from RecoPixelVertexing.PixelVertexFinding.PixelVertexes_cff import *
+from RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi import *
 recopixelvertexing = cms.Sequence(pixelTracksSequence*pixelVertices)

--- a/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
+++ b/RecoPixelVertexing/PixelVertexFinding/python/PixelVertexes_cfi.py
@@ -20,6 +20,3 @@ pixelVertices = cms.EDProducer("PixelVertexProducer",
 )
 
 
-from Configuration.ProcessModifiers.gpu_cff import gpu
-from RecoPixelVertexing.PixelVertexFinding.pixelVertexHeterogeneousProducer_cfi import pixelVertexHeterogeneousProducer as _pixelVertexHeterogeneousProducer
-gpu.toReplaceWith(pixelVertices, _pixelVertexHeterogeneousProducer)


### PR DESCRIPTION
On the Tesla K40c and P100 we get a segmentation violation in `PixelVertexHeterogeneousProducer::produceGPUCuda(...)`.