### PR TITLE
Make the ntuplet quality cuts configurable

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -2,7 +2,10 @@
 // Author: Felice Pantaleo, CERN
 //
 
+#include <array>        // for make_array<T,N>
+#include <cassert>      // for make_array<T,N>
 #include <functional>
+#include <vector>       // for make_array<T,N>
 
 #include "CommonTools/Utils/interface/DynArray.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -21,6 +24,31 @@ namespace {
   template <typename T>
   T sqr(T x) {
     return x * x;
+  }
+
+  CAHitQuadrupletGeneratorKernels::QualityCuts makeQualityCuts(edm::ParameterSet const& pset) {
+    auto coeff = pset.getParameter<std::vector<double>>("chi2Coeff");
+    assert(("CAHitQuadrupletGeneratorGPU.trackQualityCuts.chi2Coeff must have 4 elements" and coeff.size() == 4));
+    return CAHitQuadrupletGeneratorKernels::QualityCuts {
+      // polynomial coefficients for the pT-dependent chi2 cut
+      { (float) coeff[0], (float) coeff[1], (float) coeff[2], (float) coeff[3] },
+      // max pT used to detrmine the chi2 cut
+      (float) pset.getParameter<double>("chi2MaxPt"),
+      // chi2 scale factor: 30 for broken line fit, 45 for Riemann fit
+      (float) pset.getParameter<double>("chi2Scale"),
+      // regional cuts for triplets
+      {
+        (float) pset.getParameter<double>("tripletMaxTip"),
+        (float) pset.getParameter<double>("tripletMinPt"),
+        (float) pset.getParameter<double>("tripletMaxZip")
+      },
+      // regional cuts for quadruplets
+      {
+        (float) pset.getParameter<double>("quadrupletMaxTip"),
+        (float) pset.getParameter<double>("quadrupletMinPt"),
+        (float) pset.getParameter<double>("quadrupletMaxZip")
+      }
+    };
   }
 
 }  // namespace
@@ -43,7 +71,8 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
               cfg.getParameter<double>("CAThetaCutForward"),
               cfg.getParameter<double>("hardCurvCut"),
               cfg.getParameter<double>("dcaCutInnerTriplet"),
-              cfg.getParameter<double>("dcaCutOuterTriplet")),
+              cfg.getParameter<double>("dcaCutOuterTriplet"),
+              makeQualityCuts(cfg.getParameterSet("trackQualityCuts"))),
       fitter(cfg.getParameter<bool>("fit5as4")),
       caThetaCut(cfg.getParameter<double>("CAThetaCut")),
       caPhiCut(cfg.getParameter<double>("CAPhiCut")),
@@ -64,12 +93,27 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<double>("dcaCutOuterTriplet", 0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
   desc.add<bool>("earlyFishbone", false);
   desc.add<bool>("lateFishbone", true);
-  desc.add<bool>("idealConditions", true), desc.add<bool>("fillStatistics", false),
-      desc.add<unsigned int>("minHitsPerNtuplet", 4);
+  desc.add<bool>("idealConditions", true);
+  desc.add<bool>("fillStatistics", false);
+  desc.add<unsigned int>("minHitsPerNtuplet", 4);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZCut", true);
   desc.add<bool>("doPhiCut", true);
+
+  edm::ParameterSetDescription trackQualityCuts;
+  trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
+  trackQualityCuts.add<std::vector<double>>("chi2Coeff", { 0.68177776, 0.74609577, -0.08035491, 0.00315399 })
+    ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
+  trackQualityCuts.add<double>("chi2Scale", 30.)->setComment("Factor to multiply the pT-dependent chi2 cut");
+  trackQualityCuts.add<double>("tripletMinPt", 0.5)->setComment("Min pT for triplets, in GeV");
+  trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");
+  trackQualityCuts.add<double>("tripletMaxZip", 12.)->setComment("Max |Zip| for triplets, in cm");
+  trackQualityCuts.add<double>("quadrupletMinPt", 0.3)->setComment("Min pT for quadruplets, in GeV");
+  trackQualityCuts.add<double>("quadrupletMaxTip", 0.5)->setComment("Max |Tip| for quadruplets, in cm");
+  trackQualityCuts.add<double>("quadrupletMaxZip", 12.)->setComment("Max |Zip| for quadruplets, in cm");
+  desc.add<edm::ParameterSetDescription>("trackQualityCuts", trackQualityCuts)
+    ->setComment("Quality cuts based on the results of the track fit:\n  - apply a pT-dependent chi2 cut;\n  - apply \"region cuts\" based on the fit results (pT, Tip, Zip).");
 }
 
 void CAHitQuadrupletGeneratorGPU::initEvent(edm::Event const &ev, edm::EventSetup const &es) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -107,7 +107,7 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
   trackQualityCuts.add<std::vector<double>>("chi2Coeff", { 0.68177776, 0.74609577, -0.08035491, 0.00315399 })
     ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
