### PR TITLE
Move BeamSpot transfer to GPU to its own producer

### DIFF
--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="FWCore/ServiceRegistry"/>
+<use name="HeterogeneousCore/CUDAServices"/>
+<use name="cuda-api-wrappers"/>
+<use name="rootcore"/>
+
+<export>
+    <lib name="1"/>
+</export>

--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -1,0 +1,33 @@
+#ifndef CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
+#define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+#include <cuda/api_wrappers.h>
+
+class BeamSpotCUDA {
+public:
+  // alignas(128) doesn't really make sense as there is only one
+  // beamspot per event? 
+  struct Data {
+    float x,y,z;   // position
+    // TODO: add covariance matrix
+
+    float sigmaZ;
+    float beamWidthX, beamWidthY;
+    float dxdz, dydz;
+    float emittanceX, emittanceY;
+    float betaStar;
+  };
+
+  BeamSpotCUDA() = default;
+  BeamSpotCUDA(cudautils::host::unique_ptr<Data> data_h, cuda::stream_t<>& stream);
+
+  Data const* data() const { return data_d_.get(); }
+
+private:
+  cudautils::device::unique_ptr<Data> data_d_;
+};
+
+#endif

--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -2,7 +2,6 @@
 #define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 
 #include <cuda/api_wrappers.h>
 
@@ -22,7 +21,7 @@ public:
   };
 
   BeamSpotCUDA() = default;
-  BeamSpotCUDA(cudautils::host::unique_ptr<Data> data_h, cuda::stream_t<>& stream);
+  BeamSpotCUDA(Data const* data_h, cuda::stream_t<>& stream);
 
   Data const* data() const { return data_d_.get(); }
 

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -2,11 +2,10 @@
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 
-BeamSpotCUDA::BeamSpotCUDA(cudautils::host::unique_ptr<Data> data_h, cuda::stream_t<>& stream) {
+BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cuda::stream_t<>& stream) {
   edm::Service<CUDAService> cs;
 
   data_d_ = cs->make_device_unique<Data>(stream);
-  cudautils::copyAsync(data_d_, data_h, stream);
+  cuda::memory::async::copy(data_d_.get(), data_h, sizeof(Data), stream.id());
 }

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -1,0 +1,12 @@
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+
+BeamSpotCUDA::BeamSpotCUDA(cudautils::host::unique_ptr<Data> data_h, cuda::stream_t<>& stream) {
+  edm::Service<CUDAService> cs;
+
+  data_d_ = cs->make_device_unique<Data>(stream);
+  cudautils::copyAsync(data_d_, data_h, stream);
+}

--- a/CUDADataFormats/BeamSpot/src/classes.h
+++ b/CUDADataFormats/BeamSpot/src/classes.h
@@ -1,0 +1,8 @@
+#ifndef CUDADataFormats_BeamSpot_classes_h
+#define CUDADataFormats_BeamSpot_classes_h
+
+#include "CUDADataFormats/Common/interface/CUDAProduct.h"
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#endif

--- a/CUDADataFormats/BeamSpot/src/classes_def.xml
+++ b/CUDADataFormats/BeamSpot/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="CUDAProduct<BeamSpotCUDA>" persistent="false"/>
+  <class name="edm::Wrapper<CUDAProduct<BeamSpotCUDA>>" persistent="false"/>
+</lcgdict>

--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -45,6 +45,12 @@ private:
     data_(std::move(data))
   {}
 
+  template <typename... Args>
+  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event, Args&&... args):
+    CUDAProductBase(device, std::move(stream), std::move(event)),
+    data_(std::forward<Args>(args)...)
+  {}
+
   T data_; //!
 };
 

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -198,9 +198,9 @@ logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstru
 reconstruction_trackingOnly = cms.Sequence(localreco*globalreco_tracking)
 reconstruction_pixelTrackingOnly = cms.Sequence(
     pixeltrackerlocalreco*
-    offlineBeamSpot*
     siPixelClusterShapeCachePreSplitting*
-    recopixelvertexing
+    recopixelvertexing,
+    offlineBeamSpotTask
 )
 
 #need a fully expanded sequence copy

--- a/HeterogeneousCore/CUDAUtilities/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="cub"/>
 <use name="cuda"/>
+<use name="cuda-api-wrappers"/>
 
 <export>
     <lib name="1"/>

