### PR TITLE
Use a single instance of each NVTX Domain for multiple threads

### DIFF
--- a/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
@@ -293,7 +293,6 @@ private:
   const bool                                showModulePrefetching_;
   const bool                                skipFirstEvent_;
 
-  unsigned int                              concurrentStreams_;
   std::atomic<bool>                         globalFirstEventDone_ = false;
   std::vector<std::atomic<bool>>            streamFirstEventDone_;
   std::vector<nvtxRangeId_t>                event_;                 // per-stream event ranges
@@ -301,57 +300,22 @@ private:
   // use a tbb::concurrent_vector rather than an std::vector because its final size is not known
   tbb::concurrent_vector<nvtxRangeId_t>     global_modules_;        // global per-module events
 
-private:
-  struct Domains {
-    nvtxDomainHandle_t              global;
-    std::vector<nvtxDomainHandle_t> stream;
-
-    Domains(NVProfilerService* service) {
-      global = nvtxDomainCreate("EDM Global");
-      allocate_streams(service->concurrentStreams_);
-    }
-
-    ~Domains() {
-      nvtxDomainDestroy(global);
-      for (unsigned int sid = 0; sid < stream.size(); ++sid) {
-        nvtxDomainDestroy(stream[sid]);
-      }
-    }
-
-    void allocate_streams(unsigned int streams) {
-      stream.resize(streams);
-      for (unsigned int sid = 0; sid < streams; ++sid) {
-        stream[sid] = nvtxDomainCreate((boost::format("EDM Stream %d") % sid).str().c_str());
-      }
-    }
-  };
-
-  // allow access to concurrentStreams_
-  friend struct Domains;
-
-  tbb::enumerable_thread_specific<Domains> domains_;
-
-  nvtxDomainHandle_t global_domain() {
-    return domains_.local().global;
-  }
-
-  nvtxDomainHandle_t stream_domain(unsigned int sid) {
-    return domains_.local().stream.at(sid);
-  }
-
+  nvtxDomainHandle_t                        global_domain_;         // NVTX domain for global EDM transitions
+  std::vector<nvtxDomainHandle_t>           stream_domain_;         // NVTX domains for per-EDM-stream transitions
 };
 
 NVProfilerService::NVProfilerService(edm::ParameterSet const & config, edm::ActivityRegistry & registry) :
   highlightModules_(config.getUntrackedParameter<std::vector<std::string>>("highlightModules")),
   showModulePrefetching_(config.getUntrackedParameter<bool>("showModulePrefetching")),