-  trackQualityCuts.add<double>("chi2Scale", 30.)->setComment("Factor to multiply the pT-dependent chi2 cut");
+  trackQualityCuts.add<double>("chi2Scale", 30.)->setComment("Factor to multiply the pT-dependent chi2 cut (currently: 30 for the broken line fit, 45 for the Riemann fit)");
   trackQualityCuts.add<double>("tripletMinPt", 0.5)->setComment("Min pT for triplets, in GeV");
   trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");
   trackQualityCuts.add<double>("tripletMaxZip", 12.)->setComment("Max |Zip| for triplets, in cm");

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -2,17 +2,17 @@
 // Author: Felice Pantaleo, CERN
 //
 
-#include <array>        // for make_array<T,N>
-#include <cassert>      // for make_array<T,N>
+#include <array>
+#include <cassert>
 #include <functional>
-#include <vector>       // for make_array<T,N>
+#include <vector>
 
-#include "CommonTools/Utils/interface/DynArray.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
@@ -28,7 +28,9 @@ namespace {
 
   CAHitQuadrupletGeneratorKernels::QualityCuts makeQualityCuts(edm::ParameterSet const& pset) {
     auto coeff = pset.getParameter<std::vector<double>>("chi2Coeff");
-    assert(("CAHitQuadrupletGeneratorGPU.trackQualityCuts.chi2Coeff must have 4 elements" and coeff.size() == 4));
+    if (coeff.size() != 4) {
+      throw edm::Exception(edm::errors::Configuration, "CAHitQuadrupletGeneratorGPU.trackQualityCuts.chi2Coeff must have 4 elements");
+    }
     return CAHitQuadrupletGeneratorKernels::QualityCuts {
       // polynomial coefficients for the pT-dependent chi2 cut
       { (float) coeff[0], (float) coeff[1], (float) coeff[2], (float) coeff[3] },

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -34,7 +34,7 @@ namespace {
     return CAHitQuadrupletGeneratorKernels::QualityCuts {
       // polynomial coefficients for the pT-dependent chi2 cut
       { (float) coeff[0], (float) coeff[1], (float) coeff[2], (float) coeff[3] },
-      // max pT used to detrmine the chi2 cut
+      // max pT used to determine the chi2 cut
       (float) pset.getParameter<double>("chi2MaxPt"),
       // chi2 scale factor: 30 for broken line fit, 45 for Riemann fit
       (float) pset.getParameter<double>("chi2Scale"),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -97,7 +97,7 @@ private:
   const float caHardPtCut = 0.f;
 
   // products
-  std::vector<uint32_t> indToEdm;  // index of    tuple in reco tracks....
+  std::vector<uint32_t> indToEdm;  // index of tuple in reco tracks....
   TuplesOnGPU* gpu_d = nullptr;    // copy of the structure on the gpu itself: this is the "Product"
   TuplesOnGPU::Container* tuples_ = nullptr;
   Rfit::helix_fit* helix_fit_results_ = nullptr;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -2,6 +2,7 @@
 // Author: Felice Pantaleo, CERN
 //
 
+#include <cmath>
 #include <cstdint>
 
 #include <cuda_runtime.h>
@@ -271,50 +272,66 @@ __global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict
 
 __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__ tuples,
                                       Rfit::helix_fit const *__restrict__ fit_results,
+                                      CAHitQuadrupletGeneratorKernels::QualityCuts cuts,
                                       Quality *__restrict__ quality) {
   auto idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= tuples->nbins())
+  if (idx >= tuples->nbins()) {
     return;
+  }
   if (tuples->size(idx) == 0) {
     return;
   }
 
+  // mark as bad by default
   quality[idx] = pixelTuplesHeterogeneousProduct::bad;
 
+  // mark doublets as bad
   if (tuples->size(idx) < 3) {
     return;
   }
 
-  const float par[4] = {0.68177776, 0.74609577, -0.08035491, 0.00315399};
-  constexpr float chi2CutFact = 30;  // *0.7 if Riemann....
-  auto chi2Cut = [&](float pt) {
-    pt = std::min(pt, 10.f);
-    return chi2CutFact * (par[0] + pt * (par[1] + pt * (par[2] + pt * par[3])));
-  };
-
+  // if the fit has any invalid parameters, mark it as bad
   bool isNaN = false;
   for (int i = 0; i < 5; ++i) {
-    isNaN |= fit_results[idx].par(i) != fit_results[idx].par(i);
+    isNaN |= isnan(fit_results[idx].par(i));
   }
-  isNaN |= !(fit_results[idx].chi2_line + fit_results[idx].chi2_circle <
-             chi2Cut(fit_results[idx].par(2)));  // catch NaN as well
-
+  if (isNaN) {
 #ifdef GPU_DEBUG
-  if (isNaN)
-    printf("NaN or Bad Fit %d size %d chi2 %f/%f\n",
+    printf("NaN in fit %d size %d chi2 %f + %f\n",
            idx,
            tuples->size(idx),
            fit_results[idx].chi2_line,
            fit_results[idx].chi2_circle);
 #endif
+    return;
+  }
 
-  // impose "region cuts" (NaN safe)
-  // phi,Tip,pt,cotan(theta)),Zip
-  bool ok = std::abs(fit_results[idx].par(1)) < (tuples->size(idx) > 3 ? 0.5f : 0.3f) &&
-            fit_results[idx].par(2) > (tuples->size(idx) > 3 ? 0.3f : 0.5f) && std::abs(fit_results[idx].par(4)) < 12.f;
+  // compute a pT-dependent chi2 cut, up to 10 GeV
+  float pt = std::min<float>(fit_results[idx].par(2), cuts.chi2MaxPt);
+  float chi2Cut = cuts.chi2Scale *
+                  (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
+  if (fit_results[idx].chi2_line + fit_results[idx].chi2_circle >= chi2Cut) {
+#ifdef GPU_DEBUG
+    printf("Bad fit %d size %d chi2 %f + %f\n",
+           idx,
+           tuples->size(idx),
+           fit_results[idx].chi2_line,
+           fit_results[idx].chi2_circle);
+#endif
+    return;
+  }
 
-  ok &= (!isNaN);
-  quality[idx] = ok ? pixelTuplesHeterogeneousProduct::loose : pixelTuplesHeterogeneousProduct::bad;
+  // impose "region cuts" based on the fit results (phi, Tip, pt, cotan(theta)), Zip)
+  // default cuts (see CAHitQuadrupletGeneratorKernels.h)
+  // for triplets:    |Tip| < 0.3 cm, pT > 0.5 GeV, |Zip| < 12.0 cm
+  // for quadruplets: |Tip| < 0.5 cm, pT > 0.3 GeV, |Zip| < 12.0 cm
+  auto const &region = (tuples->size(idx) > 3) ? cuts.quadruplet : cuts.triplet;
+  bool isOk = (std::abs(fit_results[idx].par(1)) < region.maxTip) and (fit_results[idx].par(2) > region.minPt) and
+              (std::abs(fit_results[idx].par(4)) < region.maxZip);
+
+  if (isOk) {
+    quality[idx] = pixelTuplesHeterogeneousProduct::loose;
+  }
 }
 
 __global__ void kernel_doStatsForTracks(TuplesOnGPU::Container const *__restrict__ tuples,
@@ -597,7 +614,7 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
   // classify tracks based on kinematics
   auto numberOfBlocks = (CAConstants::maxNumberOfQuadruplets() + blockSize - 1) / blockSize;
   kernel_classifyTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
-      tuples.tuples_d, tuples.helix_fit_results_d, tuples.quality_d);
+      tuples.tuples_d, tuples.helix_fit_results_d, cuts_, tuples.quality_d);
   cudaCheck(cudaGetLastError());
 
   // apply fishbone cleaning to good tracks

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -306,7 +306,12 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
     return;
   }
 
-  // compute a pT-dependent chi2 cut, up to 10 GeV
+  // compute a pT-dependent chi2 cut
+  // default parameters:
+  //   - chi2MaxPt = 10 GeV
+  //   - chi2Coeff = { 0.68177776, 0.74609577, -0.08035491, 0.00315399 }
+  //   - chi2Scale = 30 for broken line fit, 45 for Riemann fit
+  // (see CAHitQuadrupletGeneratorGPU.cc)
   float pt = std::min<float>(fit_results[idx].par(2), cuts.chi2MaxPt);
   float chi2Cut = cuts.chi2Scale *
                   (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
@@ -322,9 +327,10 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
   }
 
   // impose "region cuts" based on the fit results (phi, Tip, pt, cotan(theta)), Zip)
-  // default cuts (see CAHitQuadrupletGeneratorKernels.h)
-  // for triplets:    |Tip| < 0.3 cm, pT > 0.5 GeV, |Zip| < 12.0 cm
-  // for quadruplets: |Tip| < 0.5 cm, pT > 0.3 GeV, |Zip| < 12.0 cm
+  // default cuts:
+  //   - for triplets:    |Tip| < 0.3 cm, pT > 0.5 GeV, |Zip| < 12.0 cm
+  //   - for quadruplets: |Tip| < 0.5 cm, pT > 0.3 GeV, |Zip| < 12.0 cm
+  // (see CAHitQuadrupletGeneratorGPU.cc)
   auto const &region = (tuples->size(idx) > 3) ? cuts.quadruplet : cuts.triplet;
   bool isOk = (std::abs(fit_results[idx].par(1)) < region.maxTip) and (fit_results[idx].par(2) > region.minPt) and
               (std::abs(fit_results[idx].par(4)) < region.maxZip);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -31,6 +31,21 @@ public:
   using HitToTuple = CAConstants::HitToTuple;
   using TupleMultiplicity = CAConstants::TupleMultiplicity;
 
+  struct QualityCuts {
+    float chi2Coeff[4]; // chi2 cut = chi2Scale * (chi2Coeff[0] + pT * (chi2Coeff[1] + pT * (chi2Coeff[2] + pT * chi2Coeff[3])))
+    float chi2MaxPt;    // GeV
+    float chi2Scale;
+
+    struct region {
+      float maxTip;     // cm
+      float minPt;      // GeV
+      float maxZip;     // cm
+    };
+
+    region triplet;
+    region quadruplet;
+  };
+
   CAHitQuadrupletGeneratorKernels(uint32_t minHitsPerNtuplet,
                                   bool earlyFishbone,
                                   bool lateFishbone,
@@ -107,6 +122,28 @@ private:
   const float hardCurvCut_;
   const float dcaCutInnerTriplet_;
   const float dcaCutOuterTriplet_;
+
+  // quality cuts
+  QualityCuts cuts_
+  {
+    // polynomial coefficients for the pT-dependent chi2 cut
+    { 0.68177776, 0.74609577, -0.08035491, 0.00315399 },
+    // max pT used to detrmine the chi2 cut
+    10.,
+    // chi2 scale factor: 30 for broken line fit, 45 for Riemann fit
+    30.,
+    // regional cuts for triplets
+    {
+      0.3,  // |Tip| < 0.3 cm
+      0.5,  // pT > 0.5 GeV
+      12.0  // |Zip| < 12.0 cm
+    },
+    // regional cuts for quadruplets
+    {
+      0.5,  // |Tip| < 0.5 cm
+      0.3,  // pT > 0.3 GeV
+      12.0  // |Zip| < 12.0 cm
+    }};
 };
 
 #endif  // RecoPixelVertexing_PixelTriplets_plugins_CAHitQuadrupletGeneratorKernels_h

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -135,7 +135,7 @@ private:
   {
     // polynomial coefficients for the pT-dependent chi2 cut
     { 0.68177776, 0.74609577, -0.08035491, 0.00315399 },
-    // max pT used to detrmine the chi2 cut
+    // max pT used to determine the chi2 cut
     10.,
     // chi2 scale factor: 30 for broken line fit, 45 for Riemann fit
     30.,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -32,7 +32,8 @@ public:
   using TupleMultiplicity = CAConstants::TupleMultiplicity;
 
   struct QualityCuts {
-    float chi2Coeff[4]; // chi2 cut = chi2Scale * (chi2Coeff[0] + pT * (chi2Coeff[1] + pT * (chi2Coeff[2] + pT * chi2Coeff[3])))
+    // chi2 cut = chi2Scale * (chi2Coeff[0] + pT/GeV * (chi2Coeff[1] + pT/GeV * (chi2Coeff[2] + pT/GeV * chi2Coeff[3])))
+    float chi2Coeff[4];
     float chi2MaxPt;    // GeV
     float chi2Scale;
 
@@ -59,7 +60,8 @@ public:
                                   float CAThetaCutForward,
                                   float hardCurvCut,
                                   float dcaCutInnerTriplet,
-                                  float dcaCutOuterTriplet)
+                                  float dcaCutOuterTriplet,
+                                  QualityCuts const& cuts)
       : minHitsPerNtuplet_(minHitsPerNtuplet),
         earlyFishbone_(earlyFishbone),
         lateFishbone_(lateFishbone),
@@ -73,8 +75,13 @@ public:
         CAThetaCutForward_(CAThetaCutForward),
         hardCurvCut_(hardCurvCut),
         dcaCutInnerTriplet_(dcaCutInnerTriplet),
-        dcaCutOuterTriplet_(dcaCutOuterTriplet){};
-  ~CAHitQuadrupletGeneratorKernels() { deallocateOnGPU(); }
+        dcaCutOuterTriplet_(dcaCutOuterTriplet),
+        cuts_(cuts)
+  { }
+
+  ~CAHitQuadrupletGeneratorKernels() {
+    deallocateOnGPU();
+  }
 
   TupleMultiplicity const* tupleMultiplicity() const { return device_tupleMultiplicity_; }
 


### PR DESCRIPTION
Move the definition of the quality cuts from the kernel to the host code.

Next steps are to
  - [x] validate the physics results (no changes expected, of course)
  - [x] check the impact on timing/throughput
  - [ ] check if using global or constant memory gives better performance
  - [x] move the cuts to the EDProducer or python configuration
