### PR TITLE
add ctor for CUDAScopedContext

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -34,6 +34,13 @@ public:
     stream_(std::move(token.streamPtr()))
   {}
 
+  explicit CUDAScopedContext(CUDAContextToken token, 
+          edm::WaitingTaskWithArenaHolder holder)
+      : CUDAScopedContext{std::move(token)}
+  {
+      waitingTaskHolder_ = std::move(holder);
+  }
+
   explicit CUDAScopedContext(const CUDAProductBase& data);
 
   explicit CUDAScopedContext(edm::StreamID streamID, edm::WaitingTaskWithArenaHolder waitingTaskHolder):


### PR DESCRIPTION
#### PR description:

Added a ctor for CUDAScopedContext. The use case is when there is a need to obtain access to a device/stream outside of product/acquire.

```cpp

class SomeProducer : edm::stream::EDProducer<edm::ExternalWork> {
...
CUDAContextToken token_;
}

void SomeProducer::beginStream(edm::StreamID id) {
  CUDAScopedContext ctx{id};

  token_ = ctx.toToken();
  // do allocations/transfers per job
}

void SomeProducer::acquire(edm::Event const& event, edm::EventSetup const& setup
    edm::WaitingTaskWithArenaHolder holder) {
  CUDAScopedContext ctx{std::move(token_), std::move(holder)};

  token_ = ctx.toToken();
  ...
}

void SomeProducer::produce() {
  CUDAScopedContext ctx{std::move(token_)};
  ...

  token_ = ctx.toToken();
}

void SomeProducer::endStream() {
  CUDAScopedContext ctx{std::move(token_)};
  // do the cleaning per job
}
```

The only way we know from which stream we are running between acquire/produce is due to the token. when trying to allocate outside of that, we do not have guarantees that we will obtain the same stream, which should be desirable (_i believe at least, may be i'm wrong on that_). as far as i see CUDAService is not tracking the current device, therefore getCUDAStream method needs current device to be preset... which is the same as using beginStream/endStream and tracking token thru the whole lifetime of the edproducer.

#### PR validation:

no validation except for compiling

