### PR TITLE
Add missing Phase 2 parameters to SiPixelRawToClusterHeterogeneous

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
@@ -248,6 +248,12 @@ void SiPixelRawToClusterHeterogeneous::fillDescriptions(edm::ConfigurationDescri
   desc.add<int>("VCaltoElectronOffset_L1", -414);
   desc.addUntracked<bool>("MissCalibrate", true);
   desc.add<bool>("SplitClusters", false);
+  desc.add<double>("ElectronPerADCGain", 135.);
+  // Phase 2 clusterizer
+  desc.add<bool>("Phase2Calibration", false);
+  desc.add<int>("Phase2ReadoutMode", -1);
+  desc.add<double>("Phase2DigiBaseline", 1200.);
+  desc.add<int>("Phase2KinkADC", 8);
 
   desc.add<bool>("gpuEnableTransfer", true);
   desc.add<bool>("gpuEnableConversion", true);


### PR DESCRIPTION
Update `SiPixelRawToClusterHeterogeneous` to cope with the mess made upstream in cms-sw#24329 .