### PR TITLE
Remove redundant CUDA event occurred checks

### DIFF
--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -80,7 +80,7 @@ void CUDAScopedContext::synchronizeStreams(int dataDevice, const cuda::stream_t<
 
   if(dataStream.id() != stream_->id()) {
     // Different streams, need to synchronize
-    if(not available and not dataEvent->has_occurred()) {
+    if(not available) {
       // Event not yet occurred, so need to add synchronization
       // here. Sychronization is done by making the CUDA stream to
       // wait for an event, so all subsequent work in the stream

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -187,10 +187,10 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
   // (because of synchronizations upstream), but let's play generic.
-  if(not hclusters->isAvailable() and not hclusters->event()->has_occurred()) {
+  if(not hclusters->isAvailable()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
-  if(not hdigis->isAvailable() and not hdigis->event()->has_occurred()) {
+  if(not hdigis->isAvailable()) {
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitHeterogeneous.cc
@@ -191,7 +191,7 @@ void SiPixelRecHitHeterogeneous::acquireGPUCuda(const edm::HeterogeneousEvent& i
     cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
   }
   if(not hdigis->isAvailable()) {
-    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hclusters->event()->id(), 0));
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), hdigis->event()->id(), 0));
   }
 
   edm::Handle<reco::BeamSpot> bsHandle;


### PR DESCRIPTION
#### PR description:

This PR removes redundant calls to `cuda::event_t::has_occurred()` when it is called in conjunction with `CUDAProduct::isAvailable()`. The former are redundant because `isAvailable()` already calls `has_occurred()`.

Also fix (interim part in) `SiPixelRecHitHeterogeneous` to use the CUDA event of the correct product when calling `cudaStreamWaitEvent()`.

Thanks to @VinInn for noticing.

#### PR validation:

Profiling workflow runs, unit tests run. 