--- a/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
@@ -1,0 +1,65 @@
+#ifndef HeterogeneousCore_CUDAUtilities_interface_host_noncached_unique_ptr_h
+#define HeterogeneousCore_CUDAUtilities_interface_host_noncached_unique_ptr_h
+
+#include <memory>
+
+#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  namespace host {
+    namespace noncached {
+      namespace impl {
+        // Additional layer of types to distinguish from host::unique_ptr
+        class HostDeleter {
+        public:
+          void operator()(void *ptr) {
+            cuda::throw_if_error(cudaFreeHost(ptr));
+          }
+        };
+      }
+
+      template <typename T>
+      using unique_ptr = std::unique_ptr<T, impl::HostDeleter>;
+
+      namespace impl {
+        template <typename T>
+        struct make_host_unique_selector { using non_array = cudautils::host::noncached::unique_ptr<T>; };
+        template <typename T>
+        struct make_host_unique_selector<T[]> { using unbounded_array = cudautils::host::noncached::unique_ptr<T[]>; };
+        template <typename T, size_t N>
+        struct make_host_unique_selector<T[N]> { struct bounded_array {}; };
+      }
+    }
+  }
+
+  /**
+   * The difference wrt. CUDAService::make_host_unique is that these
+   * do not cache, so they should not be called per-event.
+   */
+  template <typename T>
+  typename host::noncached::impl::make_host_unique_selector<T>::non_array
+  make_host_noncached_unique(unsigned int flags = cudaHostAllocDefault) {
+    static_assert(std::is_trivially_constructible<T>::value, "Allocating with non-trivial constructor on the pinned host memory is not supported");
+    void *mem;
+    cuda::throw_if_error(cudaHostAlloc(&mem, sizeof(T), flags));
+    return typename cudautils::host::noncached::impl::make_host_unique_selector<T>::non_array(reinterpret_cast<T *>(mem));
+  }
+
+  template <typename T>
+  typename host::noncached::impl::make_host_unique_selector<T>::unbounded_array
+  make_host_noncached_unique(size_t n, unsigned int flags = cudaHostAllocDefault) {
+    using element_type = typename std::remove_extent<T>::type;
+    static_assert(std::is_trivially_constructible<element_type>::value, "Allocating with non-trivial constructor on the pinned host memory is not supported");
+    void *mem;
+    cuda::throw_if_error(cudaHostAlloc(&mem, n*sizeof(element_type), flags));
+    return typename cudautils::host::noncached::impl::make_host_unique_selector<T>::unbounded_array(reinterpret_cast<element_type *>(mem));
+  }
+
+  template <typename T, typename ...Args>
+  typename cudautils::host::noncached::impl::make_host_unique_selector<T>::bounded_array
+  make_host_noncached_unique(Args&&...) = delete;
+}
+
+#endif
+

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -68,7 +68,7 @@
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>
 
-<bin file="testCatch2Main.cpp,copyAsync_t.cpp,memsetAsync_t.cpp" name="cudaMemUtils_t">
+<bin file="testCatch2Main.cpp,copyAsync_t.cpp,memsetAsync_t.cpp,host_noncached_unique_ptr_t.cpp" name="cudaMemUtils_t">
   <use name="HeterogeneousCore/CUDAServices"/>
   <use name="catch2"/>
 </bin>

