### PR TITLE
Fix modulesToUnpack in raw2digi

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
@@ -28,26 +28,12 @@ public:
   // returns pointer to GPU memory
   const SiPixelFedCablingMapGPU *getGPUProductAsync(cuda::stream_t<>& cudaStream) const;
 
+  // returns pointer to GPU memory
+  const unsigned char *getModToUnpAllAsync(cuda::stream_t<>& cudaStream) const;
+  edm::cuda::device::unique_ptr<unsigned char[]> getModToUnpRegionalAsync(std::set<unsigned int> const& modules, cuda::stream_t<>& cudaStream) const;
 
-  // Allocates host and device memory, converts data to host memory,
-  // copies host memory to device memory asynchronously. It is the
-  // caller's responsibility to have this object to live until all
-  // operations on the device memory have completed.
-  class ModulesToUnpack {
-  public:
-    ModulesToUnpack(cuda::stream_t<>& cudaStream);
-    ~ModulesToUnpack() = default;
-
-    void fillAsync(SiPixelFedCablingMap const& cablingMap, std::set<unsigned int> const& modules, cuda::stream_t<>& cudaStream);
-
-    const unsigned char *get() const { return modToUnpDevice.get(); }
-
-  private:
-    edm::cuda::device::unique_ptr<unsigned char[]> modToUnpDevice;
-    edm::cuda::host::unique_ptr<unsigned char[]> modToUnpHost;
-  };
-  
 private:
+  const SiPixelFedCablingMap *cablingMap_;
   std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  fedMap;
   std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  linkMap;
   std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  rocMap;
@@ -55,6 +41,7 @@ private:
   std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  rocInDet;
   std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  moduleId;
   std::vector<unsigned char, CUDAHostAllocator<unsigned char>> badRocs;
+  std::vector<unsigned char, CUDAHostAllocator<unsigned char>> modToUnpDefault;
   unsigned int size;
   bool hasQuality_;
 
@@ -64,6 +51,12 @@ private:
     SiPixelFedCablingMapGPU *cablingMapDevice = nullptr; // same internal pointers as above, struct itself is on GPU
   };
   CUDAESProduct<GPUData> gpuData_;
+
+  struct ModulesToUnpack {
+    ~ModulesToUnpack();
+    unsigned char *modToUnpDefault = nullptr; // pointer to GPU
+  };
+  CUDAESProduct<ModulesToUnpack> modToUnp_;
 };
 
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
@@ -132,7 +132,6 @@ std::unique_ptr<PixelUnpackingRegions> regions_;
 
   edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher;
   edm::ESWatcher<SiPixelQualityRcd> qualityWatcher;
-  bool recordWatcherUpdatedSinceLastTransfer_ = false;
 
   bool usePilotBlade;
   bool usePhase1;
@@ -276,7 +275,6 @@ const FEDRawDataCollection *SiPixelRawToClusterHeterogeneous::initialize(const e
     fedIds   = cablingMap->fedIds();
     cabling_ = cablingMap->cablingTree();
     LogDebug("map version:")<< cabling_->version();
-    recordWatcherUpdatedSinceLastTransfer_ = true;
   }
   // initialize quality record or update if necessary
   if (qualityWatcher.check( es )&&useQuality) {
@@ -467,10 +465,9 @@ void SiPixelRawToClusterHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEv
     std::set<unsigned int> modules = *(regions_->modulesToUnpack());
     gpuModulesToUnpack.fillAsync(*cablingMap_, modules, cudaStream);
   }
-  else if(recordWatcherUpdatedSinceLastTransfer_) {
+  else {
     // If regions_ are disabled, it is enough to fill and transfer only if cablingMap has changed
     gpuModulesToUnpack.fillAsync(*cablingMap_, std::set<unsigned int>(), cudaStream);
-    recordWatcherUpdatedSinceLastTransfer_ = false;
   }
 
   edm::ESHandle<SiPixelFedCablingMapGPUWrapper> hgpuMap;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc
@@ -460,16 +460,6 @@ void SiPixelRawToClusterHeterogeneous::produceCPU(edm::HeterogeneousEvent& ev, c
 void SiPixelRawToClusterHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& ev, const edm::EventSetup& es, cuda::stream_t<>& cudaStream) {
   const auto buffers = initialize(ev.event(), es);
 
-  auto gpuModulesToUnpack = SiPixelFedCablingMapGPUWrapper::ModulesToUnpack(cudaStream);
-  if (regions_) {
-    std::set<unsigned int> modules = *(regions_->modulesToUnpack());
-    gpuModulesToUnpack.fillAsync(*cablingMap_, modules, cudaStream);
-  }
-  else {
-    // If regions_ are disabled, it is enough to fill and transfer only if cablingMap has changed
-    gpuModulesToUnpack.fillAsync(*cablingMap_, std::set<unsigned int>(), cudaStream);
-  }
-
   edm::ESHandle<SiPixelFedCablingMapGPUWrapper> hgpuMap;
   es.get<CkfComponentsRecord>().get(hgpuMap);
   if(hgpuMap->hasQuality() != useQuality) {
@@ -477,6 +467,17 @@ void SiPixelRawToClusterHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEv
   }
   // get the GPU product already here so that the async transfer can begin
   const auto *gpuMap = hgpuMap->getGPUProductAsync(cudaStream);
+
+  edm::cuda::device::unique_ptr<unsigned char[]> modulesToUnpackRegional;
+  const unsigned char *gpuModulesToUnpack;
+  if (regions_) {
+    modulesToUnpackRegional = hgpuMap->getModToUnpRegionalAsync(*(regions_->modulesToUnpack()), cudaStream);
+    gpuModulesToUnpack = modulesToUnpackRegional.get();
+  }
+  else {
+    gpuModulesToUnpack = hgpuMap->getModToUnpAllAsync(cudaStream);
+  }
+
 
   edm::ESHandle<SiPixelGainCalibrationForHLTGPU> hgains;
   es.get<SiPixelGainCalibrationForHLTGPURcd>().get(hgains);
@@ -545,7 +546,7 @@ void SiPixelRawToClusterHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEv
 
   } // end of for loop
 
-  gpuAlgo_.makeClustersAsync(gpuMap, gpuModulesToUnpack.get(), hgains->getGPUProductAsync(cudaStream),
+  gpuAlgo_.makeClustersAsync(gpuMap, gpuModulesToUnpack, hgains->getGPUProductAsync(cudaStream),
                              wordFedAppender,
                              wordCounterGPU, fedCounter, convertADCtoElectrons,
                              useQuality, includeErrors, enableTransfer_, debug, cudaStream);


### PR DESCRIPTION
This PR fixes the problem of uninitialized memory reported in https://github.com/cms-patatrack/cmssw/pull/172#issuecomment-443792007 and https://github.com/cms-patatrack/cmssw/pull/172#issuecomment-443800590.

Basically the problem was that the "modules to unpack" was left uninitialized for all but first event.

@fwyzard @VinInn 