### PR TITLE
Whitelist HeterogeneousCore/* in CMS Coding rules

### DIFF
--- a/Utilities/ReleaseScripts/python/cmsCodeRules/config.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/config.py
@@ -63,7 +63,7 @@ Configuration[ruleName] = {}
 
 Configuration[ruleName]['description'] = 'Search for "catch(...)" statements in *.cc, *.cxx files'
 Configuration[ruleName]['filesToMatch'] = ['*.cc', '*.cxx']
-Configuration[ruleName]['exceptPaths'] = ['FWCore/*', 'EventFilter/*', '*/*/test/*', '*/*/bin/*']
+Configuration[ruleName]['exceptPaths'] = ['FWCore/*', 'EventFilter/*', 'HeterogeneousCore/*', '*/*/test/*', '*/*/bin/*']
 Configuration[ruleName]['skip']  = [comment]
 Configuration[ruleName]['filter'] = 'catch\s*\(\s*\.\.\.\s*\)' #should be regular expression
 Configuration[ruleName]['exceptFilter'] = []


### PR DESCRIPTION
Let packages under `HeterogeneousCore/` ignore violations to CMS coding rule #3, that forbids using `catch (...)` statements.