### PR TITLE
Automate the nvprof-remote script

### DIFF
--- a/HeterogeneousCore/CUDAServices/scripts/nvprof-remote
+++ b/HeterogeneousCore/CUDAServices/scripts/nvprof-remote
@@ -1,12 +1,14 @@
 #! /bin/bash
 
-# load the CMSSW environment
-if ! [ "$CMSSW_BASE" ]; then
-  EXEC=`readlink -f $0`
-  CMSSW_BASE=`dirname "$EXEC"`
-  unset EXEC
+# find the CMSSW release
+if [ -z "$CMSSW_BASE" ]; then
+  export CMSSW_BASE=$(readlink -f $(dirname $0)/../..)
 fi
-which scram >& /dev/null || source "$CMS_PATH"/cmsset_default.sh
+
+# load the CMS environment
+source $(< "$CMSSW_BASE"/config/scram_basedir)/cmsset_default.sh
+
+# load the CMSSW release environment
 eval `cd "$CMSSW_BASE"; scram runtime -sh 2> /dev/null`
 
 # log the commands being run
@@ -15,7 +17,7 @@ eval `cd "$CMSSW_BASE"; scram runtime -sh 2> /dev/null`
   echo "cwd: $PWD"
   echo "cmd: $0 $@"
   echo
-} > $CMSSW_BASE/tmp/nvprof.log
+} >> $CMSSW_BASE/tmp/nvprof.log
 
 # run the CUDA profiler
 nvprof "$@"


### PR DESCRIPTION
Let the `nvprof-remote` script automatically determine the values for the environment variables `CMS_HOME` and `CMSSW_BASE`, based on its path and the release's scram configuration.