### PR TITLE
change assert in protection in RecHit producer

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -235,7 +235,7 @@ void SiPixelRecHitHeterogeneous::run(const edm::Handle<SiPixelClusterCollectionN
     auto mrp = &hoc.mr[fc];
     uint32_t ngh=0;
     for (uint32_t i=0; i<nhits;++i) {
-      if( hoc.charge[fc+i]<2000 || (gind>=96 && hoc.charge[fc+i]<4000) ) { ++numberOfLostClusters; continue;}
+      if (hoc.charge[fc+i]<2000 || (gind>=96 && hoc.charge[fc+i]<4000) ) { ++numberOfLostClusters; continue;}
       ind[ngh]=i;std::push_heap(ind, ind+ngh+1,[&](auto a, auto b) { return mrp[a]<mrp[b];});
       ++ngh;
     }
@@ -244,7 +244,10 @@ void SiPixelRecHitHeterogeneous::run(const edm::Handle<SiPixelClusterCollectionN
     auto jnd = [&](int k) { return fc+ind[k]; };
     assert(ngh<=DSViter->size());
     for (auto const & clust : *DSViter) {
-      if(ic>=ngh) break;
+      if (ic>=ngh) {
+        // FIXME add a way to handle this case, or at least notify via edm::LogError
+        break;
+      }
       // order is not stable... assume minPixelCol to be unique...
       auto ij = jnd(ic);
       // assert( clust.minPixelRow()==hoc.mr[ij] );
@@ -309,14 +312,13 @@ void SiPixelRecHitHeterogeneous::run(const edm::Handle<SiPixelClusterCollectionN
 
   } //    <-- End loop on DetUnits
 
-  /*  
+  /*
   std::cout << "SiPixelRecHitGPUVI $ det, clus, lost "
     <<  numberOfDetUnits << ' '
     << numberOfClusters  << ' '
     << numberOfLostClusters
     << std::endl;
   */
-
 }
 
 DEFINE_FWK_MODULE(SiPixelRecHitHeterogeneous);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -242,9 +242,9 @@ void SiPixelRecHitHeterogeneous::run(const edm::Handle<SiPixelClusterCollectionN
     std::sort_heap(ind, ind+ngh,[&](auto a, auto b) { return mrp[a]<mrp[b];});
     uint32_t ic=0;
     auto jnd = [&](int k) { return fc+ind[k]; };
-    assert(ngh==DSViter->size());
+    assert(ngh<=DSViter->size());
     for (auto const & clust : *DSViter) {
-      assert(ic<ngh);
+      if(ic>=ngh) break;
       // order is not stable... assume minPixelCol to be unique...
       auto ij = jnd(ic);
       // assert( clust.minPixelRow()==hoc.mr[ij] );
@@ -309,13 +309,13 @@ void SiPixelRecHitHeterogeneous::run(const edm::Handle<SiPixelClusterCollectionN
 
   } //    <-- End loop on DetUnits
 
-  /*
+  /*  
   std::cout << "SiPixelRecHitGPUVI $ det, clus, lost "
     <<  numberOfDetUnits << ' '
     << numberOfClusters  << ' '
     << numberOfLostClusters
     << std::endl;
-   */
+  */
 
 }
 


### PR DESCRIPTION
somehow this went lost in my last PR
now it runs w/o crash on real data including events (one event) with two very hot modules