### PR TITLE
Fix the CUDA product availability logic in rechit

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -187,10 +187,10 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
   // (because of synchronizations upstream), but let's play generic.
-  if(not hclusters->isAvailable() && hclusters->event()->has_occurred()) {
+  if(not hclusters->isAvailable() and not hclusters->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-  if(not hdigis->isAvailable() && hdigis->event()->has_occurred()) {
+  if(not hdigis->isAvailable() and not hdigis->event()->has_occurred()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
 


### PR DESCRIPTION
#### PR description:

#292 used incorrect logic to determine whether a CUDA product is ready or not. Thanks to @VinInn for reporting the problem.

#### PR validation:

Code compiles (in 10_6_X_Patatrack) and profiling test job runs.
