### PR TITLE
Remove unused variable from SiPixelDigisFromSoA

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -44,8 +44,6 @@ namespace {
       return true;
     }
   };
-
-  constexpr uint32_t dummydetid = 0xffffffff;
 }
 
 class SiPixelDigisClustersFromSoA: public edm::global::EDProducer<> {


### PR DESCRIPTION
#### PR description:

Fix for the clang warning in #26402.