### PR TITLE
[RFC] Fix synchronization in various places

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuSortByPt2.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuSortByPt2.h
@@ -28,30 +28,36 @@ namespace gpuVertexFinder {
     float * __restrict__ ptv2 = data.ptv2;
     uint16_t * __restrict__ sortInd = data.sortInd;
 
-    if (nvFinal<1) return;
+    bool active = nvFinal>=1;
 
     // can be done asynchronoisly at the end of previous event
-    for (int i = threadIdx.x; i < nvFinal; i += blockDim.x) {
-      ptv2[i]=0;
+    if (active) {
+      for (int i = threadIdx.x; i < nvFinal; i += blockDim.x) {
+        ptv2[i]=0;
+      }
     }
     __syncthreads();
 
 
-    for (int i = threadIdx.x; i < nt; i += blockDim.x) {
-      if (iv[i]>9990) continue;
-      atomicAdd(&ptv2[iv[i]], ptt2[i]);
+    if (active) {
+      for (int i = threadIdx.x; i < nt; i += blockDim.x) {
+        if (iv[i]>9990) continue;
+        atomicAdd(&ptv2[iv[i]], ptt2[i]);
+      }
     }
     __syncthreads();
 
-    if (1==nvFinal) {
+    if (active && 1==nvFinal) {
       if (threadIdx.x==0) sortInd[0]=0;
-      return;
+      active = false;
     }
     __shared__ uint16_t ws[1024];
-    radixSort(ptv2,sortInd,ws,nvFinal);
+    if (active) {
+      radixSort(ptv2,sortInd,ws,nvFinal);
 
-    assert(ptv2[sortInd[nvFinal-1]]>=ptv2[sortInd[nvFinal-2]]);
-    assert(ptv2[sortInd[1]]>=ptv2[sortInd[0]]);
+      assert(ptv2[sortInd[nvFinal-1]]>=ptv2[sortInd[nvFinal-2]]);
+      assert(ptv2[sortInd[1]]>=ptv2[sortInd[0]]);
+    }
   }
 
 }


### PR DESCRIPTION
While rebasing #100 I got stuck for a while debugging crashes/failing asserts. One case was that `cuda-memcheck --tool racecheck` got stuck in `gpuClusterChargeCut()`. After looking the code I recalled #102 and that `__syncthreads()` with some threads returning early did not work well together. Fixing that alone did not help, so I checked all cases where we use `__syncthreads()` and attempted to fix all of those that currently return early.

In the end my problem was caused by something else, but I think we should at least discuss about these (RFC also because I'm not sure of all the details, and that racecheck still hangs).