-  skipFirstEvent_(config.getUntrackedParameter<bool>("skipFirstEvent")),
-  concurrentStreams_(0),
-  domains_(this)
+  skipFirstEvent_(config.getUntrackedParameter<bool>("skipFirstEvent"))
 {
   // make sure that CUDA is initialised, and that the CUDAService destructor is called after this service's destructor
   edm::Service<CUDAService> cudaService;
 
   std::sort(highlightModules_.begin(), highlightModules_.end());
+
+  // create the NVTX domain for global EDM transitions
+  global_domain_ = nvtxDomainCreate("EDM Global");
 
   // enables profile collection; if profiling is already enabled it has no effect
   if (not skipFirstEvent_) {
@@ -507,6 +471,10 @@ NVProfilerService::NVProfilerService(edm::ParameterSet const & config, edm::Acti
 }
 
 NVProfilerService::~NVProfilerService() {
+  for (unsigned int sid = 0; sid < stream_domain_.size(); ++sid) {
+    nvtxDomainDestroy(stream_domain_[sid]);
+  }
+  nvtxDomainDestroy(global_domain_);
   cudaProfilerStop();
 }
 
@@ -532,17 +500,20 @@ NVProfilerService::preallocate(edm::service::SystemBounds const& bounds) {
                          << bounds.maxNumberOfConcurrentLuminosityBlocks() << " luminosity sections, "
                          << bounds.maxNumberOfStreams() << " streams\nrunning on"
                          << bounds.maxNumberOfThreads() << " threads";
-  nvtxDomainMark(global_domain(), out.str().c_str());
+  nvtxDomainMark(global_domain_, out.str().c_str());
 
-  concurrentStreams_ = bounds.maxNumberOfStreams();
-  for (auto& domain: domains_) {
-    domain.allocate_streams(concurrentStreams_);
+  auto concurrentStreams = bounds.maxNumberOfStreams();
+  // create the NVTX domains for per-EDM-stream transitions
+  stream_domain_.resize(concurrentStreams);
+  for (unsigned int sid = 0; sid < concurrentStreams; ++sid) {
+    stream_domain_[sid] = nvtxDomainCreate((boost::format("EDM Stream %d") % sid).str().c_str());
   }
-  event_.resize(concurrentStreams_);
-  stream_modules_.resize(concurrentStreams_);
+
+  event_.resize(concurrentStreams);
+  stream_modules_.resize(concurrentStreams);
   if (skipFirstEvent_) {
     globalFirstEventDone_ = false;
-    std::vector<std::atomic<bool>> tmp(concurrentStreams_);
+    std::vector<std::atomic<bool>> tmp(concurrentStreams);
     for (auto & element: tmp)
       std::atomic_init(&element, false);
     streamFirstEventDone_ = std::move(tmp);
@@ -551,13 +522,13 @@ NVProfilerService::preallocate(edm::service::SystemBounds const& bounds) {
 
 void
 NVProfilerService::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes, edm::ProcessContext const& pc) {
-  nvtxDomainMark(global_domain(), "preBeginJob");
+  nvtxDomainMark(global_domain_, "preBeginJob");
 
   // FIXME this probably works only in the absence of subprocesses
   // size() + 1 because pathsAndConsumes.allModules() does not include the source
   unsigned int modules = pathsAndConsumes.allModules().size() + 1;
   global_modules_.resize(modules, nvtxInvalidRangeId);
-  for (unsigned int sid = 0; sid < concurrentStreams_; ++sid) {
+  for (unsigned int sid = 0; sid < stream_modules_.size(); ++sid) {
     stream_modules_[sid].resize(modules, nvtxInvalidRangeId);
   }
 }
@@ -565,84 +536,84 @@ NVProfilerService::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAn
 void
 NVProfilerService::postBeginJob() {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainMark(global_domain(), "postBeginJob");
+    nvtxDomainMark(global_domain_, "postBeginJob");
   }
 }
 
 void
 NVProfilerService::postEndJob() {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainMark(global_domain(), "postEndJob");
+    nvtxDomainMark(global_domain_, "postEndJob");
   }
 }
 
 void
 NVProfilerService::preSourceEvent(edm::StreamID sid) {
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePush(stream_domain(sid), "source");
+    nvtxDomainRangePush(stream_domain_[sid], "source");
   }
 }
 
 void
 NVProfilerService::postSourceEvent(edm::StreamID sid) {
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePop(stream_domain(sid));
+    nvtxDomainRangePop(stream_domain_[sid]);
   }
 }
 
 void
 NVProfilerService::preSourceLumi(edm::LuminosityBlockIndex index) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "source lumi");
+    nvtxDomainRangePush(global_domain_, "source lumi");
   }
 }
 
 void
 NVProfilerService::postSourceLumi(edm::LuminosityBlockIndex index) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
 void
 NVProfilerService::preSourceRun(edm::RunIndex index) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "source run");
+    nvtxDomainRangePush(global_domain_, "source run");
   }
 }
 
 void
 NVProfilerService::postSourceRun(edm::RunIndex index) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
 void
 NVProfilerService::preOpenFile(std::string const& lfn, bool) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), ("open file "s + lfn).c_str());
+    nvtxDomainRangePush(global_domain_, ("open file "s + lfn).c_str());
   }
 }
 
 void
 NVProfilerService::postOpenFile(std::string const& lfn, bool) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
 void
 NVProfilerService::preCloseFile(std::string const & lfn, bool) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), ("close file "s + lfn).c_str());
+    nvtxDomainRangePush(global_domain_, ("close file "s + lfn).c_str());
   }
 }
 
 void
 NVProfilerService::postCloseFile(std::string const& lfn, bool) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
