### PR TITLE
Fix setting the data pointer of error SimpleVector

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -221,6 +221,8 @@ namespace pixelgpudetails {
     }
 
     CPUData&& getCPUData() {
+      // Set the vector data pointer to point to CPU
+      digis_clusters_h.error->set_data(digis_clusters_h.data.get());
       return std::move(digis_clusters_h);
     }
 


### PR DESCRIPTION
While working on Raw2Cluster migration to #100, I realized that #109 removed re-setting the data pointer of the erro `SimpleVector` to point to the host memory after the `cudaMemcpyAsync()` in
https://github.com/cms-patatrack/cmssw/blob/6f55d706f3507d49d34b45ddb29ef3c3c25fd6e0/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu#L586-L587

We haven't hit on the problem because on the consumer side
https://github.com/cms-patatrack/cmssw/blob/6f55d706f3507d49d34b45ddb29ef3c3c25fd6e0/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterHeterogeneous.cc#L644-L646
the data is accessed only if `size() > 0`, and for MC the size appears to be `0`.

This PR sets the data pointer in a proper place (after the async copies have completed).