### PR TITLE
Simplify SiPixelFedCablingMapGPU SoA

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPU.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPU.h
@@ -8,20 +8,19 @@ namespace pixelgpudetails {
   constexpr unsigned int MAX_LINK =  48;  // maximum links/channels for Phase 1
   constexpr unsigned int MAX_ROC  =   8;
   constexpr unsigned int MAX_SIZE = MAX_FED * MAX_LINK * MAX_ROC;
-  constexpr unsigned int MAX_SIZE_BYTE_INT  = MAX_SIZE * sizeof(unsigned int);
   constexpr unsigned int MAX_SIZE_BYTE_BOOL = MAX_SIZE * sizeof(unsigned char);
 }
 
 // TODO: since this has more information than just cabling map, maybe we should invent a better name?
 struct SiPixelFedCablingMapGPU {
+  unsigned int fed[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned int link[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned int roc[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned int RawId[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned int rocInDet[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned int moduleId[pixelgpudetails::MAX_SIZE] alignas(128);
+  unsigned char badRocs[pixelgpudetails::MAX_SIZE] alignas(128);
   unsigned int size = 0;
-  unsigned int * fed = nullptr;
-  unsigned int * link = nullptr;
-  unsigned int * roc = nullptr;
-  unsigned int * RawId = nullptr;
-  unsigned int * rocInDet = nullptr;
-  unsigned int * moduleId = nullptr;
-  unsigned char * badRocs = nullptr;
 };
 
 #endif

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
@@ -33,21 +33,15 @@ public:
 
 private:
   const SiPixelFedCablingMap *cablingMap_;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  fedMap;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  linkMap;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  rocMap;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  RawId;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  rocInDet;
-  std::vector<unsigned int,  CUDAHostAllocator<unsigned int>>  moduleId;
-  std::vector<unsigned char, CUDAHostAllocator<unsigned char>> badRocs;
   std::vector<unsigned char, CUDAHostAllocator<unsigned char>> modToUnpDefault;
   unsigned int size;
   bool hasQuality_;
 
+  SiPixelFedCablingMapGPU *cablingMapHost = nullptr; // pointer to struct in CPU
+
   struct GPUData {
     ~GPUData();
-    SiPixelFedCablingMapGPU *cablingMapHost = nullptr;   // internal pointers are to GPU, struct itself is on CPU
-    SiPixelFedCablingMapGPU *cablingMapDevice = nullptr; // same internal pointers as above, struct itself is on GPU
+    SiPixelFedCablingMapGPU *cablingMapDevice = nullptr; // pointer to struct in GPU
   };
   CUDAESProduct<GPUData> gpuData_;
 


### PR DESCRIPTION
I wanted to dump the `SiPixelFedCablingMapGPU` to a file for some standalone testing (we can talk about that next week), and easiest was to try out the suggestion https://github.com/cms-patatrack/cmssw/issues/272#issuecomment-466065123 since the arrays were allocated to compile-time maximum size anyway.