### PR TITLE
Move to  View

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -52,15 +52,11 @@ namespace pixelgpudetails {
     if (blocks)  // protect from empty events
       gpuPixelRecHits::getHits<<<blocks, threadsPerBlock, 0, stream.id()>>>(cpeParams,
                                                                             bs_d.data(),
-                                                                            digis_d.moduleInd(),
-                                                                            digis_d.xx(),
-                                                                            digis_d.yy(),
-                                                                            digis_d.adc(),
+                                                                            digis_d.view(),
+                                                                            digis_d.nDigis(),
                                                                             clusters_d.moduleStart(),
                                                                             clusters_d.clusInModule(),
                                                                             clusters_d.moduleId(),
-                                                                            digis_d.clus(),
-                                                                            digis_d.nDigis(),
                                                                             clusters_d.clusModuleStart(),
                                                                             hits_d.view());
     cudaCheck(cudaGetLastError());

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -54,10 +54,7 @@ namespace pixelgpudetails {
                                                                             bs_d.data(),
                                                                             digis_d.view(),
                                                                             digis_d.nDigis(),
-                                                                            clusters_d.moduleStart(),
-                                                                            clusters_d.clusInModule(),
-                                                                            clusters_d.moduleId(),
-                                                                            clusters_d.clusModuleStart(),
+                                                                            clusters_d.view(),
                                                                             hits_d.view());
     cudaCheck(cudaGetLastError());
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -43,7 +43,7 @@ namespace pixelgpudetails {
     auto nHits = clusters_d.nClusters();
     TrackingRecHit2DCUDA hits_d(nHits, cpeParams, clusters_d.clusModuleStart(), stream);
 
-    int threadsPerBlock = 256;
+    int threadsPerBlock = 128;
     int blocks = digis_d.nModules();  // active modules (with digis)
 
 #ifdef GPU_DEBUG

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -19,6 +19,12 @@ namespace gpuPixelRecHits {
                           int numElements,
                           SiPixelClustersCUDA::DeviceConstView const * __restrict__ pclusters,
                           TrackingRecHit2DSOAView* phits) {
+
+    // FIXME
+    // the compiler seems NOT to optimize loads from views (even in a simple test case)
+    // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
+    // not using views (passing a gazzilion of array pointers) seems to produce the fastest code (but it is harder to mantain)  
+
     auto& hits = *phits;
 
     auto const digis = *pdigis; // the copy is intentional!


### PR DESCRIPTION
Finish to move to view...
Moving Raw2digi and clusterizer to view most probably not worth (reading and writing from the same data-structures)

PR ready  for review!

Just to make everybody aware that deferencing device views in global memory is utterly slow.
The first attempt of this PR resulted in having gpuPixelRecHits::getHits 20% slower.
now is only 2% slower (see inline comments)