--- a/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
@@ -1,0 +1,22 @@
+#include "catch.hpp"
+
+#include "HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+
+TEST_CASE("host_noncached_unique_ptr", "[cudaMemTools]") {
+  exitSansCUDADevices();
+
+  SECTION("Single element") {
+    auto ptr1 = cudautils::make_host_noncached_unique<int>();
+    REQUIRE(ptr1 != nullptr);
+    auto ptr2 = cudautils::make_host_noncached_unique<int>(cudaHostAllocPortable | cudaHostAllocWriteCombined);
+    REQUIRE(ptr2 != nullptr);
+  }
+
+  SECTION("Multiple elements") {
+    auto ptr1 = cudautils::make_host_noncached_unique<int[]>(10);
+    REQUIRE(ptr1 != nullptr);
+    auto ptr2 = cudautils::make_host_noncached_unique<int[]>(10, cudaHostAllocPortable | cudaHostAllocWriteCombined);
+    REQUIRE(ptr2 != nullptr);
+  }
+}

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -45,10 +45,9 @@ namespace pixelgpudetails {
   // number of words for all the FEDs
   constexpr uint32_t MAX_FED_WORDS   = pixelgpudetails::MAX_FED * pixelgpudetails::MAX_WORD;
 
-  SiPixelRawToClusterGPUKernel::WordFedAppender::WordFedAppender(cuda::stream_t<>& cudaStream) {
-    edm::Service<CUDAService> cs;
-    word_ = cs->make_host_unique<unsigned int[]>(MAX_FED_WORDS, cudaStream);
-    fedId_ = cs->make_host_unique<unsigned char[]>(MAX_FED_WORDS, cudaStream);
+  SiPixelRawToClusterGPUKernel::WordFedAppender::WordFedAppender() {
+    word_ = cudautils::make_host_noncached_unique<unsigned int[]>(MAX_FED_WORDS, cudaHostAllocWriteCombined);
+    fedId_ = cudautils::make_host_noncached_unique<unsigned char[]>(MAX_FED_WORDS, cudaHostAllocWriteCombined);
   }
 
   void SiPixelRawToClusterGPUKernel::WordFedAppender::initializeWordFed(int fedId, unsigned int wordCounterGPU, const cms_uint32_t *src, unsigned int length) {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -11,6 +11,7 @@
 #include "FWCore/Utilities/interface/typedefs.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h"
 #include "DataFormats/SiPixelDigi/interface/PixelErrors.h"
 
 struct SiPixelFedCablingMapGPU;
@@ -159,7 +160,7 @@ namespace pixelgpudetails {
   public:
     class WordFedAppender {
     public:
-      WordFedAppender(cuda::stream_t<>& cudaStream);
+      WordFedAppender();
       ~WordFedAppender() = default;
 
       void initializeWordFed(int fedId, unsigned int wordCounterGPU, const cms_uint32_t *src, unsigned int length);
@@ -168,8 +169,8 @@ namespace pixelgpudetails {
       const unsigned char *fedId() const { return fedId_.get(); }
 
     private:
-      cudautils::host::unique_ptr<unsigned int[]> word_;
-      cudautils::host::unique_ptr<unsigned char[]> fedId_;
+      cudautils::host::noncached::unique_ptr<unsigned int[]> word_;
+      cudautils::host::noncached::unique_ptr<unsigned char[]> fedId_;
     };
 
     SiPixelRawToClusterGPUKernel() = default;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CUDADataFormats/BeamSpot"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/Producer"/>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -1,6 +1,7 @@
 #ifndef RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
 #define RecoLocalTracker_SiPixelRecHits_plugins_PixelRecHits_h
 
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "CUDADataFormats/SiPixelCluster/interface/SiPixelClustersCUDA.h"
 #include "CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDA.h"
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusteringConstants.h"
@@ -34,7 +35,7 @@ namespace pixelgpudetails {
 
     void makeHitsAsync(SiPixelDigisCUDA const& digis_d,
                        SiPixelClustersCUDA const& clusters_d,
-                       float const * bs,
+                       BeamSpotCUDA const& bs_d,
                        pixelCPEforGPU::ParamsOnGPU const * cpeParams,
                        bool transferToCPU,
                        cuda::stream_t<>& stream);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -191,13 +191,13 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
   // (because of synchronizations upstream), but let's play generic.
-  if(not hclusters->isAvailable() && hclusters->event()->has_occurred()) {
+  if(not hclusters->isAvailable() and not hclusters->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-  if(not hdigis->isAvailable() && hdigis->event()->has_occurred()) {
+  if(not hdigis->isAvailable() and not hdigis->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-  if(not hbs->isAvailable() && hbs->event()->has_occurred()) {
+  if(not hbs->isAvailable() and not hbs->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hbs->event()->id(), 0));
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -1,9 +1,9 @@
 #include "CUDADataFormats/Common/interface/CUDAProduct.h"
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "CUDADataFormats/SiPixelCluster/interface/SiPixelClustersCUDA.h"
 #include "CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDA.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -64,8 +64,8 @@ private:
   void run(const edm::Handle<SiPixelClusterCollectionNew>& inputhandle, SiPixelRecHitCollectionNew &output, const pixelgpudetails::HitsOnCPU& hoc) const;
 
 
-  edm::EDGetTokenT<reco::BeamSpot> 	 tBeamSpot;
   // The mess with inputs will be cleaned up when migrating to the new framework
+  edm::EDGetTokenT<CUDAProduct<BeamSpotCUDA>> tBeamSpot;
   edm::EDGetTokenT<CUDAProduct<SiPixelClustersCUDA>> token_;
   edm::EDGetTokenT<CUDAProduct<SiPixelDigisCUDA>> tokenDigi_;
   edm::EDGetTokenT<SiPixelClusterCollectionNew> clusterToken_;
@@ -82,7 +82,7 @@ private:
 
 SiPixelRecHitHeterogeneous::SiPixelRecHitHeterogeneous(const edm::ParameterSet& iConfig):
   HeterogeneousEDProducer(iConfig),
-  tBeamSpot(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+  tBeamSpot(consumes<CUDAProduct<BeamSpotCUDA>>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
   token_(consumes<CUDAProduct<SiPixelClustersCUDA>>(iConfig.getParameter<edm::InputTag>("heterogeneousSrc"))),
   tokenDigi_(consumes<CUDAProduct<SiPixelDigisCUDA>>(iConfig.getParameter<edm::InputTag>("heterogeneousSrc"))),
   cpeName_(iConfig.getParameter<std::string>("CPE"))
@@ -100,7 +100,7 @@ SiPixelRecHitHeterogeneous::SiPixelRecHitHeterogeneous(const edm::ParameterSet& 
 void SiPixelRecHitHeterogeneous::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpotCUDA"));
   desc.add<edm::InputTag>("heterogeneousSrc", edm::InputTag("siPixelClustersCUDAPreSplitting"));
   desc.add<edm::InputTag>("src", edm::InputTag("siPixelClustersPreSplitting"));
   desc.add<std::string>("CPE", "PixelCPEFast");
@@ -183,6 +183,10 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   iEvent.getByToken(tokenDigi_, hdigis);
   auto const& digis = ctx.get(*hdigis);
 
+  edm::Handle<CUDAProduct<BeamSpotCUDA>> hbs;
+  iEvent.getByToken(tBeamSpot, hbs);
+  auto const& bs = ctx.get(*hbs);
+
   // We're processing in a stream given by base class, so need to
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
@@ -193,13 +197,8 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   if(not hdigis->isAvailable() && hdigis->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-
-  edm::Handle<reco::BeamSpot> bsHandle;
-  iEvent.getByToken( tBeamSpot, bsHandle);
-  float bs[3] = {0.f};
-  if(bsHandle.isValid()) {
-    const auto  & bsh = *bsHandle;
-    bs[0]=bsh.x0(); bs[1]=bsh.y0(); bs[2]=bsh.z0();
+  if(not hbs->isAvailable() && hbs->event()->has_occurred()) {
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hbs->event()->id(), 0));
   }
 
   gpuAlgo_->makeHitsAsync(digis, clusters, bs, fcpe->getGPUProductAsync(cudaStream), enableTransfer_, cudaStream);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <limits>
 
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h"
@@ -15,7 +16,7 @@ namespace gpuPixelRecHits {
 
 
   __global__ void getHits(pixelCPEforGPU::ParamsOnGPU const * __restrict__  cpeParams,
-                          float const * __restrict__  bs,
+                          BeamSpotCUDA::Data const * __restrict__  bs,
                           uint16_t const * __restrict__  id,
 			  uint16_t const * __restrict__  x,
 			  uint16_t const * __restrict__  y,
@@ -143,9 +144,9 @@ namespace gpuPixelRecHits {
     // to global and compute phi... 
     cpeParams->detParams(me).frame.toGlobal(xl[h],yl[h], xg[h],yg[h],zg[h]);
     // here correct for the beamspot...
-    xg[h]-=bs[0];
-    yg[h]-=bs[1];
-    zg[h]-=bs[2];
+    xg[h]-=bs->x;
+    yg[h]-=bs->y;
+    zg[h]-=bs->z;
 
     rg[h] = std::sqrt(xg[h]*xg[h]+yg[h]*yg[h]);
     iph[h] = unsafe_atan2s<7>(yg[h],xg[h]);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/siPixelRecHitsHeterogeneousProduct.h
@@ -22,7 +22,6 @@ namespace siPixelRecHitsHeterogeneousProduct {
 
   struct HitsOnGPU{
      pixelCPEforGPU::ParamsOnGPU const * cpeParams = nullptr;    // forwarded from setup, NOT owned
-     float * bs_d;
      const uint32_t * hitsModuleStart_d; // forwarded from clusters
      uint32_t * hitsLayerStart_d;
      int32_t  * charge_d;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
@@ -1,0 +1,65 @@
+#include "CUDADataFormats/Common/interface/CUDAProduct.h"
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+
+class BeamSpotToCUDA: public edm::global::EDProducer<> {
+public:
+  explicit BeamSpotToCUDA(const edm::ParameterSet& iConfig);
+  ~BeamSpotToCUDA() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+private:
+  edm::EDGetTokenT<reco::BeamSpot> bsGetToken_;
+  edm::EDPutTokenT<CUDAProduct<BeamSpotCUDA>> bsPutToken_;
+};
+
+BeamSpotToCUDA::BeamSpotToCUDA(const edm::ParameterSet& iConfig):
+  bsGetToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("src"))},
+  bsPutToken_{produces<CUDAProduct<BeamSpotCUDA>>()}
+{}
+
+void BeamSpotToCUDA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("offlineBeamSpot"));
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void BeamSpotToCUDA::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  CUDAScopedContext ctx{streamID};
+
+  const reco::BeamSpot& bs = iEvent.get(bsGetToken_);
+
+  edm::Service<CUDAService> cs;
+  auto bsHost = cs->make_host_unique<BeamSpotCUDA::Data>(ctx.stream());
+  bsHost->x = bs.x0();
+  bsHost->y = bs.y0();
+  bsHost->z = bs.z0();
+
+  bsHost->sigmaZ = bs.sigmaZ();
+  bsHost->beamWidthX = bs.BeamWidthX();
+  bsHost->beamWidthY = bs.BeamWidthY();
+  bsHost->dxdz = bs.dxdz();
+  bsHost->dydz = bs.dydz();
+  bsHost->emittanceX = bs.emittanceX();
+  bsHost->emittanceY = bs.emittanceY();
+  bsHost->betaStar = bs.betaStar();
+
+  ctx.emplace(iEvent, bsPutToken_, std::move(bsHost), ctx.stream());
+}
+
+DEFINE_FWK_MODULE(BeamSpotToCUDA);
+

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -14,6 +14,14 @@
 <library   file="BeamSpotProducer.cc" name="BeamSpotProducer">
   <flags   EDM_PLUGIN="1"/>
 </library>
+<library   file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+  <use name="CUDADataFormats/BeamSpot"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="cuda"/>
+  <use name="cuda-api-wrappers"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>
 <library   file="BeamSpotOnlineProducer.cc" name="BeamSpotOnlineProducer">
   <flags   EDM_PLUGIN="1"/>
   <use name="DataFormats/L1GlobalTrigger"/>

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
@@ -1,4 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
+from RecoVertex.BeamSpotProducer.beamSpotToCUDA_cfi import beamSpotToCUDA as _beamSpotToCUDA
 
+offlineBeamSpotCUDA = _beamSpotToCUDA.clone()
+
+offlineBeamSpotTask = cms.Task(
+    offlineBeamSpot,
+    offlineBeamSpotCUDA
+)


### PR DESCRIPTION
#### PR description:

This PR is a followup to #245 and makes the first attempt to transfer BeamSpot data to GPU in its own producer instead of in rechit producer. I left the covariance matrix for subsequent work as it is not strictly needed at the moment, and currently Eigen apparently does not support minimal storage for symmetric matrices.

In addition, a perfect forwarding overload is added for `CUDAProduct` constructor enabling the use of `CUDAScopedContext::emplace()` in `BeamSpotToCUDA::produce()`.

As in #245, a mechanism is added to create non-cached pinned host memory `unique_ptr`s with the possibility to pass custom flags to `cudaHostAlloc()`. There is one commit for moving the BeamSpot transfer to use once-per-stream-per-job allocated write-combined buffer, and another commit for doing the same for the raw data. A difference wrt. #245 is that the empty `GPU::SimpleVector<PixelErrorCompact>` is still transferred via a pinned host memory from the caching allocator (with the current `SiPixelDigiErrorsCUDA` providing the transfer buffer outside of the class would look ugly, but could be done if really wanted).

#### PR validation:

Tested that a profile configuration runs, and with `nvprof` that the BeamSpot transfer can occur in parallel to e.g. clustering kernels.