### PR TITLE
Fix a race for CUDA event in CachingHostAllocator

### DIFF
--- a/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h
+++ b/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h
@@ -538,9 +538,6 @@ struct CachingHostAllocator
             }
         }
 
-        // Unlock
-        mutex.Unlock();
-
         if (CubDebug(error = cudaGetDevice(&entrypoint_device))) return error;
         if (entrypoint_device != search_key.device) {
             if (CubDebug(error = cudaSetDevice(search_key.device))) return error;
@@ -550,7 +547,11 @@ struct CachingHostAllocator
             // Insert the ready event in the associated stream (must have current device set properly)
             if (CubDebug(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream))) return error;
         }
-        else
+
+        // Unlock
+        mutex.Unlock();
+
+        if (!recached)
         {
             // Free the allocation from the runtime and cleanup the event.
             if (CubDebug(error = cudaFreeHost(d_ptr))) return error;


### PR DESCRIPTION
Currently the mutex in the allocator is unlocked after the memory block is inserted in the free list (`cached_bytes`), but before calling `cudaEventRecord()`. This means that there is a short period of time when the memory block is in the free list and the CUDA event status is not `cudaErrorNotReady`, and thus a `HostAllocate()` (called in another thread) may consider the memory block to be free in
https://github.com/cms-patatrack/cmssw/blob/6f55d706f3507d49d34b45ddb29ef3c3c25fd6e0/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h#L393
If the memory block was previously associated to a CUDA stream on a different device, the CUDA event gets destroyed and created on the current device. In the original (freeing) thread, the `cudaEventRecord()` in
https://github.com/cms-patatrack/cmssw/blob/6f55d706f3507d49d34b45ddb29ef3c3c25fd6e0/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h#L551
gets a CUDA event that is now all the sudden on a different device, leading to the segfaults reported in #197 and #216.

This PR fixes the race condition by unlocking the mutex only after the `cudaEventRecord()` is called in `HostFree()`.

@fwyzard @VinInn 