### PR TITLE
Create CUDA events for CUDAProduct only when needed

### DIFF
--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -40,8 +40,8 @@ private:
   friend class CUDAScopedContext;
   friend class edm::Wrapper<CUDAProduct<T>>;
 
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, T data):
-    CUDAProductBase(device, std::move(stream)),
+  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event, T data):
+    CUDAProductBase(device, std::move(stream), std::move(event)),
     data_(std::move(data))
   {}
 

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -14,6 +14,7 @@ public:
   CUDAProductBase() = default; // Needed only for ROOT dictionary generation
 
   bool isValid() const { return stream_.get() != nullptr; }
+  bool isAvailable() const;
 
   int device() const { return device_; }
 
@@ -21,11 +22,11 @@ public:
   cuda::stream_t<>& stream() { return *stream_; }
   const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
 
-  const cuda::event_t& event() const { return *event_; }
-  cuda::event_t& event() { return *event_; }
+  const cuda::event_t *event() const { return event_.get(); }
+  cuda::event_t *event() { return event_.get(); }
 
 protected:
-  explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream);
+  explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event);
 
 private:
   // The cuda::stream_t is really shared among edm::Event products, so

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -68,7 +68,7 @@ public:
 
   template <typename T>
   const T& get(const CUDAProduct<T>& data) {
-    synchronizeStreams(data.device(), data.stream(), data.event());
+    synchronizeStreams(data.device(), data.stream(), data.isAvailable(), data.event());
     return data.data_;
   }
 
@@ -78,32 +78,36 @@ public:
   }
 
   template <typename T>
