### PR TITLE
Add scripts to update CMS binaries using CUDA

### DIFF
--- a/HeterogeneousCore/CUDAServices/bin/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/bin/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin name="cudaComputeCapabilities" file="cudaComputeCapabilities.cpp">
+  <use name="cuda"/>
+</bin>

--- a/HeterogeneousCore/CUDAServices/bin/cudaComputeCapabilities.cpp
+++ b/HeterogeneousCore/CUDAServices/bin/cudaComputeCapabilities.cpp
@@ -1,0 +1,23 @@
+// C++ standard headers
+#include <iomanip>
+#include <iostream>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// CMSSW headers
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+int main() {
+
+  int devices = 0;
+  cudaCheck(cudaGetDeviceCount(&devices));
+
+  for (int i = 0; i < devices; ++i) {
+    cudaDeviceProp properties;
+    cudaGetDeviceProperties(&properties, i);
+    std::cout << std::setw(4) << i << "    " << std::setw(2) << properties.major << "." << properties.minor << "    " << properties.name << std::endl;
+  }
+
+  return 0;
+}

--- a/HeterogeneousCore/CUDAServices/scripts/cmsCudaRebuild.sh
+++ b/HeterogeneousCore/CUDAServices/scripts/cmsCudaRebuild.sh
@@ -1,0 +1,10 @@
+#! /bin/bash -e
+
+# move to the .../src directory
+cd $CMSSW_BASE/src/
+
+# check out all packages containing .cu files
+git ls-files --full-name | grep '.*\.cu$' | cut -d/ -f-2 | sort -u | xargs git cms-addpkg
+
+# rebuild all checked out packages
+scram b -j

--- a/HeterogeneousCore/CUDAServices/scripts/cmsCudaSetup.sh
+++ b/HeterogeneousCore/CUDAServices/scripts/cmsCudaSetup.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+TOOL=$CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected/cuda.xml
+
+# enumerate the supported streaming multiprocessor (sm) compute capabilites
+DOTS=$(cudaComputeCapabilities | awk '{ print $2 }' | sort -u)
+CAPS=$(echo $DOTS | sed -e's#\.*##g')
+
+# remove existing capabilities
+sed -i $TOOL -e'\#<flags CUDA_FLAGS="-gencode arch=compute_..,code=sm_.."/>#d'
+
+# add support for the capabilities found on this machine
+for CAP in $CAPS; do
+  sed -i $TOOL -e"\#</client>#a\  <flags CUDA_FLAGS=\"-gencode arch=compute_$CAP,code=sm_$CAP\"/>"
+done
+
+# reconfigure the cuda.xml tool
+scram setup cuda
+
+echo "SCRAM configured to support CUDA streaming multiprocessor architectures $DOTS"


### PR DESCRIPTION
Add scripts to handle updates to CMS binaries (libraries and executables) that depend on CUDA.

### `cudaComputeCapabilities`
List available GPUs and corresponding compute capabilities, for example:
```
$ cudaComputeCapabilities
   0     7.0    Tesla V100-PCIE-16GB
   1     7.0    Tesla V100-PCIE-16GB
```
### `cmsCudaSetup.sh`
Update SCRAM's cuda.xml tool file to support the compute capabilities as discovered by `cudaComputeCapabilities`.

### `cmsCudaRebuild.sh`
Check out all packages containing any CUDA source code file (`.cu`) and rebuild all packages.