### PR TITLE
Fix number of floats per hit

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cc
@@ -78,7 +78,7 @@ void PixelTrackReconstructionGPU::run(TracksWithTTRHs& tracks,
   // We use 3 floats for GlobalPosition and 6 floats for GlobalError (that's what is used by the Riemann fit).
   // Assume a safe maximum of 3K seeds: it will dynamically grow, if needed.
   int total_seeds = 0;
-  hits_and_covariances.reserve(sizeof(float)*3000*(points_in_seed*12));
+  hits_and_covariances.reserve(sizeof(float)*3000*(points_in_seed*9));
   for (auto const & regionHitSets : hitSets) {
     const TrackingRegion& region = regionHitSets.region();
     for (auto const & tuplet : regionHitSets) {
@@ -112,7 +112,7 @@ void PixelTrackReconstructionGPU::run(TracksWithTTRHs& tracks,
       sizeof(float)*hits_and_covariances.size(), cudaMemcpyDefault));
 
   // LAUNCH THE KERNEL FIT
-  launchKernelFit(hits_and_covariancesGPU, 12*4*total_seeds, 4,
+  launchKernelFit(hits_and_covariancesGPU, 9*4*total_seeds, 4,
       bField, helix_fit_resultsGPU);
   // CUDA MEMCOPY DEVICE2HOST OF HELIX_FIT
   cudaCheck(cudaDeviceSynchronize());

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cu
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cu
@@ -25,7 +25,7 @@ KernelFastFitAllHits(float *hits_and_covariances,
   // Loop for hits_in_fit times:
   //   first 3 are the points
   //   the rest is the covariance matrix, 3x3
-  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 12;
+  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 9;
   int helix_start = (blockIdx.x * blockDim.x + threadIdx.x);
   if (start >= cumulative_size) {
     return;
@@ -67,7 +67,7 @@ KernelCircleFitAllHits(float *hits_and_covariances, int hits_in_fit,
   // Loop for hits_in_fit times:
   //   first 3 are the points
   //   the rest is the covariance matrix, 3x3
-  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 12;
+  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 9;
   int helix_start = (blockIdx.x * blockDim.x + threadIdx.x);
   if (start >= cumulative_size) {
     return;
@@ -115,7 +115,7 @@ KernelLineFitAllHits(float *hits_and_covariances, int hits_in_fit,
   // Loop for hits_in_fit times:
   //   first 3 are the points
   //   the rest is the covariance matrix, 3x3
-  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 12;
+  int start = (blockIdx.x * blockDim.x + threadIdx.x) * hits_in_fit * 9;
   int helix_start = (blockIdx.x * blockDim.x + threadIdx.x);
   if (start >= cumulative_size) {
     return;
@@ -162,8 +162,8 @@ void PixelTrackReconstructionGPU::launchKernelFit(
     float B, Rfit::helix_fit *results)
 {
   const dim3 threads_per_block(32, 1);
-  int num_blocks = cumulative_size / (hits_in_fit * 12) / threads_per_block.x + 1;
-  auto numberOfSeeds = cumulative_size / (hits_in_fit * 12);
+  int num_blocks = cumulative_size / (hits_in_fit * 9) / threads_per_block.x + 1;
+  auto numberOfSeeds = cumulative_size / (hits_in_fit * 9);
 
   Rfit::Matrix3xNd<4> *hitsGPU;
   cudaCheck(cudaMalloc(&hitsGPU, 48 * numberOfSeeds * sizeof(Rfit::Matrix3xNd<4>)));


### PR DESCRIPTION
#### PR description:

This PR arises from my attempt to run the Pixel Track reconstruction validation on a local machine.  The problem comes from the 10824.53 workflow when running with the --tool memcheck option. In the step3-memcheck.log file there is a fatal crash:

11-Apr-2019 11:43:35 EDT  Initiating request to open file file:/cms/data/store/relval/CMSSW_10_4_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW/PU25ns_103X_upgrade2018_realistic_v8-v1/10000/29C415\
A1-48E9-8445-A19C-49B84D1505ED.root
11-Apr-2019 11:43:36 EDT  Successfully opened file file:/cms/data/store/relval/CMSSW_10_4_0_pre2/RelValTTbar_13/GEN-SIM-DIGI-RAW/PU25ns_103X_upgrade2018_realistic_v8-v1/10000/29C415A1-48E9\
-8445-A19C-49B84D1505ED.root
Begin processing the 1st record. Run 1, Event 8503, LumiSection 171 on stream 0 at 11-Apr-2019 11:43:44.504 EDT
%MSG-e TkDetLayers:  SeedingLayersEDProducer:pixelTracksSeedLayers  11-Apr-2019 11:43:46 EDT Run: 1 Event: 8503
 ForwardDiskSectorBuilderFromDet: Trying to build Petal Wedge from Dets at different z positions !! Delta_z = -0.950417
%MSG
/data/user/fwyzard/patatrack/build/slc7_amd64_gcc700.patatrack106x/tmp/BUILDROOT/4798e156c43b9007e8153f352738cf66/opt/cmssw/slc7_amd64_gcc700/cms/cmssw/CMSSW_10_6_0_pre2_Patatrack/src/Reco\
PixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cu, line 204: cudaErrorLaunchFailure: unspecified launch failure

In the cuda-memcheck.log file there is more information:

========= CUDA-MEMCHECK
========= Invalid __global__ read of size 4
=========     at 0x000007b0 in /data/user/fwyzard/patatrack/build/slc7_amd64_gcc700.patatrack106x/tmp/BUILDROOT/4798e156c43b9007e8153f352738cf66/opt/cmssw/slc7_amd64_gcc700/cms/cmssw/CMSSW\
_10_6_0_pre2_Patatrack/src/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackReconstructionGPU.cu:42:KernelFastFitAllHits(float*, int, int, float, Rfit::helix_fit*, Eigen::Matrix<doub\
le, int=3, int=4, int=0, int=3, int=4>*, Eigen::Matrix<float, int=6, int=4, int=0, int=6, int=4>*, Rfit::circle_fit*, Eigen::Matrix<double, int=4, int=1, int=0, int=4, int=1>*, Rfit::line_\
fit*)
=========     by thread (23,0,0) in block (11,0,0)
=========     Address 0x7f59ff411940 is out of bounds


This appears to me to be a problem with the number floats assigned per hit. The code assumes 12 but there are only 9, 3 for position and 6 instead of 9 for position errors, presumably because the covariance matrix is assumed to be symmetric. 

#### PR validation:

After this change the 10824.53 workflow when running with the --tool memcheck option runs successfully without any crash. I didn't do any comparison of performance before and after, but would be happy to if I could be pointed to which validation plots are the most relevant. 
