### PR TITLE
Synchronize stream in the CUDAProductBase destructor

### DIFF
--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CUDADataFormats/Common"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HeterogeneousCore/CUDAServices"/>
 <use name="cuda-api-wrappers"/>

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -13,6 +13,7 @@
 class CUDAProductBase {
 public:
   CUDAProductBase() = default; // Needed only for ROOT dictionary generation
+  ~CUDAProductBase();
 
   CUDAProductBase(CUDAProductBase&& other):
     stream_{std::move(other.stream_)},

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -3,6 +3,14 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 
+CUDAProductBase::~CUDAProductBase() {
+  // TODO: a callback notifying a WaitingTaskHolder would avoid
+  // blocking the CPU, but would also require more work.
+  if(stream_) {
+    stream_->synchronize();
+  }
+}
+
 bool CUDAProductBase::isAvailable() const {
   // In absence of event, the product was available already at the end
   // of produce() of the producer.

--- a/CUDADataFormats/SiPixelCluster/BuildFile.xml
+++ b/CUDADataFormats/SiPixelCluster/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CUDADataFormats/Common"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HeterogeneousCore/CUDAServices"/>
 <use name="cuda-api-wrappers"/>

--- a/CUDADataFormats/SiPixelDigi/BuildFile.xml
+++ b/CUDADataFormats/SiPixelDigi/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CUDADataFormats/Common"/>
 <use name="DataFormats/SiPixelRawData"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HeterogeneousCore/CUDAServices"/>


### PR DESCRIPTION
#### PR description:

Otherwise there are possibilities for weird races (e.g. combination non-ExternalWork producers, consumed-but-not-read CUDAProducts, CUDA streams executing work later than expected (= on the next event)).

#### PR validation:

Profiling workflow runs, unit tests run.