@@ -654,7 +625,7 @@ NVProfilerService::preModuleBeginStream(edm::StreamContext const& sc, edm::Modul
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " begin stream";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -663,7 +634,7 @@ NVProfilerService::postModuleBeginStream(edm::StreamContext const& sc, edm::Modu
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -676,7 +647,7 @@ NVProfilerService::preModuleEndStream(edm::StreamContext const& sc, edm::ModuleC
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " end stream";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -685,7 +656,7 @@ NVProfilerService::postModuleEndStream(edm::StreamContext const& sc, edm::Module
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -693,28 +664,28 @@ NVProfilerService::postModuleEndStream(edm::StreamContext const& sc, edm::Module
 void
 NVProfilerService::preGlobalBeginRun(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "global begin run");
+    nvtxDomainRangePush(global_domain_, "global begin run");
   }
 }
 
 void
 NVProfilerService::postGlobalBeginRun(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
 void
 NVProfilerService::preGlobalEndRun(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "global end run");
+    nvtxDomainRangePush(global_domain_, "global end run");
   }
 }
 
 void
 NVProfilerService::postGlobalEndRun(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
@@ -722,7 +693,7 @@ void
 NVProfilerService::preStreamBeginRun(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePush(stream_domain(sid), "stream begin run");
+    nvtxDomainRangePush(stream_domain_[sid], "stream begin run");
   }
 }
 
@@ -730,7 +701,7 @@ void
 NVProfilerService::postStreamBeginRun(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePop(stream_domain(sid));
+    nvtxDomainRangePop(stream_domain_[sid]);
   }
 }
 
@@ -738,7 +709,7 @@ void
 NVProfilerService::preStreamEndRun(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePush(stream_domain(sid), "stream end run");
+    nvtxDomainRangePush(stream_domain_[sid], "stream end run");
   }
 }
 
@@ -746,35 +717,35 @@ void
 NVProfilerService::postStreamEndRun(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePop(stream_domain(sid));
+    nvtxDomainRangePop(stream_domain_[sid]);
   }
 }
 
 void
 NVProfilerService::preGlobalBeginLumi(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "global begin lumi");
+    nvtxDomainRangePush(global_domain_, "global begin lumi");
   }
 }
 
 void
 NVProfilerService::postGlobalBeginLumi(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
 void
 NVProfilerService::preGlobalEndLumi(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePush(global_domain(), "global end lumi");
+    nvtxDomainRangePush(global_domain_, "global end lumi");
   }
 }
 
 void
 NVProfilerService::postGlobalEndLumi(edm::GlobalContext const& gc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
-    nvtxDomainRangePop(global_domain());
+    nvtxDomainRangePop(global_domain_);
   }
 }
 
@@ -782,7 +753,7 @@ void
 NVProfilerService::preStreamBeginLumi(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePush(stream_domain(sid), "stream begin lumi");
+    nvtxDomainRangePush(stream_domain_[sid], "stream begin lumi");
   }
 }
 
@@ -790,21 +761,21 @@ void
 NVProfilerService::postStreamBeginLumi(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePop(stream_domain(sid));
+    nvtxDomainRangePop(stream_domain_[sid]);
   }
 }
 
 void
 NVProfilerService::preStreamEndLumi(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
-  nvtxDomainRangePush(stream_domain(sid), "stream end lumi");
+  nvtxDomainRangePush(stream_domain_[sid], "stream end lumi");
 }
 
 void
 NVProfilerService::postStreamEndLumi(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangePop(stream_domain(sid));
+    nvtxDomainRangePop(stream_domain_[sid]);
   }
 }
 
@@ -812,7 +783,7 @@ void
 NVProfilerService::preEvent(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    event_[sid] = nvtxDomainRangeStartColor(stream_domain(sid), "event", nvtxDarkGreen);
+    event_[sid] = nvtxDomainRangeStartColor(stream_domain_[sid], "event", nvtxDarkGreen);
   }
 }
 
@@ -820,7 +791,7 @@ void
 NVProfilerService::postEvent(edm::StreamContext const& sc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainRangeEnd(stream_domain(sid), event_[sid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], event_[sid]);
     event_[sid] = nvtxInvalidRangeId;
   } else {
     streamFirstEventDone_[sid] = true;
@@ -837,7 +808,7 @@ void
 NVProfilerService::prePathEvent(edm::StreamContext const& sc, edm::PathContext const& pc) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainMark(global_domain(), ("before path "s + pc.pathName()).c_str());
+    nvtxDomainMark(global_domain_, ("before path "s + pc.pathName()).c_str());
   }
 }
 
