### PR TITLE
Fix synchronization mistake in CUDAScopedContext

### DIFF
--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -45,6 +45,12 @@ private:
     data_(std::move(data))
   {}
 
+  template <typename... Args>
+  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event, Args&&... args):
+    CUDAProductBase(device, std::move(stream), std::move(event)),
+    data_(std::forward<Args>(args)...)
+  {}
+
   T data_; //!
 };
 

--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -40,14 +40,14 @@ private:
   friend class CUDAScopedContext;
   friend class edm::Wrapper<CUDAProduct<T>>;
 
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event, T data):
-    CUDAProductBase(device, std::move(stream), std::move(event)),
+  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, T data):
+    CUDAProductBase(device, std::move(stream)),
     data_(std::move(data))
   {}
 
   template <typename... Args>
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event, Args&&... args):
-    CUDAProductBase(device, std::move(stream), std::move(event)),
+  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, Args&&... args):
+    CUDAProductBase(device, std::move(stream)),
     data_(std::forward<Args>(args)...)
   {}
 

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -40,12 +40,18 @@ public:
   cuda::event_t *event() { return event_.get(); }
 
 protected:
-  explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event);
+  explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream):
+    stream_{std::move(stream)},
+    device_{device}
+  {}
 
 private:
   friend class CUDAScopedContext;
 
-  // Intended to be used only from CUDAScopedContext
+  // The following functions are intended to be used only from CUDAScopedContext
+  void setEvent(std::shared_ptr<cuda::event_t> event) {
+    event_ = std::move(event);
+  }
   const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
 
   bool mayReuseStream() const {

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -3,12 +3,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 
-CUDAProductBase::CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream, std::shared_ptr<cuda::event_t> event):
-  stream_(std::move(stream)),
-  event_(std::move(event)),
-  device_(device)
-{}
-
 bool CUDAProductBase::isAvailable() const {
   // In absence of event, the product was available already at the end
   // of produce() of the producer.


### PR DESCRIPTION
#### PR description:

This PR fixes a synchronization mistake in `CUDAScopedContext` reported by @VinInn e.g. here https://github.com/cms-patatrack/cmssw/pull/318#issuecomment-485123229. The problem was restricted to cases where the producer
* is not an `ExternalWork`
* inserts the CUDA product to the event via `CUDAScopedContext::emplace()`
* queued more asynchronous work in the constructor of the CUDA product

(all of these are fulfilled by the BeamSpot PR #318)

The problem was that `CUDASCopedContext` checked whether the CUDA stream is idle or not **before** calling the CUDA product constructor (for the CUDA event optimization of #292). If the stream is idle, the `CUDAProduct` is marked immediately to be available to avoid inspecting the state of the CUDA event (well, even creation of the event). But if the constructor queues more work, the state of the `CUDAProduct` is incorrect.

The proposed fix is to check for the CUDA stream status after calling the constructor.

#### PR validation:

Profiling workflow runs, unit tests run. Verified with printouts that now the product status information in the consumer of BeamSpot is consistent with the stream status information.