### PR TITLE
Fix the sizes of stream and event caches

### DIFF
--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -334,8 +334,8 @@ CUDAService::CUDAService(edm::ParameterSet const& config, edm::ActivityRegistry&
     log << "cub::CachingDeviceAllocator disabled\n";
   }
 
-  cudaStreamCache_ = std::make_unique<CUDAStreamCache>(numberOfDevices_);
-  cudaEventCache_ = std::make_unique<CUDAEventCache>(numberOfDevices_);
+  cudaStreamCache_ = std::make_unique<CUDAStreamCache>(lastDevice+1);
+  cudaEventCache_ = std::make_unique<CUDAEventCache>(lastDevice+1);
 
   log << "\n";
 


### PR DESCRIPTION
Needed after #286 to have the device indexing correct inside the caches.