@@ -845,7 +816,7 @@ void
 NVProfilerService::postPathEvent(edm::StreamContext const& sc, edm::PathContext const& pc, edm::HLTPathStatus const& hlts) {
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
-    nvtxDomainMark(global_domain(), ("after path "s + pc.pathName()).c_str());
+    nvtxDomainMark(global_domain_, ("after path "s + pc.pathName()).c_str());
   }
 }
 
@@ -857,7 +828,7 @@ NVProfilerService::preModuleEventPrefetching(edm::StreamContext const& sc, edm::
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " prefetching";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColorLight(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColorLight(label));
   }
 }
 
@@ -866,7 +837,7 @@ NVProfilerService::postModuleEventPrefetching(edm::StreamContext const& sc, edm:
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -878,7 +849,7 @@ NVProfilerService::preModuleConstruction(edm::ModuleDescription const& desc) {
     global_modules_.grow_to_at_least(mid+1);
     auto const & label = desc.moduleLabel();
     auto const & msg = label + " construction";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -886,7 +857,7 @@ void
 NVProfilerService::postModuleConstruction(edm::ModuleDescription const& desc) {
   if (not skipFirstEvent_) {
     auto mid = desc.id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -897,7 +868,7 @@ NVProfilerService::preModuleBeginJob(edm::ModuleDescription const& desc) {
     auto mid = desc.id();
     auto const & label = desc.moduleLabel();
     auto const & msg = label + " begin job";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -905,7 +876,7 @@ void
 NVProfilerService::postModuleBeginJob(edm::ModuleDescription const& desc) {
   if (not skipFirstEvent_) {
     auto mid = desc.id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -916,7 +887,7 @@ NVProfilerService::preModuleEndJob(edm::ModuleDescription const& desc) {
     auto mid = desc.id();
     auto const & label = desc.moduleLabel();
     auto const & msg = label + " end job";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -924,7 +895,7 @@ void
 NVProfilerService::postModuleEndJob(edm::ModuleDescription const& desc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     auto mid = desc.id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -937,7 +908,7 @@ NVProfilerService::preModuleEventAcquire(edm::StreamContext const& sc, edm::Modu
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " acquire";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -946,7 +917,7 @@ NVProfilerService::postModuleEventAcquire(edm::StreamContext const& sc, edm::Mod
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -958,7 +929,7 @@ NVProfilerService::preModuleEvent(edm::StreamContext const& sc, edm::ModuleCalli
     auto mid = mcc.moduleDescription()->id();
     auto const & label = mcc.moduleDescription()->moduleLabel();
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), label.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], label.c_str(), labelColor(label));
   }
 }
 
@@ -967,7 +938,7 @@ NVProfilerService::postModuleEvent(edm::StreamContext const& sc, edm::ModuleCall
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -981,7 +952,7 @@ NVProfilerService::preModuleEventDelayedGet(edm::StreamContext const& sc, edm::M
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " delayed get";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), label.c_str(), labelColorLight(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], label.c_str(), labelColorLight(label));
   }
   */
 }
@@ -992,7 +963,7 @@ NVProfilerService::postModuleEventDelayedGet(edm::StreamContext const& sc, edm::
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
   */
@@ -1007,7 +978,7 @@ NVProfilerService::preEventReadFromSource(edm::StreamContext const& sc, edm::Mod
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " read from source";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColorLight(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColorLight(label));
   }
   */
 }
@@ -1018,7 +989,7 @@ NVProfilerService::postEventReadFromSource(edm::StreamContext const& sc, edm::Mo
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
   */
@@ -1032,7 +1003,7 @@ NVProfilerService::preModuleStreamBeginRun(edm::StreamContext const& sc, edm::Mo
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " stream begin run";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -1041,7 +1012,7 @@ NVProfilerService::postModuleStreamBeginRun(edm::StreamContext const& sc, edm::M
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -1054,7 +1025,7 @@ NVProfilerService::preModuleStreamEndRun(edm::StreamContext const& sc, edm::Modu
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " stream end run";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -1063,7 +1034,7 @@ NVProfilerService::postModuleStreamEndRun(edm::StreamContext const& sc, edm::Mod
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -1076,7 +1047,7 @@ NVProfilerService::preModuleStreamBeginLumi(edm::StreamContext const& sc, edm::M
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " stream begin lumi";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -1085,7 +1056,7 @@ NVProfilerService::postModuleStreamBeginLumi(edm::StreamContext const& sc, edm::
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -1098,7 +1069,7 @@ NVProfilerService::preModuleStreamEndLumi(edm::StreamContext const& sc, edm::Mod
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " stream end lumi";
     assert(stream_modules_[sid][mid] == nvtxInvalidRangeId);
-    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain(sid), msg.c_str(), labelColor(label));
+    stream_modules_[sid][mid] = nvtxDomainRangeStartColor(stream_domain_[sid], msg.c_str(), labelColor(label));
   }
 }
 
@@ -1107,7 +1078,7 @@ NVProfilerService::postModuleStreamEndLumi(edm::StreamContext const& sc, edm::Mo
   auto sid = sc.streamID();
   if (not skipFirstEvent_ or streamFirstEventDone_[sid]) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(stream_domain(sid), stream_modules_[sid][mid]);
+    nvtxDomainRangeEnd(stream_domain_[sid], stream_modules_[sid][mid]);
     stream_modules_[sid][mid] = nvtxInvalidRangeId;
   }
 }
@@ -1118,7 +1089,7 @@ NVProfilerService::preModuleGlobalBeginRun(edm::GlobalContext const& gc, edm::Mo
     auto mid = mcc.moduleDescription()->id();
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " global begin run";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -1126,7 +1097,7 @@ void
 NVProfilerService::postModuleGlobalBeginRun(edm::GlobalContext const& gc, edm::ModuleCallingContext const& mcc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -1137,7 +1108,7 @@ NVProfilerService::preModuleGlobalEndRun(edm::GlobalContext const& gc, edm::Modu
     auto mid = mcc.moduleDescription()->id();
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " global end run";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -1145,7 +1116,7 @@ void
 NVProfilerService::postModuleGlobalEndRun(edm::GlobalContext const& gc, edm::ModuleCallingContext const& mcc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -1156,7 +1127,7 @@ NVProfilerService::preModuleGlobalBeginLumi(edm::GlobalContext const& gc, edm::M
     auto mid = mcc.moduleDescription()->id();
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " global begin lumi";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -1164,7 +1135,7 @@ void
 NVProfilerService::postModuleGlobalBeginLumi(edm::GlobalContext const& gc, edm::ModuleCallingContext const& mcc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -1175,7 +1146,7 @@ NVProfilerService::preModuleGlobalEndLumi(edm::GlobalContext const& gc, edm::Mod
     auto mid = mcc.moduleDescription()->id();
     auto const & label = mcc.moduleDescription()->moduleLabel();
     auto const & msg = label + " global end lumi";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -1183,7 +1154,7 @@ void
 NVProfilerService::postModuleGlobalEndLumi(edm::GlobalContext const& gc, edm::ModuleCallingContext const& mcc) {
   if (not skipFirstEvent_ or globalFirstEventDone_) {
     auto mid = mcc.moduleDescription()->id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }
@@ -1195,7 +1166,7 @@ NVProfilerService::preSourceConstruction(edm::ModuleDescription const& desc) {
     global_modules_.grow_to_at_least(mid+1);
     auto const & label = desc.moduleLabel();
     auto const & msg = label + " construction";
-    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain(), msg.c_str(), labelColor(label));
+    global_modules_[mid] = nvtxDomainRangeStartColor(global_domain_, msg.c_str(), labelColor(label));
   }
 }
 
@@ -1203,7 +1174,7 @@ void
 NVProfilerService::postSourceConstruction(edm::ModuleDescription const& desc) {
   if (not skipFirstEvent_) {
     auto mid = desc.id();
-    nvtxDomainRangeEnd(global_domain(), global_modules_[mid]);
+    nvtxDomainRangeEnd(global_domain_, global_modules_[mid]);
     global_modules_[mid] = nvtxInvalidRangeId;
   }
 }


### PR DESCRIPTION
Unlike the Visual Profiler, Nsight Systems is able to show NVTX Domain information from multiple threads in a coherent view; it now makes sense to create a single NVTX Domain per EDM domain (global or stream).