### PR TITLE
Add a wrapper to run nvprof in a CMSSW environment

### DIFF
--- a/HeterogeneousCore/CUDAServices/scripts/nvprof-remote
+++ b/HeterogeneousCore/CUDAServices/scripts/nvprof-remote
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+# load the CMSSW environment
+if ! [ "$CMSSW_BASE" ]; then
+  EXEC=`readlink -f $0`
+  CMSSW_BASE=`dirname "$EXEC"`
+  unset EXEC
+fi
+which scram >& /dev/null || source "$CMS_PATH"/cmsset_default.sh
+eval `cd "$CMSSW_BASE"; scram runtime -sh 2> /dev/null`
+
+# log the commands being run
+{
+  date
+  echo "cwd: $PWD"
+  echo "cmd: $0 $@"
+  echo
+} > $CMSSW_BASE/tmp/nvprof.log
+
+# run the CUDA profiler
+nvprof "$@"


### PR DESCRIPTION
To run cmsRun within the Visual Profiler on a remote machine:
  - set up an SSH connection to the remote node
  - browse, and set the "custom script" to the output of
        `which nvprof-remote`
  - set the "file" to the output of
        `which cmsRun`
  - set the "working directory" as needed
  - set the "arguments" to the cmsRun arguments, e.g. (the full path to) the python configuration and any other arguments
  - set the "environment" variable CMS_PATH to the result of
        `echo $CMS_PATH`
  - set the "environment" variable CMSSW_BASE to the result of
        `echo $CMSSW_BASE`

See [Remote Profiling](https://docs.nvidia.com/cuda/profiler-users-guide/index.html#remote-profiling) for more information.