### PR TITLE
Fix initialization of gpuVertexFinder::Producer to avoid crash when cudaMalloc has not been called

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
@@ -66,6 +66,7 @@ namespace gpuVertexFinder {
 	     float ichi2max,   // max normalized distance to cluster
              bool ienableTransfer
 	     ) :
+      onGPU{nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr},
       minT(iminT),
       eps(ieps),
       errmax(ierrmax),

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
@@ -14,6 +14,14 @@ namespace gpuVertexFinder {
     static constexpr uint32_t MAXTRACKS = 16000;
     static constexpr uint32_t MAXVTX= 1024;
 
+    OnGPU() = default;
+    OnGPU(nullptr_t):
+      ntrks{nullptr}, itrk{nullptr}, zt{nullptr}, ezt2{nullptr}, ptt2{nullptr},
+      zv{nullptr}, wv{nullptr}, chi2{nullptr}, ptv2{nullptr}, nvFinal{nullptr},
+      nvIntermediate{nullptr}, iv{nullptr}, sortInd{nullptr},
+      izt{nullptr}, nn{nullptr}
+    {}
+
     uint32_t * ntrks; // number of "selected tracks"
     uint16_t * itrk; // index of original track    
     float * zt;   // input track z at bs
@@ -66,7 +74,7 @@ namespace gpuVertexFinder {
 	     float ichi2max,   // max normalized distance to cluster
              bool ienableTransfer
 	     ) :
-      onGPU{nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr},
+      onGPU(nullptr),
       minT(iminT),
       eps(ieps),
       errmax(ierrmax),


### PR DESCRIPTION
While rebasing #100 I got stuck for a while debugging crashes/failing asserts. One failure on the course (but not the real cause) was that if `gpuVertexFinder::Producer` gets destructed without its `allocateOnGPU()` being called, `cudaFree()` returns an error and `cudaCheck()` aborts.

A possible fix is to initialize all the device-memory-pointers to `nullptr`. Note that the initialization can not be done in constructor because `cuda::memory::device::make_unique()` requires trivial constructor (as do our `CUDAService::make_device_unique`).