-  std::unique_ptr<CUDAProduct<T> > wrap(T data) const {
+  std::unique_ptr<CUDAProduct<T> > wrap(T data) {
+    createEventIfStreamBusy();
     // make_unique doesn't work because of private constructor
     //
     // CUDAProduct<T> constructor records CUDA event to the CUDA
     // stream. The event will become "occurred" after all work queued
     // to the stream before this point has been finished.
-    return std::unique_ptr<CUDAProduct<T> >(new CUDAProduct<T>(device(), streamPtr(), std::move(data)));
+    return std::unique_ptr<CUDAProduct<T> >(new CUDAProduct<T>(device(), streamPtr(), event_, std::move(data)));
   }
 
   template <typename T, typename... Args>
-  auto emplace(edm::Event& iEvent, edm::EDPutTokenT<T> token, Args&&... args) const {
-    return iEvent.emplace(token, device(), streamPtr(), std::forward<Args>(args)...);
+  auto emplace(edm::Event& iEvent, edm::EDPutTokenT<T> token, Args&&... args) {
+    createEventIfStreamBusy();
+    return iEvent.emplace(token, device(), streamPtr(), event_, std::forward<Args>(args)...);
   }
 
 private:
   friend class cudatest::TestCUDAScopedContext;
 
   // This construcor is only meant for testing
-  explicit CUDAScopedContext(int device, std::unique_ptr<cuda::stream_t<>> stream);
+  explicit CUDAScopedContext(int device, std::unique_ptr<cuda::stream_t<>> stream, std::unique_ptr<cuda::event_t> event);
 
-  void synchronizeStreams(int dataDevice, const cuda::stream_t<>& dataStream, const cuda::event_t& dataEvent);
+  void createEventIfStreamBusy();
+  void synchronizeStreams(int dataDevice, const cuda::stream_t<>& dataStream, bool available, const cuda::event_t *dataEvent);
 
   int currentDevice_;
   std::optional<edm::WaitingTaskWithArenaHolder> waitingTaskHolder_;
   cuda::device::current::scoped_override_t<> setDeviceForThisScope_;
   std::shared_ptr<cuda::stream_t<>> stream_;
+  std::shared_ptr<cuda::event_t> event_;
 };
 
 #endif

--- a/HeterogeneousCore/CUDACore/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/test/BuildFile.xml
@@ -1,6 +1,10 @@
-<bin file="test*.cc test*.cu" name="testHeterogeneousCoreCUDACore">
+<bin file="test_*.cc test_*.cu" name="testHeterogeneousCoreCUDACore">
   <use name="FWCore/TestProcessor"/>
   <use name="HeterogeneousCore/CUDACore"/>
   <use name="catch2"/>
+  <use name="cuda"/>
+</bin>
+<bin file="testStreamEvent.cu" name="testHeterogeneousCoreCUDACoreStreamEvent">
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="cuda"/>
 </bin>

--- a/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
+++ b/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
@@ -1,0 +1,117 @@
+/**
+ * The purpose of this test program is to ensure that the logic for
+ * CUDA event use in CUDAProduct and CUDAScopedContext
+ */
+
+#include <iostream>
+#include <memory>
+#include <type_traits>
+#include <chrono>
+#include <thread>
+#include <cassert>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+
+namespace {
+  constexpr int ARRAY_SIZE = 20000000;
+  constexpr int NLOOPS = 10;
+}
+
+__global__ void kernel_looping(float* point, unsigned int num) {
+  unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
+
+  for(int iloop=0; iloop<NLOOPS; ++iloop) {
+    for (size_t offset = idx; offset < num; offset += gridDim.x * blockDim.x) {
+      point[offset] += 1;
+    }
+  }
+}
+
+int main() {
+  exitSansCUDADevices();
+
+  constexpr bool debug = false;
+
+  float *dev_points1;
+  float *host_points1;
+  cudaStream_t stream1, stream2;
+  cudaEvent_t event1, event2;
+
+  cudaMalloc(&dev_points1, ARRAY_SIZE * sizeof(float));
+  cudaMallocHost(&host_points1, ARRAY_SIZE * sizeof(float));
+  cudaStreamCreateWithFlags(&stream1, cudaStreamNonBlocking);
+  cudaStreamCreateWithFlags(&stream2, cudaStreamNonBlocking);
+  cudaEventCreate(&event1);
+  cudaEventCreate(&event2);
+
+  for (size_t j = 0; j < ARRAY_SIZE; ++j) {
+    host_points1[j] = static_cast<float>(j);
+  }
+
+  cudaMemcpyAsync(dev_points1, host_points1, 
+                  ARRAY_SIZE * sizeof(float), 
+                  cudaMemcpyHostToDevice, stream1);
+  kernel_looping<<<1, 16, 0, stream1>>>(dev_points1, ARRAY_SIZE);
+  if(debug) std::cout << "Kernel launched on stream1" << std::endl;
+
+  auto status = cudaStreamQuery(stream1);
+  if(debug) std::cout << "Stream1 busy? " << (status == cudaErrorNotReady) << " idle? " << (status == cudaSuccess) << std::endl;
+  cudaEventRecord(event1, stream1);
+  status = cudaEventQuery(event1);
+  if (debug) std::cout << "Event1 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaErrorNotReady);
+
+  status = cudaStreamQuery(stream2);
+  if(debug) std::cout << "Stream2 busy? " << (status == cudaErrorNotReady) << " idle? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaSuccess);
+  if(debug) {
+    cudaEventRecord(event2, stream2);
+    status = cudaEventQuery(event2);
+    std::cout << "Event2 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    status = cudaEventQuery(event2);
+    std::cout << "Event2 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  }
+
+  cudaStreamWaitEvent(stream2, event1, 0);
+  if(debug) std::cout << "\nStream2 waiting for event1" << std::endl;
+  status = cudaStreamQuery(stream2);
+  if(debug) std::cout << "Stream2 busy? " << (status == cudaErrorNotReady) << " idle? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaErrorNotReady);
+  cudaEventRecord(event2, stream2);
+  status = cudaEventQuery(event2);
+  if(debug) std::cout << "Event2 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaErrorNotReady);
+  if(debug) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    status = cudaEventQuery(event2);
+    std::cout << "Event2 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  }
+
+  status = cudaStreamQuery(stream1);
+  if(debug) {
+    std::cout << "\nStream1 busy? " << (status == cudaErrorNotReady) << " idle? " << (status == cudaSuccess) << std::endl;
+    std::cout << "Synchronizing stream1" << std::endl;
+  }
+  assert(status == cudaErrorNotReady);
+  cudaStreamSynchronize(stream1);
+  if(debug) std::cout << "Synchronized stream1" << std::endl;
+
+  status = cudaEventQuery(event1);
+  if(debug) std::cout << "Event1 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaSuccess);
+  status = cudaEventQuery(event2);
+  if(debug) std::cout << "Event2 recorded? " << (status == cudaErrorNotReady) << " occurred? " << (status == cudaSuccess) << std::endl;
+  assert(status == cudaSuccess);
+
+  cudaFree(dev_points1);
+  cudaFreeHost(host_points1);
+  cudaStreamDestroy(stream1);
+  cudaStreamDestroy(stream2);
+  cudaEventDestroy(event1);
+  cudaEventDestroy(event2);
+
+  return 0;
+}

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -81,7 +81,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       cuda::device::current::scoped_override_t<> setDeviceForThisScope(defaultDevice);
       auto current_device = cuda::device::current::get();
 
-      // Mimick a producer on the second CUDA stream
+      // Mimick a producer on the first CUDA stream
       int h_a1 = 1;
       auto d_a1 = cuda::memory::device::make_unique<int>(current_device);
       auto wprod1 = produce(defaultDevice, d_a1.get(), &h_a1);
@@ -96,12 +96,12 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       // Mimick a third producer "joining" the two streams
       CUDAScopedContext ctx2{*wprod1};
 
-      auto prod1 = ctx.get(*wprod1);
-      auto prod2 = ctx.get(*wprod2);
+      auto prod1 = ctx2.get(*wprod1);
+      auto prod2 = ctx2.get(*wprod2);
 
       auto d_a3 = cuda::memory::device::make_unique<int>(current_device);
-      testCUDAScopedContextKernels_join(prod1, prod2, d_a3.get(), ctx.stream());
-      ctx.stream().synchronize();
+      testCUDAScopedContextKernels_join(prod1, prod2, d_a3.get(), ctx2.stream());
+      ctx2.stream().synchronize();
       REQUIRE(wprod2->isAvailable());
       REQUIRE(wprod2->event()->has_occurred());
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -187,11 +187,11 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
   // (because of synchronizations upstream), but let's play generic.
-  if(not hclusters->event().has_occurred()) {
-    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event().id(), 0));
+  if(not hclusters->isAvailable() && hclusters->event()->has_occurred()) {
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-  if(not hdigis->event().has_occurred()) {
-    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event().id(), 0));
+  if(not hdigis->isAvailable() && hdigis->event()->has_occurred()) {
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
 
   edm::Handle<reco::BeamSpot> bsHandle;

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
@@ -199,8 +199,8 @@ void ClusterTPAssociationHeterogeneous::acquireGPUCuda(const edm::HeterogeneousE
     // synchronize explicitly (implementation is from
     // CUDAScopedContext). In practice these should not be needed
     // (because of synchronizations upstream), but let's play generic.
-    if(not gd->event().has_occurred()) {
-      cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gd->event().id(), 0));
+    if(not gd->isAvailable() and gd->event()->has_occurred()) {
+      cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gd->event()->id(), 0));
     }
 
     edm::Handle<siPixelRecHitsHeterogeneousProduct::GPUProduct> gh;


### PR DESCRIPTION
Do not create event if the CUDA stream is idle, i.e. has already
finished all work that was queued, at the point when data products are
wrapped/emplaced for/to `edm::Event`.

When creating an event, create only a single event per producer, i.e.
all products of a producer share the same event.

Fixes #287.