### PR TITLE
Remove CUDAService numberOfStreamsPerDevice as unsupported

### DIFF
--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -26,7 +26,7 @@ namespace heterogeneous {
 
   void GPUCuda::call_beginStreamGPUCuda(edm::StreamID id) {
     edm::Service<CUDAService> cudaService;
-    enabled_ = (enabled_ && cudaService->enabled(id));
+    enabled_ = (enabled_ && cudaService->enabled());
     if(!enabled_) {
       if(forced_) {
         throw cms::Exception("LogicError") << "This module was forced to run on GPUCuda, but the device is not available.";

--- a/HeterogeneousCore/CUDAServices/interface/CUDAService.h
+++ b/HeterogeneousCore/CUDAServices/interface/CUDAService.h
@@ -52,7 +52,7 @@ public:
   bool enabled() const { return enabled_; }
   // To be used in stream context when an edm::Stream is available
   bool enabled(edm::StreamID streamId) const { return enabled(static_cast<unsigned int>(streamId)); }
-  bool enabled(unsigned int streamId) const { return enabled_ && (numberOfStreamsTotal_ == 0 || streamId < numberOfStreamsTotal_); } // to make testing easier
+  bool enabled(unsigned int streamId) const { return enabled_; } // to make testing easier
 
   int numberOfDevices() const { return numberOfDevices_; }
 
@@ -140,7 +140,6 @@ private:
   void *allocate_host(size_t nbytes, cuda::stream_t<>& stream);
 
   int numberOfDevices_ = 0;
-  unsigned int numberOfStreamsTotal_ = 0;
   std::vector<std::pair<int, int>> computeCapabilities_;
   bool enabled_ = false;
 };

--- a/HeterogeneousCore/CUDAServices/interface/CUDAService.h
+++ b/HeterogeneousCore/CUDAServices/interface/CUDAService.h
@@ -48,11 +48,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
-  // To be used in global context when an edm::Stream is not available
   bool enabled() const { return enabled_; }
-  // To be used in stream context when an edm::Stream is available
-  bool enabled(edm::StreamID streamId) const { return enabled(static_cast<unsigned int>(streamId)); }
-  bool enabled(unsigned int streamId) const { return enabled_; } // to make testing easier
 
   int numberOfDevices() const { return numberOfDevices_; }
 

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -129,12 +129,6 @@ CUDAService::CUDAService(edm::ParameterSet const& config, edm::ActivityRegistry&
   computeCapabilities_.reserve(numberOfDevices_);
   log << "CUDA runtime successfully initialised, found " << numberOfDevices_ << " compute devices.\n\n";
 
-  auto numberOfStreamsPerDevice = config.getUntrackedParameter<unsigned int>("numberOfStreamsPerDevice");
-  if (numberOfStreamsPerDevice > 0) {
-    numberOfStreamsTotal_ = numberOfStreamsPerDevice * numberOfDevices_;
-    log << "Number of edm::Streams per CUDA device has been set to " << numberOfStreamsPerDevice << ", for a total of " << numberOfStreamsTotal_ << " edm::Streams across all CUDA device(s).\n\n";
-  }
-
   auto const& limits = config.getUntrackedParameter<edm::ParameterSet>("limits");
   auto printfFifoSize               = limits.getUntrackedParameter<int>("cudaLimitPrintfFifoSize");
   auto stackSize                    = limits.getUntrackedParameter<int>("cudaLimitStackSize");
@@ -365,7 +359,6 @@ CUDAService::~CUDAService() {
 void CUDAService::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
   edm::ParameterSetDescription desc;
   desc.addUntracked<bool>("enabled", true);
-  desc.addUntracked<unsigned int>("numberOfStreamsPerDevice", 0)->setComment("Upper limit of the number of edm::Streams that will run on a single CUDA GPU device. The remaining edm::Streams will be run only on other devices (for time being this means CPU in practice).\nThe value '0' means 'unlimited', a value >= 1 imposes the limit.");
 
   edm::ParameterSetDescription limits;
   limits.addUntracked<int>("cudaLimitPrintfFifoSize", -1)->setComment("Size in bytes of the shared FIFO used by the printf() device system call.");

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -41,7 +41,6 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
   SECTION("CUDAService enabled") {
     edm::ParameterSet ps;
     ps.addUntrackedParameter("enabled", true);
-    ps.addUntrackedParameter("numberOfStreamsPerDevice", 0U);
     SECTION("Enabled only if there are CUDA capable GPUs") {
       auto cs = makeCUDAService(ps, ar);
       if(deviceCount <= 0) {
@@ -129,45 +128,9 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
   SECTION("Force to be disabled") {
     edm::ParameterSet ps;
     ps.addUntrackedParameter("enabled", false);
-    ps.addUntrackedParameter("numberOfStreamsPerDevice", 0U);
     auto cs = makeCUDAService(ps, ar);
     REQUIRE(cs.enabled() == false);
     REQUIRE(cs.numberOfDevices() == 0);
-  }
-
-  SECTION("Limit number of edm::Streams per device") {
-    edm::ParameterSet ps;
-    ps.addUntrackedParameter("enabled", true);
-    SECTION("Unlimited") {
-      ps.addUntrackedParameter("numberOfStreamsPerDevice", 0U);
-      auto cs = makeCUDAService(ps, ar);
-      REQUIRE(cs.enabled() == true);
-      REQUIRE(cs.enabled(0) == true);
-      REQUIRE(cs.enabled(100) == true);
-      REQUIRE(cs.enabled(100*deviceCount) == true);
-      REQUIRE(cs.enabled(std::numeric_limits<unsigned int>::max()) == true);
-    }
-
-    SECTION("Limit to 1") {
-      ps.addUntrackedParameter("numberOfStreamsPerDevice", 1U);
-      auto cs = makeCUDAService(ps, ar);
-      REQUIRE(cs.enabled() == true);
-      REQUIRE(cs.enabled(0) == true);
-      REQUIRE(cs.enabled(1*deviceCount-1) == true);
-      REQUIRE(cs.enabled(1*deviceCount) == false);
-      REQUIRE(cs.enabled(1*deviceCount+1) == false);
-    }
-
-    SECTION("Limit to 2") {
-      ps.addUntrackedParameter("numberOfStreamsPerDevice", 2U);
-      auto cs = makeCUDAService(ps, ar);
-      REQUIRE(cs.enabled() == true);
-      REQUIRE(cs.enabled(0) == true);
-      REQUIRE(cs.enabled(1*deviceCount) == true);
-      REQUIRE(cs.enabled(2*deviceCount-1) == true);
-      REQUIRE(cs.enabled(2*deviceCount) == false);
-    }
-
   }
 
   SECTION("Device allocator") {

--- a/HeterogeneousCore/Producer/test/testGPU_cfg.py
+++ b/HeterogeneousCore/Producer/test/testGPU_cfg.py
@@ -30,6 +30,3 @@ process.p.associate(process.t)
 
 # Example of disabling CUDA device type for one module via configuration
 #process.prod4.heterogeneousEnabled_.GPUCuda = False
-
-# Example of limiting the number of EDM streams per device
-#process.CUDAService.numberOfStreamsPerDevice = 1


### PR DESCRIPTION
Currently the `SwitchProducer(CUDA)` (see #100) decides between CPU and GPU algorithm at the beginning of the job. This approach does not allow supporting the `numberOfStreamsPerDevice` parameter of `CUDAService`. Therefore this PR suggests to remove that functionality from `CUDAService`.

If the feature is wanted back, the SwitchProducer would have to be enhanced to do the device type decisions event-by-event (see #281).
