### PR TITLE
Apply code checks reported in #25647

### DIFF
--- a/HeterogeneousCore/CUDAServices/src/CachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAServices/src/CachingDeviceAllocator.h
@@ -38,13 +38,12 @@
  * thread-safe and capable of managing device allocations on multiple devices.
  ******************************************************************************/
 
-#include <cub/util_debug.cuh>
-
-#include <set>
+#include <cmath>
 #include <map>
+#include <set>
 
+#include <cub/util_debug.cuh>
 #include <cub/host/mutex.cuh>
-#include <math.h>
 
 /// CUB namespace
 namespace notcub {
@@ -139,18 +138,18 @@ struct CachingDeviceAllocator
             bytes(0),
             bin(INVALID_BIN),
             device(device),
-            associated_stream(0),
-            ready_event(0)
+            associated_stream(nullptr),
+            ready_event(nullptr)
         {}
 
         // Constructor (suitable for searching maps for a range of suitable blocks, given a device)
         BlockDescriptor(int device) :
-            d_ptr(NULL),
+            d_ptr(nullptr),
             bytes(0),
             bin(INVALID_BIN),
             device(device),
-            associated_stream(0),
-            ready_event(0)
+            associated_stream(nullptr),
+            ready_event(nullptr)
         {}
 
         // Comparison functor for comparing device pointers
@@ -356,12 +355,12 @@ struct CachingDeviceAllocator
      * streams when all prior work submitted to \p active_stream has completed.
      */
     cudaError_t DeviceAllocate(
-        int             device,             ///< [in] Device on which to place the allocation
-        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
-        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
-        cudaStream_t    active_stream = 0)  ///< [in] The stream to be associated with this allocation
+        int             device,                     ///< [in] Device on which to place the allocation
+        void            **d_ptr,                    ///< [out] Reference to pointer to the allocation
+        size_t          bytes,                      ///< [in] Minimum number of bytes for the allocation
+        cudaStream_t    active_stream = nullptr)    ///< [in] The stream to be associated with this allocation
     {
-        *d_ptr                          = NULL;
+        *d_ptr                          = nullptr;
         int entrypoint_device           = INVALID_DEVICE_ORDINAL;
         cudaError_t error               = cudaSuccess;
 
@@ -529,9 +528,9 @@ struct CachingDeviceAllocator
      * streams when all prior work submitted to \p active_stream has completed.
      */
     cudaError_t DeviceAllocate(
-        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
-        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
-        cudaStream_t    active_stream = 0)  ///< [in] The stream to be associated with this allocation
+        void            **d_ptr,                    ///< [out] Reference to pointer to the allocation
+        size_t          bytes,                      ///< [in] Minimum number of bytes for the allocation
+        cudaStream_t    active_stream = nullptr)    ///< [in] The stream to be associated with this allocation
     {
         return DeviceAllocate(INVALID_DEVICE_ORDINAL, d_ptr, bytes, active_stream);
     }

--- a/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h
+++ b/HeterogeneousCore/CUDAServices/src/CachingHostAllocator.h
@@ -38,9 +38,9 @@
  * thread-safe.
  ******************************************************************************/
 
-#include <set>
-#include <map>
 #include <cmath>
+#include <map>
+#include <set>
 
 #include <cub/util_debug.cuh>
 #include <cub/host/mutex.cuh>
@@ -343,9 +343,9 @@ struct CachingHostAllocator
      * Once freed, the allocation becomes available immediately for reuse.
      */
     cudaError_t HostAllocate(
-        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
-        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
-        cudaStream_t    active_stream = nullptr)  ///< [in] The stream to be associated with this allocation
+        void            **d_ptr,                    ///< [out] Reference to pointer to the allocation
+        size_t          bytes,                      ///< [in] Minimum number of bytes for the allocation
+        cudaStream_t    active_stream = nullptr)    ///< [in] The stream to be associated with this allocation
     {
         *d_ptr                          = nullptr;
         int device                      = INVALID_DEVICE_ORDINAL;


### PR DESCRIPTION
Apply `scram`/`clang-tidy` code checks, reported in cms-sw#25647.