### PR TITLE
Use the explicit exception type instead of the ellipsis

### DIFF
--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -84,7 +84,7 @@ namespace heterogeneous {
                                           auto error = cudaGetErrorName(status);
                                           auto message = cudaGetErrorString(status);
                                           throw cms::Exception("CUDAError") << "Callback of CUDA stream " << streamId << " in device " << deviceId << " error " << error << ": " << message;
-                                        } catch(...) {
+                                        } catch(cms::Exception &) {
                                           waitingTaskHolder.doneWaiting(std::current_exception());
                                         }
                                       }


### PR DESCRIPTION
Use the explicit exception type instead of the ellipsis where the type is known.