### PR TITLE
Silence nvcc warnings

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -27,6 +27,7 @@
 <bin file="radixSort_t.cu" name="gpuRadixSort_debug">
   <use name="cuda-api-wrappers"/>
   <flags CUDA_FLAGS="-g -G -DGPU_DEBUG"/>
+  <flags REM_CUDA_FLAGS="--generate-line-info -lineinfo"/>
 </bin>
 
 <bin file="HistoContainer_t.cpp">
@@ -43,6 +44,7 @@
   <use name="cuda-api-wrappers"/>
   <use name="cub"/>
   <flags CUDA_FLAGS="-g -G -DGPU_DEBUG"/>
+  <flags REM_CUDA_FLAGS="--generate-line-info -lineinfo"/>
 </bin>
 
 <bin file="OneHistoContainer_t.cu" name="gpuOneHistoContainer_t">

--- a/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
@@ -94,7 +94,7 @@ void go(bool useShared) {
 
   if (i<2) std::cout << "lauch for " << offsets[blocks] << std::endl;
 
-  auto ntXBl = 1==i%4 ? 256 : 256;
+  auto ntXBl __attribute__((unused)) = 1==i%4 ? 256 : 256;
 
   delta -= (std::chrono::high_resolution_clock::now()-start);
   constexpr int MaxSize = 256*32;


### PR DESCRIPTION
`nvcc`/`cicc` are picky about conflicting command line arguments, and tend to generate false positives for unused variables.