### PR TITLE
Fix access to uninitialised memory in `RawToDigi_kernel`

### DIFF
--- a/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
+++ b/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 #include <cuda_runtime.h>
 
@@ -20,5 +21,5 @@ SiPixelDigisCUDA::SiPixelDigisCUDA(size_t nelements, cuda::stream_t<>& stream) {
   view->moduleInd_ = moduleInd_d.get();
 
   view_d = cs->make_device_unique<DeviceConstView>(stream);
-  cudaMemcpyAsync(view_d.get(), view.get(), sizeof(DeviceConstView), cudaMemcpyDefault, stream.id());
+  cudaCheck(cudaMemcpyAsync(view_d.get(), view.get(), sizeof(DeviceConstView), cudaMemcpyDefault, stream.id()));
 }


### PR DESCRIPTION
Reported by cuda-memcheck --tool initcheck:
```
CUDA-MEMCHECK
Host API memory access error at host access to 0x7fe311800000 of size 112660 bytes
    Uninitialized access at 0x7fe311811720 on access by cudaMemcopy source.
    Saved host backtrace up to driver entry point at error
    ...
    Host Frame:.../pluginRecoLocalTrackerSiPixelClusterizerPlugins.so (pixelgpudetails::SiPixelRawToClusterGPUKernel::makeClustersAsync(SiPixelFedCablingMapGPU const*, unsigned char const*, SiPixelGainForHLTonGPU const*, pixelgpudetails::SiPixelRawToClusterGPUKernel::WordFedAppender const&, unsigned int, unsigned int, bool, bool, bool, bool, bool, cuda::stream_t<false>&) + 0x1d87) [0x6e827]
    Host Frame:.../pluginRecoLocalTrackerSiPixelClusterizerPlugins.so (SiPixelRawToClusterHeterogeneous::acquireGPUCuda(edm::HeterogeneousEvent const&, edm::EventSetup const&, cuda::stream_t<false>&) + 0x768) [0x58618]
    ...
```