### PR TITLE
bugfix - change treatment of GPU tracks not on CPU

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexHeterogeneousProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexHeterogeneousProducer.cc
@@ -205,7 +205,7 @@ void PixelVertexHeterogeneousProducer::produceGPUCuda(
       assert(it< (*tuples_).indToEdm.size());
       auto k = (*tuples_).indToEdm[it];
       if (k>tracks.size()) {
-        std::cout << "oops track " << it << " does not exists on CPU " << k << std::endl;
+        edm::LogWarning("PixelVertexHeterogeneousProducer") << "oops track " << it << " does not exists on CPU " << k;
         continue;
       }
       auto tk = reco::TrackRef(trackCollection, k);

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexHeterogeneousProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexHeterogeneousProducer.cc
@@ -204,7 +204,10 @@ void PixelVertexHeterogeneousProducer::produceGPUCuda(
     for (auto it: itrk) {
       assert(it< (*tuples_).indToEdm.size());
       auto k = (*tuples_).indToEdm[it];
-      assert(k<tracks.size());
+      if (k>tracks.size()) {
+        std::cout << "oops track " << it << " does not exists on CPU " << k << std::endl;
+        continue;
+      }
       auto tk = reco::TrackRef(trackCollection, k);
       v.add(reco::TrackBaseRef(tk));
     }


### PR DESCRIPTION
In very rare cases a GPU track, which does not exist on the CPU, might be created. 
This is due to the fact that the clusterizer is not exactly the same and a single hit difference in very rare cases could lead to a single track difference.
Currently the treatment for this track, which is not found on the CPU is to throw an assert. 
This PR changes this assert into a skip of the track, fix by @VinInn 