### PR TITLE
Implement full pixel triplets

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h
@@ -9,6 +9,8 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
+
 
 namespace pixelCPEforGPU {
   struct ParamsOnGPU;
@@ -20,6 +22,8 @@ public:
   using hindex_type = uint16_t;  // if above is <=2^16
 
   using Hist = HistoContainer<int16_t, 128, gpuClustering::MaxNumClusters, 8 * sizeof(int16_t), uint16_t, 10>;
+
+  using AverageGeometry = phase1PixelTopology::AverageGeometry;
 
   friend class TrackingRecHit2DCUDA;
 
@@ -66,6 +70,10 @@ public:
   __device__ __forceinline__ Hist& phiBinner() { return *m_hist; }
   __device__ __forceinline__ Hist const& phiBinner() const { return *m_hist; }
 
+  __device__ __forceinline__ AverageGeometry & averageGeometry() { return *m_averageGeometry; }
+  __device__ __forceinline__ AverageGeometry const& averageGeometry() const { return *m_averageGeometry; }
+
+
 private:
   // local coord
   float *m_xl, *m_yl;
@@ -82,6 +90,7 @@ private:
   uint16_t* m_detInd;
 
   // supporting objects
+  AverageGeometry * m_averageGeometry; // owned (corrected for beam spot: not sure where to host it otherwise)
   pixelCPEforGPU::ParamsOnGPU const* m_cpeParams;  // forwarded from setup, NOT owned
   uint32_t const* m_hitsModuleStart;               // forwarded from clusters
 
@@ -133,6 +142,7 @@ private:
   cudautils::device::unique_ptr<float[]> m_store32;
 
   cudautils::device::unique_ptr<TrackingRecHit2DSOAView::Hist> m_HistStore;
+  cudautils::device::unique_ptr<TrackingRecHit2DSOAView::AverageGeometry> m_AverageGeometryStore;
 
   cudautils::device::unique_ptr<TrackingRecHit2DSOAView> m_view;
 

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
@@ -14,6 +14,10 @@ TrackingRecHit2DCUDA::TrackingRecHit2DCUDA(uint32_t nHits,
   auto view = cs->make_host_unique<TrackingRecHit2DSOAView>(stream);
   view->m_nHits = nHits;
   m_view = cs->make_device_unique<TrackingRecHit2DSOAView>(stream);
+  m_AverageGeometryStore = cs->make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
+  view->m_averageGeometry = m_AverageGeometryStore.get();
+  view->m_cpeParams = cpeParams;
+  view->m_hitsModuleStart = hitsModuleStart;
 
   // if empy do not bother
   if (0 == nHits) {
@@ -35,9 +39,6 @@ TrackingRecHit2DCUDA::TrackingRecHit2DCUDA(uint32_t nHits,
 
   // copy all the pointers
   m_hist = view->m_hist = m_HistStore.get();
-
-  view->m_cpeParams = cpeParams;
-  view->m_hitsModuleStart = hitsModuleStart;
 
   view->m_xl = get32(0);
   view->m_yl = get32(1);

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -35,6 +35,8 @@ namespace phase1PixelTopology {
     "E-1", "E-2", "E-3"             // negative endcap
   };
 
+  constexpr uint32_t numberOfModulesInBarrel = 1184;
+  constexpr uint32_t numberOfLaddersInBarrel = numberOfModulesInBarrel/8;
 
   template<class Function, std::size_t... Indices>
   constexpr auto map_to_array_helper(Function f, std::index_sequence<Indices...>)
@@ -145,6 +147,18 @@ namespace phase1PixelTopology {
     if (yInRoc>0) shift+=1;
     return py+shift;
   }
+
+  //FIXME move it elsewhere?
+  struct AverageGeometry {
+    static constexpr auto numberOfLaddersInBarrel = phase1PixelTopology::numberOfLaddersInBarrel;
+    float ladderZ[numberOfLaddersInBarrel];
+    float ladderX[numberOfLaddersInBarrel];
+    float ladderY[numberOfLaddersInBarrel];
+    float ladderR[numberOfLaddersInBarrel];
+    float ladderMinZ[numberOfLaddersInBarrel];
+    float ladderMaxZ[numberOfLaddersInBarrel];
+    float endCapZ[2];  // just for pos and neg Layer1
+  };
 
 }
 

--- a/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
@@ -87,7 +87,7 @@ namespace GPU {
     inline constexpr T &operator[](int i) { return m_data[i]; }
     inline constexpr const T &operator[](int i) const { return m_data[i]; }
     inline constexpr void reset() { m_size = 0; }
-    inline constexpr int capacity() const { return maxSize; }
+    inline static constexpr int capacity() { return maxSize; }
     inline constexpr T const *data() const { return m_data; }
     inline constexpr void resize(int size) { m_size = size; }
     inline constexpr bool empty() const { return 0 == m_size; }

--- a/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
@@ -269,6 +269,10 @@ public:
   __device__ __host__ __forceinline__ void bulkFinalizeFill(AtomicPairCounter const &apc) {
     auto m = apc.get().m;
     auto n = apc.get().n;
+    if (m >= nbins()) { // overflow!
+      off[nbins()]=uint32_t(off[nbins()-1]);
+      return;
+    }
     auto first = m + blockDim.x * blockIdx.x + threadIdx.x;
     for (auto i = first; i < totbins(); i += gridDim.x * blockDim.x) {
       off[i] = n;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -12,6 +12,10 @@
 
 namespace gpuClustering {
 
+#ifdef GPU_DEBUG
+  __device__ uint32_t gMaxHit=0;
+#endif
+
   __global__ void countModules(uint16_t const* __restrict__ id,
                                uint32_t* __restrict__ moduleStart,
                                int32_t* __restrict__ clusterId,
@@ -272,8 +276,13 @@ namespace gpuClustering {
       nClustersInModule[thisModuleId] = foundClusters;
       moduleId[blockIdx.x] = thisModuleId;
 #ifdef GPU_DEBUG
+      if (foundClusters>gMaxHit) {
+         gMaxHit = foundClusters;
+         if (foundClusters>8) printf("max hit %d in %d\n",foundClusters, thisModuleId);
+      }
+#endif
+#ifdef GPU_DEBUG
       if (thisModuleId % 100 == 1)
-        if (threadIdx.x == 0)
           printf("%d clusters in module %d\n", foundClusters, thisModuleId);
 #endif
     }

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
@@ -81,6 +81,7 @@ private:
   std::vector<pixelCPEforGPU::DetParams, CUDAHostAllocator<pixelCPEforGPU::DetParams>> m_detParamsGPU;
   pixelCPEforGPU::CommonParams m_commonParamsGPU;
   pixelCPEforGPU::LayerGeometry m_layerGeometry;
+  pixelCPEforGPU::AverageGeometry m_averageGeometry;
 
   struct GPUData {
     ~GPUData();

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -44,6 +44,9 @@ namespace pixelCPEforGPU {
     Frame frame;
   };
 
+
+  using phase1PixelTopology::AverageGeometry;
+
   struct LayerGeometry {
     uint32_t layerStart[phase1PixelTopology::numberOfLayers + 1];
     uint8_t layer[phase1PixelTopology::layerIndexSize];
@@ -53,6 +56,7 @@ namespace pixelCPEforGPU {
     CommonParams* m_commonParams;
     DetParams* m_detParams;
     LayerGeometry* m_layerGeometry;
+    AverageGeometry * m_averageGeometry;
 
     constexpr CommonParams const& __restrict__ commonParams() const {
       CommonParams const* __restrict__ l = m_commonParams;
@@ -63,6 +67,7 @@ namespace pixelCPEforGPU {
       return l[i];
     }
     constexpr LayerGeometry const& __restrict__ layerGeometry() const { return *m_layerGeometry; }
+    constexpr AverageGeometry const& __restrict__ averageGeometry() const { return *m_averageGeometry; }
 
     __device__ uint8_t layer(uint16_t id) const {
       return __ldg(m_layerGeometry->layer + id / phase1PixelTopology::maxModuleStride);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -59,8 +59,10 @@ namespace pixelgpudetails {
     cudaCheck(cudaGetLastError());
 
     // assuming full warp of threads is better than a smaller number...
-    setHitsLayerStart<<<1, 32, 0, stream.id()>>>(clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart());
-    cudaCheck(cudaGetLastError());
+    if (nHits) {
+      setHitsLayerStart<<<1, 32, 0, stream.id()>>>(clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart());
+      cudaCheck(cudaGetLastError());
+    }
 
     if (nHits >= TrackingRecHit2DSOAView::maxHits()) {
       edm::LogWarning("PixelRecHitGPUKernel")
@@ -74,6 +76,13 @@ namespace pixelgpudetails {
           hits_d.phiBinner(), hws.get(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, stream.id());
       cudaCheck(cudaGetLastError());
     }
+
+    
+#ifdef GPU_DEBUG
+    cudaDeviceSynchronize();
+    cudaCheck(cudaGetLastError());
+#endif
+
     return hits_d;
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -38,13 +38,16 @@ __global__ void kernelBLFastFit(TuplesOnGPU::Container const *__restrict__ found
 
   assert(pfast_fit);
   assert(foundNtuplets);
+  assert(tupleMultiplicity);
 
   // look in bin for this hit multiplicity
   auto local_start = (blockIdx.x * blockDim.x + threadIdx.x);
 
 #ifdef BROKENLINE_DEBUG
-  if (0 == local_start)
+  if (0 == local_start) {
+    printf("%d total Ntuple\n",foundNtuplets->nbins());
     printf("%d Ntuple of size %d for %d hits to fit\n", tupleMultiplicity->size(nHits), nHits, hitsInFit);
+  }
 #endif
 
   auto tuple_start = local_start + offset;

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -12,7 +12,6 @@
 <use name="RecoPixelVertexing/PixelTriplets"/>
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TkTrackingRegions"/>
-<flags CXXFLAGS="-fno-math-errno"/>
 
 <library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -18,24 +18,24 @@ namespace CAConstants {
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
-  constexpr uint32_t maxNumberOfTuples() { return 6 * 1024; }
+  constexpr uint32_t maxNumberOfTuples() { return 24 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
 #ifndef GPU_SMALL_EVENTS
-  constexpr uint32_t maxNumberOfDoublets() { return 262144; }
+  constexpr uint32_t maxNumberOfDoublets() { return 448*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128; }
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 262144 / 2; }
+  constexpr uint32_t maxNumberOfDoublets() { return  128*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 6 * 262144; }
+  constexpr uint32_t maxNumberOfDoublets() { return 448*1024; }
   constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
 
-  constexpr uint32_t maxNumberOfLayerPairs() { return 13; }
+  constexpr uint32_t maxNumberOfLayerPairs() { return 20; }
   constexpr uint32_t maxNumberOfLayers() { return 10; }
   constexpr uint32_t maxTuples() { return maxNumberOfTuples(); }
 
@@ -44,7 +44,7 @@ namespace CAConstants {
   using tindex_type = uint16_t;  //  for tuples
 
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
-  using CellTracks = GPU::VecArray<tindex_type, 42>;
+  using CellTracks = GPU::VecArray<tindex_type, 56>;
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -44,7 +44,7 @@ namespace CAConstants {
   using tindex_type = uint16_t;  //  for tuples
 
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
-  using CellTracks = GPU::VecArray<tindex_type, 56>;
+  using CellTracks = GPU::VecArray<tindex_type, 42>;
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -61,6 +61,7 @@ constexpr unsigned int CAHitQuadrupletGeneratorGPU::minLayers;
 
 CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : kernels(cfg.getParameter<unsigned int>("minHitsPerNtuplet"),
+              cfg.getParameter<bool>("includeJumpingForwardDoublets"),
               cfg.getParameter<bool>("earlyFishbone"),
               cfg.getParameter<bool>("lateFishbone"),
               cfg.getParameter<bool>("idealConditions"),
@@ -68,6 +69,7 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
               cfg.getParameter<bool>("doClusterCut"),
               cfg.getParameter<bool>("doZCut"),
               cfg.getParameter<bool>("doPhiCut"),
+              cfg.getParameter<bool>("doIterations"),
               cfg.getParameter<double>("ptmin"),
               cfg.getParameter<double>("CAThetaCutBarrel"),
               cfg.getParameter<double>("CAThetaCutForward"),
@@ -78,7 +80,15 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
       fitter(cfg.getParameter<bool>("fit5as4")),
       caThetaCut(cfg.getParameter<double>("CAThetaCut")),
       caPhiCut(cfg.getParameter<double>("CAPhiCut")),
-      caHardPtCut(cfg.getParameter<double>("CAHardPtCut")) {}
+      caHardPtCut(cfg.getParameter<double>("CAHardPtCut")) {
+
+#ifdef    DUMP_GPU_TK_TUPLES
+      printf("TK: %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
+             "tid", "qual", "nh","phi","tip","pt","cot","zip","eta","chil","chic",
+             "h1","h2","h3","h4","h5");
+#endif
+
+}
 
 void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription &desc) {
   desc.add<double>("CAThetaCut", 0.00125);
@@ -93,15 +103,18 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<double>("hardCurvCut", 1.f / (0.35 * 87.f))->setComment("Cut on minimum curvature");
   desc.add<double>("dcaCutInnerTriplet", 0.15f)->setComment("Cut on origin radius when the inner hit is on BPix1");
   desc.add<double>("dcaCutOuterTriplet", 0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
-  desc.add<bool>("earlyFishbone", false);
-  desc.add<bool>("lateFishbone", true);
+  desc.add<bool>("earlyFishbone", true);
+  desc.add<bool>("lateFishbone", false);
   desc.add<bool>("idealConditions", true);
   desc.add<bool>("fillStatistics", false);
   desc.add<unsigned int>("minHitsPerNtuplet", 4);
+  desc.add<bool>("includeJumpingForwardDoublets", false);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZCut", true);
   desc.add<bool>("doPhiCut", true);
+  desc.add<bool>("doIterations", false);
+
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -2,6 +2,8 @@
 // Author: Felice Pantaleo, CERN
 //
 
+// #define NTUPLE_DEBUG
+
 #include <cmath>
 #include <cstdint>
 
@@ -26,6 +28,7 @@ using TuplesOnGPU = pixelTuplesHeterogeneousProduct::TuplesOnGPU;
 using Quality = pixelTuplesHeterogeneousProduct::Quality;
 
 __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
+                                      CAConstants::TupleMultiplicity * tupleMultiplicity,
                                       AtomicPairCounter *apc,
                                       GPUCACell const *__restrict__ cells,
                                       uint32_t const *__restrict__ nCells,
@@ -43,17 +46,20 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
     atomicAdd(&c.nHits, nHits);
     atomicAdd(&c.nCells, *nCells);
     atomicAdd(&c.nTuples, apc->get().m);
+    atomicAdd(&c.nFitTracks,tupleMultiplicity->size());
   }
 
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
   if (0 == idx) {
     printf("number of found cells %d, found tuples %d with total hits %d out of %d\n",
            *nCells,
            apc->get().m,
            apc->get().n,
            nHits);
-    assert(foundNtuplets->size(apc->get().m) == 0);
-    assert(foundNtuplets->size() == apc->get().n);
+    if (apc->get().m < CAConstants::maxNumberOfQuadruplets()) {
+      assert(foundNtuplets->size(apc->get().m) == 0);
+      assert(foundNtuplets->size() == apc->get().n);
+    }
   }
 
   if (idx < foundNtuplets->nbins()) {
@@ -80,7 +86,7 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
       printf("Tracks overflow %d in %d\n", idx, thisCell.theLayerPairId);
     if (thisCell.theDoubletId < 0)
       atomicAdd(&c.nKilledCells, 1);
-    if (thisCell.outerNeighbors().empty())
+    if (0==thisCell.theUsed)
       atomicAdd(&c.nEmptyCells, 1);
     if (thisCell.tracks().empty())
       atomicAdd(&c.nZeroTrackCells, 1);
@@ -108,14 +114,15 @@ __global__ void kernel_fishboneCleaner(GPUCACell const *cells,
     quality[it] = bad;
 }
 
-__global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
+__global__ void kernel_earlyDuplicateRemover(GPUCACell const *cells,
                                             uint32_t const *__restrict__ nCells,
                                             TuplesOnGPU::Container *foundNtuplets,
-                                            Rfit::helix_fit const *__restrict__ hfit,
                                             pixelTuplesHeterogeneousProduct::Quality *quality) {
-  constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
+  // constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
   constexpr auto dup = pixelTuplesHeterogeneousProduct::dup;
   // constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
+
+  assert(nCells);
 
   auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -125,33 +132,57 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
   if (thisCell.theDoubletId < 0)
     return;
 
-  float mc = 1000.f;
-  uint16_t im = 60000;
   uint32_t maxNh = 0;
+
+  // find maxNh
+  for (auto it : thisCell.tracks()) {
+    auto nh = foundNtuplets->size(it);
+    maxNh = std::max(nh, maxNh);
+  }
+
+  for (auto it : thisCell.tracks()) {
+    if (foundNtuplets->size(it) != maxNh)
+      quality[it] = dup;  //no race:  simple assignment of the same constant
+  }
+
+}
+
+
+__global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
+                                            uint32_t const *__restrict__ nCells,
+                                            TuplesOnGPU::Container *foundNtuplets,
+                                            Rfit::helix_fit const *__restrict__ hfit,
+                                            pixelTuplesHeterogeneousProduct::Quality *quality) {
+  constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
+  constexpr auto dup = pixelTuplesHeterogeneousProduct::dup;
+  constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
+
+  assert(nCells);
+
+  auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (cellIndex >= (*nCells))
+    return;
+  auto const &thisCell = cells[cellIndex];
+  if (thisCell.theDoubletId < 0)
+    return;
+
+  float mc = 10000.f;
+  uint16_t im = 60000;
 
   auto score = [&](auto it) {
     return std::abs(hfit[it].par(1));  // tip
     // return hfit[it].chi2_line+hfit[it].chi2_circle;  //chi2
   };
 
-  // find maxNh
-  for (auto it : thisCell.tracks()) {
-    if (quality[it] == bad)
-      continue;
-    auto nh = foundNtuplets->size(it);
-    maxNh = std::max(nh, maxNh);
-  }
   // find min chi2
   for (auto it : thisCell.tracks()) {
-    auto nh = foundNtuplets->size(it);
-    if (nh != maxNh)
-      continue;
-    if (quality[it] != bad && score(it) < mc) {
+    if (quality[it] == loose && score(it) < mc) {
       mc = score(it);
       im = it;
     }
   }
-  // mark duplicates
+  // mark all other duplicates
   for (auto it : thisCell.tracks()) {
     if (quality[it] != bad && it != im)
       quality[it] = dup;  //no race:  simple assignment of the same constant
@@ -184,27 +215,49 @@ __global__ void kernel_connect(AtomicPairCounter *apc1,
 
   if (cellIndex >= (*nCells))
     return;
-  auto const &thisCell = cells[cellIndex];
-  if (thisCell.theDoubletId < 0)
-    return;
+  auto & thisCell = cells[cellIndex];
+  //if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
+  //  return;
   auto innerHitId = thisCell.get_inner_hit_id();
   auto numberOfPossibleNeighbors = isOuterHitOfCell[innerHitId].size();
   auto vi = isOuterHitOfCell[innerHitId].data();
+
+  constexpr uint32_t last_bpix1_detIndex = 96;
+  constexpr uint32_t last_barrel_detIndex = 1184;
+  auto ri = thisCell.get_inner_r(hh);
+  auto zi = thisCell.get_inner_z(hh);
+
+  auto ro = thisCell.get_outer_r(hh);
+  auto zo = thisCell.get_outer_z(hh);
+  auto isBarrel = thisCell.get_inner_detIndex(hh) < last_barrel_detIndex;
+
   for (auto j = first; j < numberOfPossibleNeighbors; j += stride) {
     auto otherCell = __ldg(vi + j);
-    if (cells[otherCell].theDoubletId < 0)
-      continue;
-    if (thisCell.check_alignment(hh,
-                                 cells[otherCell],
-                                 ptmin,
-                                 hardCurvCut,
-                                 CAThetaCutBarrel,
-                                 CAThetaCutForward,
-                                 dcaCutInnerTriplet,
-                                 dcaCutOuterTriplet)) {
-      cells[otherCell].addOuterNeighbor(cellIndex, *cellNeighbors);
+    auto & oc = cells[otherCell];
+    // if (cells[otherCell].theDoubletId < 0 ||
+    //    cells[otherCell].theUsed>1 )
+    //  continue;
+    auto r1 = oc.get_inner_r(hh);
+    auto z1 = oc.get_inner_z(hh);
+    // auto isBarrel = oc.get_outer_detIndex(hh) < last_barrel_detIndex;
+    bool aligned = GPUCACell::areAlignedRZ(r1,
+                                z1,
+                                ri,
+                                zi,
+                                ro,
+                                zo,
+                                ptmin,
+                                isBarrel ? CAThetaCutBarrel : CAThetaCutForward);  // 2.f*thetaCut); // FIXME tune cuts
+    if(aligned &&
+      thisCell.dcaCut(hh,oc,
+                      oc.get_inner_detIndex(hh) < last_bpix1_detIndex ? dcaCutInnerTriplet : dcaCutOuterTriplet,
+                      hardCurvCut)
+       ) {  // FIXME tune cuts
+      oc.addOuterNeighbor(cellIndex, *cellNeighbors);
+      thisCell.theUsed |= 1;
+      oc.theUsed |= 1;
     }
-  }
+  } // loop on inner cells
 }
 
 __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
@@ -213,8 +266,9 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                                      CellTracksVector *cellTracks,
                                      TuplesOnGPU::Container *foundNtuplets,
                                      AtomicPairCounter *apc,
-                                     GPUCACell::TupleMultiplicity *tupleMultiplicity,
-                                     unsigned int minHitsPerNtuplet) {
+                                     Quality * __restrict__ quality,
+                                     unsigned int minHitsPerNtuplet, 
+                                     int start) {
   // recursive: not obvious to widen
   auto const &hh = *hhp;
 
@@ -223,15 +277,17 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     return;
   auto &thisCell = cells[cellIndex];
 
-#ifdef CA_USE_LOCAL_COUNTERS
-  __shared__ GPUCACell::TupleMultiplicity::CountersOnly local;
-  if (0 == threadIdx.x)
-    local.zero();
-  __syncthreads();
-#endif
+  if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
+    return;
 
-  if (thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
-      thisCell.theLayerPairId == 8) {  // inner layer is 0 FIXME
+  // this stuff may need further optimization....
+  bool myStart[3];
+  myStart[0] =  thisCell.theLayerPairId <3; // inner layer is "0"
+  myStart[1] =  thisCell.theLayerPairId >2 && thisCell.theLayerPairId <8; // inner layer is "1"
+  myStart[2] =  thisCell.theLayerPairId > 12;  // jumps
+  //
+  auto doit = start>=0 ? myStart[start] : myStart[0]||myStart[1]||myStart[2];
+  if (doit) {
     GPUCACell::TmpTuple stack;
     stack.reset();
     thisCell.find_ntuplets(hh,
@@ -239,26 +295,35 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                            *cellTracks,
                            *foundNtuplets,
                            *apc,
-#ifdef CA_USE_LOCAL_COUNTERS
-                           local,
-#else
-                           *tupleMultiplicity,
-#endif
+                           quality,
                            stack,
-                           minHitsPerNtuplet);
+                           minHitsPerNtuplet, 
+                           myStart[0]);
     assert(stack.size() == 0);
     // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
   }
 
-#ifdef CA_USE_LOCAL_COUNTERS
-  __syncthreads();
-  if (0 == threadIdx.x)
-    tupleMultiplicity->add(local);
-#endif
 }
 
-__global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
-                                        GPUCACell::TupleMultiplicity *tupleMultiplicity) {
+
+__global__ void kernel_mark_used(GPUCACell::Hits const *__restrict__ hhp,
+                                     GPUCACell *__restrict__ cells,
+                                     uint32_t const *nCells) {
+
+  // auto const &hh = *hhp;
+
+  auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
+  if (cellIndex >= (*nCells))
+    return;
+  auto &thisCell = cells[cellIndex];
+  if (!thisCell.tracks().empty())
+    thisCell.theUsed |= 2;
+
+}
+
+__global__ void kernel_countMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
+                                         Quality const * __restrict__ quality,
+                                         CAConstants::TupleMultiplicity *tupleMultiplicity) {
   auto it = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (it >= foundNtuplets->nbins())
@@ -267,8 +332,33 @@ __global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict
   auto nhits = foundNtuplets->size(it);
   if (nhits < 3)
     return;
+  if (quality[it] == pixelTuplesHeterogeneousProduct::dup) return;
+  assert(quality[it] == pixelTuplesHeterogeneousProduct::bad);
+  if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
+  assert(nhits<8);
+  tupleMultiplicity->countDirect(nhits);
+}
+
+
+
+__global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
+                                        Quality const * __restrict__ quality,
+                                        CAConstants::TupleMultiplicity *tupleMultiplicity) {
+  auto it = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (it >= foundNtuplets->nbins())
+    return;
+
+  auto nhits = foundNtuplets->size(it);
+  if (nhits < 3)
+    return;
+  if (quality[it] == pixelTuplesHeterogeneousProduct::dup) return;
+  if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
+  assert(nhits<8);
   tupleMultiplicity->fillDirect(nhits, it);
 }
+
+
 
 __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__ tuples,
                                       Rfit::helix_fit const *__restrict__ fit_results,
@@ -282,8 +372,10 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
     return;
   }
 
-  // mark as bad by default
-  quality[idx] = pixelTuplesHeterogeneousProduct::bad;
+  // if duplicate: not even fit
+  if (quality[idx] == pixelTuplesHeterogeneousProduct::dup) return;
+
+  assert(quality[idx] == pixelTuplesHeterogeneousProduct::bad);
 
   // mark doublets as bad
   if (tuples->size(idx) < 3) {
@@ -296,7 +388,7 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
     isNaN |= isnan(fit_results[idx].par(i));
   }
   if (isNaN) {
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
     printf("NaN in fit %d size %d chi2 %f + %f\n",
            idx,
            tuples->size(idx),
@@ -316,10 +408,12 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
   float chi2Cut = cuts.chi2Scale *
                   (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
   if (fit_results[idx].chi2_line + fit_results[idx].chi2_circle >= chi2Cut) {
-#ifdef GPU_DEBUG
-    printf("Bad fit %d size %d chi2 %f + %f\n",
+#ifdef NTUPLE_DEBUG
+    printf("Bad fit %d size %d pt %f eta %f chi2 l %f + c %f\n",
            idx,
-           tuples->size(idx),
+           tuples->size(idx), 
+           fit_results[idx].par(2),
+           asinhf(fit_results[idx].par(3)), 
            fit_results[idx].chi2_line,
            fit_results[idx].chi2_circle);
 #endif
@@ -492,17 +586,35 @@ __global__ void kernel_tripletCleaner(TrackingRecHit2DSOAView const *__restrict_
   }  // loop over hits
 }
 
-__global__ void kernel_print_found_ntuplets(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
-                                            uint32_t maxPrint) {
-  for (int i = 0; i < std::min(maxPrint, foundNtuplets->nbins()); ++i) {
-    if (foundNtuplets->size(i) < 4)
-      continue;
-    printf("\nquadruplet %d: %d %d %d %d\n",
-           i,
-           (*(*foundNtuplets).begin(i)),
-           (*(*foundNtuplets).begin(i) + 1),
-           (*(*foundNtuplets).begin(i) + 2),
-           (*(*foundNtuplets).begin(i) + 3));
+__global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__restrict__ hhp,
+                                      TuplesOnGPU::Container const *__restrict__ ptuples,
+                                      Rfit::helix_fit const *__restrict__ fit_results,
+                                      Quality *__restrict__ quality,
+                                      CAHitQuadrupletGeneratorKernels::HitToTuple const *__restrict__ phitToTuple,
+                                      uint32_t maxPrint, int iev) {
+  auto const & foundNtuplets = *ptuples;
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < std::min(maxPrint, foundNtuplets.nbins()); i+=blockDim.x*gridDim.x) {
+    auto nh = foundNtuplets.size(i);
+    if (nh<3) continue;
+    printf("TK: %d %d %d %f %f %f %f %f %f %f %f %d %d %d %d %d\n",
+           10000*iev+i,
+           int(quality[i]),
+           nh,
+           fit_results[i].par(0),
+           fit_results[i].par(1),
+           fit_results[i].par(2),
+           fit_results[i].par(3),
+           fit_results[i].par(4),
+           asinhf(fit_results[i].par(3)),
+           fit_results[i].chi2_line,
+           fit_results[i].chi2_circle,
+           *foundNtuplets.begin(i),
+           *(foundNtuplets.begin(i) + 1),
+           *(foundNtuplets.begin(i) + 2),
+           nh>3 ? int(*(foundNtuplets.begin(i) + 3)):-1,
+           nh>4 ? int(*(foundNtuplets.begin(i) + 4)):-1
+          );
   }
 }
 
@@ -516,17 +628,12 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
 
-  if (nhits > 1 && earlyFishbone_) {
-    auto nthTot = 64;
-    auto stride = 4;
-    auto blockSize = nthTot / stride;
-    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
-    dim3 blks(1, numberOfBlocks, 1);
-    dim3 thrs(stride, blockSize, 1);
-    fishbone<<<blks, thrs, 0, cudaStream>>>(
-        hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
-    cudaCheck(cudaGetLastError());
-  }
+  // std::cout << "N hits " << nhits << std::endl;
+  // if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
+
+  //
+  // applying conbinatoric cleaning such as fishbone at this stage is too expensive
+  //
 
   auto nthTot = 64;
   auto stride = 4;
@@ -556,24 +663,63 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
       dcaCutOuterTriplet_);
   cudaCheck(cudaGetLastError());
 
-  kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
+
+  if (nhits > 1 && earlyFishbone_) {
+    auto nthTot = 128;
+    auto stride = 16;
+    auto blockSize = nthTot / stride;
+    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
+    dim3 blks(1, numberOfBlocks, 1);
+    dim3 thrs(stride, blockSize, 1);
+    fishbone<<<blks, thrs, 0, cudaStream>>>(
+        hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
+    cudaCheck(cudaGetLastError());
+  }
+
+
+  blockSize = 64;
+  numberOfBlocks = (maxNumberOfDoublets_ + blockSize - 1) / blockSize;
+  int nIter = doIterations_ ? 3 : 1;
+  if (minHitsPerNtuplet_>3) nIter=1;
+  for (int startLayer=0; startLayer<nIter; ++startLayer) {
+    kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                      device_theCells_.get(),
                                                                      device_nCells_,
                                                                      device_theCellTracks_,
                                                                      gpu_.tuples_d,
                                                                      gpu_.apc_d,
-                                                                     device_tupleMultiplicity_,
-                                                                     minHitsPerNtuplet_);
-  cudaCheck(cudaGetLastError());
+                                                                     gpu_.quality_d,
+                                                                     minHitsPerNtuplet_,
+                                                                     doIterations_ ? startLayer : -1);
+    cudaCheck(cudaGetLastError());
 
+    if (doIterations_ || doStats_)
+    kernel_mark_used<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
+                                                                   device_theCells_.get(),
+                                                                   device_nCells_);
+    cudaCheck(cudaGetLastError());
+  }
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
+
+  blockSize = 128;
   numberOfBlocks = (TuplesOnGPU::Container::totbins() + blockSize - 1) / blockSize;
   cudautils::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.apc_d, gpu_.tuples_d);
 
-  cudautils::launchFinalize(device_tupleMultiplicity_, device_tmws_, cudaStream);
+  // remove duplicates (tracks that share a doublet)
+  numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
+  kernel_earlyDuplicateRemover<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
+      device_theCells_.get(), device_nCells_, gpu_.tuples_d, gpu_.quality_d);
+  cudaCheck(cudaGetLastError());
 
   blockSize = 128;
   numberOfBlocks = (CAConstants::maxTuples() + blockSize - 1) / blockSize;
-  kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, device_tupleMultiplicity_);
+  kernel_countMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, gpu_.quality_d, device_tupleMultiplicity_);
+  cudautils::launchFinalize(device_tupleMultiplicity_, device_tmws_, cudaStream);
+  kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, gpu_.quality_d, device_tupleMultiplicity_);
   cudaCheck(cudaGetLastError());
 
   if (nhits > 1 && lateFishbone_) {
@@ -591,6 +737,7 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   if (doStats_) {
     numberOfBlocks = (std::max(nhits, maxNumberOfDoublets_) + blockSize - 1) / blockSize;
     kernel_checkOverflows<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d,
+                                                                        device_tupleMultiplicity_,
                                                                         gpu_.apc_d,
                                                                         device_theCells_.get(),
                                                                         device_nCells_,
@@ -600,27 +747,34 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                         nhits,
                                                                         counters_);
     cudaCheck(cudaGetLastError());
-#ifdef GPU_DEBUG
-    cudaDeviceSynchronize();
-#endif
   }
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
 
-  // kernel_print_found_ntuplets<<<1, 1, 0, cudaStream>>>(gpu_.tuples_d, 10);
 }
 
 void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::stream_t<> &stream) {
   auto nhits = hh.nHits();
 
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
   std::cout << "building Doublets out of " << nhits << " Hits" << std::endl;
+#endif
+
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
 #endif
 
   // in principle we can use "nhits" to heuristically dimension the workspace...
   edm::Service<CUDAService> cs;
-  device_isOuterHitOfCell_ = cs->make_device_unique<GPUCACell::OuterHitOfCell[]>(nhits, stream);
+  device_isOuterHitOfCell_ = cs->make_device_unique<GPUCACell::OuterHitOfCell[]>(std::max(1U,nhits), stream);
+  assert(device_isOuterHitOfCell_.get());
   {
     int threadsPerBlock = 128;
-    int blocks = (nhits + threadsPerBlock - 1) / threadsPerBlock;
+    // at least one block!
+    int blocks = ( std::max(1U,nhits) + threadsPerBlock - 1) / threadsPerBlock;
     gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0, stream.id()>>>(device_isOuterHitOfCell_.get(),
                                                                                 nhits,
                                                                                 device_theCellNeighbors_,
@@ -632,9 +786,22 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
 
   device_theCells_ = cs->make_device_unique<GPUCACell[]>(CAConstants::maxNumberOfDoublets(), stream);
 
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
   if (0 == nhits)
     return;  // protect against empty events
 
+  // FIXME avoid magic numbers
+  auto nActualPairs=gpuPixelDoublets::nPairs;
+  if (!includeJumpingForwardDoublets_) nActualPairs = 15;
+  if (minHitsPerNtuplet_>3) {
+    nActualPairs = 13;
+  }
+
+  assert(nActualPairs<=gpuPixelDoublets::nPairs);
   int stride = 1;
   int threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
   int blocks = (2 * nhits + threadsPerBlock - 1) / threadsPerBlock;
@@ -646,11 +813,18 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
                                                                          device_theCellTracks_,
                                                                          hh.view(),
                                                                          device_isOuterHitOfCell_.get(),
+                                                                         nActualPairs,
                                                                          idealConditions_,
                                                                          doClusterCut_,
                                                                          doZCut_,
                                                                          doPhiCut_);
   cudaCheck(cudaGetLastError());
+
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
 }
 
 void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
@@ -664,11 +838,13 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
       tuples.tuples_d, tuples.helix_fit_results_d, cuts_, tuples.quality_d);
   cudaCheck(cudaGetLastError());
 
-  // apply fishbone cleaning to good tracks
-  numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
-  kernel_fishboneCleaner<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
-      device_theCells_.get(), device_nCells_, tuples.quality_d);
-  cudaCheck(cudaGetLastError());
+  if (lateFishbone_) {
+    // apply fishbone cleaning to good tracks
+    numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
+    kernel_fishboneCleaner<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
+        device_theCells_.get(), device_nCells_, tuples.quality_d);
+    cudaCheck(cudaGetLastError());
+  }
 
   // remove duplicates (tracks that share a doublet)
   numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
@@ -702,29 +878,42 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
     kernel_doStatsForTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples.tuples_d, tuples.quality_d, counters_);
     cudaCheck(cudaGetLastError());
   }
+#ifdef GPU_DEBUG
+    cudaDeviceSynchronize();
+    cudaCheck(cudaGetLastError());
+#endif
+
+#ifdef    DUMP_GPU_TK_TUPLES
+  static std::atomic<int> iev(0);
+  ++iev;
+  kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(hh.view(), tuples.tuples_d, tuples.helix_fit_results_d, tuples.quality_d, device_hitToTuple_, 100,iev);
+#endif
+
 }
 
 __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters const *counters) {
   auto const &c = *counters;
   printf(
-      "||Counters | nEvents | nHits | nCells | nTuples | nGoodTracks | nUsedHits | nDupHits | nKilledCells | "
+      "||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nGoodTracks | nUsedHits | nDupHits | nKilledCells | "
       "nEmptyCells | nZeroTrackCells ||\n");
-  printf("Counters Raw %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
+  printf("Counters Raw %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
          c.nEvents,
          c.nHits,
          c.nCells,
          c.nTuples,
          c.nGoodTracks,
+         c.nFitTracks,
          c.nUsedHits,
          c.nDupHits,
          c.nKilledCells,
          c.nEmptyCells,
          c.nZeroTrackCells);
-  printf("Counters Norm %lld ||  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.3f|  %.3f||\n",
+  printf("Counters Norm %lld ||  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.3f|  %.3f||\n",
          c.nEvents,
          c.nHits / double(c.nEvents),
          c.nCells / double(c.nEvents),
          c.nTuples / double(c.nEvents),
+         c.nFitTracks / double(c.nEvents),
          c.nGoodTracks / double(c.nEvents),
          c.nUsedHits / double(c.nEvents),
          c.nDupHits / double(c.nEvents),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -7,6 +7,9 @@
 
 #include "GPUCACell.h"
 
+// #define DUMP_GPU_TK_TUPLES
+
+
 class CAHitQuadrupletGeneratorKernels {
 public:
   // counters
@@ -15,6 +18,7 @@ public:
     unsigned long long nHits;
     unsigned long long nCells;
     unsigned long long nTuples;
+    unsigned long long nFitTracks;
     unsigned long long nGoodTracks;
     unsigned long long nUsedHits;
     unsigned long long nDupHits;
@@ -48,6 +52,7 @@ public:
   };
 
   CAHitQuadrupletGeneratorKernels(uint32_t minHitsPerNtuplet,
+                                  bool includeJumpingForwardDoublets,
                                   bool earlyFishbone,
                                   bool lateFishbone,
                                   bool idealConditions,
@@ -55,6 +60,7 @@ public:
                                   bool doClusterCut,
                                   bool doZCut,
                                   bool doPhiCut,
+                                  bool doIterations,
                                   float ptmin,
                                   float CAThetaCutBarrel,
                                   float CAThetaCutForward,
@@ -63,6 +69,7 @@ public:
                                   float dcaCutOuterTriplet,
                                   QualityCuts const& cuts)
       : minHitsPerNtuplet_(minHitsPerNtuplet),
+        includeJumpingForwardDoublets_(includeJumpingForwardDoublets),
         earlyFishbone_(earlyFishbone),
         lateFishbone_(lateFishbone),
         idealConditions_(idealConditions),
@@ -70,6 +77,7 @@ public:
         doClusterCut_(doClusterCut),
         doZCut_(doZCut),
         doPhiCut_(doPhiCut),
+        doIterations_(doIterations),
         ptmin_(ptmin),
         CAThetaCutBarrel_(CAThetaCutBarrel),
         CAThetaCutForward_(CAThetaCutForward),
@@ -118,6 +126,7 @@ private:
 
   // params
   const uint32_t minHitsPerNtuplet_;
+  const bool includeJumpingForwardDoublets_;
   const bool earlyFishbone_;
   const bool lateFishbone_;
   const bool idealConditions_;
@@ -125,6 +134,7 @@ private:
   const bool doClusterCut_;
   const bool doZCut_;
   const bool doPhiCut_;
+  const bool doIterations_;
   const float ptmin_;
   const float CAThetaCutBarrel_;
   const float CAThetaCutForward_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -267,7 +267,7 @@ public:
     bool last=true;
     for (int j = 0; j < outerNeighbors().size(); ++j) {
       auto otherCell = outerNeighbors()[j];
-      if (cells[otherCell].theDoubletId<0 || cells[otherCell].theUsed>1) continue; // already in a track found in previous iteration
+      if (cells[otherCell].theDoubletId<0) continue; // killed by earlyFishbone
         last = false;
         cells[otherCell].find_ntuplets(
             hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet,startAt0);

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -5,6 +5,9 @@
 // Author: Felice Pantaleo, CERN
 //
 
+
+// #define ONLY_TRIPLETS_IN_HOLE
+
 #include <cuda_runtime.h>
 
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h"
@@ -32,7 +35,8 @@ public:
 
   using TuplesOnGPU = pixelTuplesHeterogeneousProduct::TuplesOnGPU;
 
-  using TupleMultiplicity = CAConstants::TupleMultiplicity;
+  using Quality = pixelTuplesHeterogeneousProduct::Quality;
+  static constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
 
   GPUCACell() = default;
 #ifdef __CUDACC__
@@ -48,7 +52,9 @@ public:
     theOuterHitId = outerHitId;
     theDoubletId = doubletId;
     theLayerPairId = layerPairId;
+    theUsed = 0;
 
+    // optimization that depends on access pattern
     theInnerZ = hh.zGlobal(innerHitId);
     theInnerR = hh.rGlobal(innerHitId);
 
@@ -74,13 +80,11 @@ public:
   __device__ __forceinline__ float get_outer_x(Hits const& hh) const { return hh.xGlobal(theOuterHitId); }
   __device__ __forceinline__ float get_inner_y(Hits const& hh) const { return hh.yGlobal(theInnerHitId); }
   __device__ __forceinline__ float get_outer_y(Hits const& hh) const { return hh.yGlobal(theOuterHitId); }
-  __device__ __forceinline__ float get_inner_z(Hits const& hh) const {
-    return theInnerZ;
-  }  // { return hh.zGlobal(theInnerHitId); } // { return theInnerZ; }
+  __device__ __forceinline__ float get_inner_z(Hits const& hh) const { return theInnerZ; }
+     // { return hh.zGlobal(theInnerHitId); } // { return theInnerZ; }
   __device__ __forceinline__ float get_outer_z(Hits const& hh) const { return hh.zGlobal(theOuterHitId); }
-  __device__ __forceinline__ float get_inner_r(Hits const& hh) const {
-    return theInnerR;
-  }  // { return hh.rGlobal(theInnerHitId); } // { return theInnerR; }
+  __device__ __forceinline__ float get_inner_r(Hits const& hh) const { return theInnerR; }
+     // { return hh.rGlobal(theInnerHitId); } // { return theInnerR; }
   __device__ __forceinline__ float get_outer_r(Hits const& hh) const { return hh.rGlobal(theOuterHitId); }
 
   __device__ __forceinline__ auto get_inner_iphi(Hits const& hh) const { return hh.iphi(theInnerHitId); }
@@ -137,7 +141,6 @@ public:
                    otherCell,
                    otherCell.get_inner_detIndex(hh) < last_bpix1_detIndex ? dcaCutInnerTriplet : dcaCutOuterTriplet,
                    hardCurvCut));  // FIXME tune cuts
-                                   // region_origin_radius_plus_tolerance,  hardCurvCut));
   }
 
   __device__ __forceinline__ static bool areAlignedRZ(
@@ -173,42 +176,85 @@ public:
     return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
   }
 
-  __device__ inline bool hole(Hits const& hh, GPUCACell const& innerCell) const {
-    constexpr uint32_t max_ladder_bpx4 = 64;
-    constexpr float radius_even_ladder = 15.815f;
-    constexpr float radius_odd_ladder = 16.146f;
-    constexpr float ladder_length = 6.7f;
-    constexpr float ladder_tolerance = 0.2f;
-    constexpr float barrel_z_length = 26.f;
-    constexpr float forward_z_begin = 32.f;
-    int p = get_outer_iphi(hh);
+
+  __device__ __forceinline__ static bool dcaCutH(float x1,float y1, float x2,float y2, float x3,float y3,
+                                const float region_origin_radius_plus_tolerance,
+                                   const float maxCurv) {
+
+    CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
+
+    if (eq.curvature() > maxCurv)
+      return false;
+
+    return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
+  }
+
+
+
+  __device__ inline bool hole0(Hits const& hh, GPUCACell const& innerCell) const {
+    constexpr uint32_t max_ladder_bpx0 = 12;
+    constexpr uint32_t first_ladder_bpx0 = 0;
+    constexpr float module_length = 6.7f;
+    constexpr float module_tolerance = 0.4f; // projection to cylinder is inaccurate on BPIX1
+    int p = innerCell.get_inner_iphi(hh);
     if (p < 0)
       p += std::numeric_limits<unsigned short>::max();
-    p = (max_ladder_bpx4 * p) / std::numeric_limits<unsigned short>::max();
-    p %= 2;
-    float r4 = p == 0 ? radius_even_ladder : radius_odd_ladder;  // later on from geom
+    p = (max_ladder_bpx0 * p) / std::numeric_limits<unsigned short>::max();
+    p %= max_ladder_bpx0;
+    auto il = first_ladder_bpx0+p;
+    auto r0 = hh.averageGeometry().ladderR[il];
     auto ri = innerCell.get_inner_r(hh);
     auto zi = innerCell.get_inner_z(hh);
     auto ro = get_outer_r(hh);
     auto zo = get_outer_z(hh);
-    auto z4 = std::abs(zi + (r4 - ri) * (zo - zi) / (ro - ri));
-    auto z_in_ladder = z4 - ladder_length * int(z4 / ladder_length);
-    auto h = z_in_ladder < ladder_tolerance || z_in_ladder > (ladder_length - ladder_tolerance);
-    return h || (z4 > barrel_z_length && z4 < forward_z_begin);
+    auto z0 = zi + (r0 - ri) * (zo - zi) / (ro - ri);
+    auto z_in_ladder = std::abs(z0-hh.averageGeometry().ladderZ[il]);
+    auto z_in_module = z_in_ladder - module_length * int(z_in_ladder / module_length);
+    auto gap = z_in_module < module_tolerance || z_in_module > (module_length - module_tolerance);
+    return gap;
+  }
+
+
+  __device__ inline bool hole4(Hits const& hh, GPUCACell const& innerCell) const {
+    constexpr uint32_t max_ladder_bpx4 = 64;
+    constexpr uint32_t first_ladder_bpx4 = 84;
+    // constexpr float radius_even_ladder = 15.815f;
+    // constexpr float radius_odd_ladder = 16.146f;
+    constexpr float module_length = 6.7f;
+    constexpr float module_tolerance = 0.2f;
+    // constexpr float barrel_z_length = 26.f;
+    // constexpr float forward_z_begin = 32.f;
+    int p = get_outer_iphi(hh);
+    if (p < 0)
+      p += std::numeric_limits<unsigned short>::max();
+    p = (max_ladder_bpx4 * p) / std::numeric_limits<unsigned short>::max();
+    p %= max_ladder_bpx4;
+    auto il = first_ladder_bpx4+p;  
+    auto r4 = hh.averageGeometry().ladderR[il];
+    auto ri = innerCell.get_inner_r(hh);
+    auto zi = innerCell.get_inner_z(hh);
+    auto ro = get_outer_r(hh);
+    auto zo = get_outer_z(hh);
+    auto z4 = zo + (r4 - ro) * (zo - zi) / (ro - ri);
+    auto z_in_ladder = std::abs(z4-hh.averageGeometry().ladderZ[il]);
+    auto z_in_module = z_in_ladder - module_length * int(z_in_ladder / module_length);
+    auto gap = z_in_module < module_tolerance || z_in_module > (module_length - module_tolerance);
+    auto holeP = z4 > hh.averageGeometry().ladderMaxZ[il] && z4 < hh.averageGeometry().endCapZ[0];
+    auto holeN = z4 < hh.averageGeometry().ladderMinZ[il] && z4 > hh.averageGeometry().endCapZ[1];
+    return gap || holeP || holeN;
   }
 
   // trying to free the track building process from hardcoded layers, leaving
   // the visit of the graph based on the neighborhood connections between cells.
-
-  template <typename CM>
   __device__ inline void find_ntuplets(Hits const& hh,
                                        GPUCACell* __restrict__ cells,
                                        CellTracksVector& cellTracks,
                                        TuplesOnGPU::Container& foundNtuplets,
                                        AtomicPairCounter& apc,
-                                       CM& tupleMultiplicity,
+                                       Quality* __restrict__ quality,
                                        TmpTuple& tmpNtuplet,
-                                       const unsigned int minHitsPerNtuplet) const {
+                                       const unsigned int minHitsPerNtuplet,
+                                       bool startAt0) const {
     // the building process for a track ends if:
     // it has no right neighbor
     // it has no compatible neighbor
@@ -218,29 +264,35 @@ public:
     tmpNtuplet.push_back_unsafe(theDoubletId);
     assert(tmpNtuplet.size() <= 4);
 
-    if (outerNeighbors().size() > 0) {
-      for (int j = 0; j < outerNeighbors().size(); ++j) {
-        auto otherCell = outerNeighbors()[j];
+    bool last=true;
+    for (int j = 0; j < outerNeighbors().size(); ++j) {
+      auto otherCell = outerNeighbors()[j];
+      if (cells[otherCell].theDoubletId<0 || cells[otherCell].theUsed>1) continue; // already in a track found in previous iteration
+        last = false;
         cells[otherCell].find_ntuplets(
-            hh, cells, cellTracks, foundNtuplets, apc, tupleMultiplicity, tmpNtuplet, minHitsPerNtuplet);
-      }
-    } else {  // if long enough save...
+            hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet,startAt0);
+    }
+    if(last) {  // if long enough save...
       if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet - 1) {
-#ifndef ALL_TRIPLETS
+#ifdef ONLY_TRIPLETS_IN_HOLE
         // triplets accepted only pointing to the hole
-        if (tmpNtuplet.size() >= 3 || hole(hh, cells[tmpNtuplet[0]]))
+        if (tmpNtuplet.size() >= 3 || 
+            ( startAt0&&hole4(hh, cells[tmpNtuplet[0]]) ) ||
+            ( (!startAt0)&&hole0(hh, cells[tmpNtuplet[0]]) )
+        )
 #endif
         {
           hindex_type hits[6];
           auto nh = 0U;
-          for (auto c : tmpNtuplet)
+          for (auto c : tmpNtuplet) {
             hits[nh++] = cells[c].theInnerHitId;
+          }
           hits[nh] = theOuterHitId;
           auto it = foundNtuplets.bulkFill(apc, hits, tmpNtuplet.size() + 1);
           if (it >= 0) {  // if negative is overflow....
             for (auto c : tmpNtuplet)
               cells[c].addTrack(it, cellTracks);
-            tupleMultiplicity.countDirect(tmpNtuplet.size() + 1);
+            quality[it] =  bad; // initialize to bad
           }
         }
       }
@@ -257,7 +309,8 @@ private:
 
 public:
   int32_t theDoubletId;
-  int32_t theLayerPairId;
+  int16_t theLayerPairId;
+  uint16_t theUsed; // tbd
 
 private:
   float theInnerZ;

--- a/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
@@ -10,7 +10,8 @@ class TrackingRecHit2DSOAView;
 class TrackingRecHit2DCUDA;
 
 namespace Rfit {
-  constexpr uint32_t maxNumberOfConcurrentFits() { return 6 * 1024; }
+  // in case of memory issue can be made smaller
+  constexpr uint32_t maxNumberOfConcurrentFits() { return CAConstants::maxNumberOfTuples(); }
   constexpr uint32_t stride() { return maxNumberOfConcurrentFits(); }
   using Matrix3x4d = Eigen::Matrix<double, 3, 4>;
   using Map3x4d = Eigen::Map<Matrix3x4d, 0, Eigen::Stride<3 * stride(), stride()> >;

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -40,6 +40,7 @@ namespace gpuPixelDoublets {
     if (s < 2)
       return;
     // if alligned kill one of the two.
+    // in principle one could try to relax the cut (only in r-z?) for jumping-doublets 
     auto const& c0 = cells[vc[0]];
     auto xo = c0.get_outer_x(hh);
     auto yo = c0.get_outer_y(hh);
@@ -50,6 +51,7 @@ namespace gpuPixelDoublets {
     auto sg = 0;
     for (uint32_t ic = 0; ic < s; ++ic) {
       auto& ci = cells[vc[ic]];
+      if (0==ci.theUsed) continue; // for triplets equivalent to next 
       if (checkTrack && ci.tracks().empty())
         continue;
       cc[sg] = vc[ic];

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -9,60 +9,40 @@ namespace gpuPixelDoublets {
 
   using namespace gpuPixelDoubletsAlgos;
 
-  constexpr int nPairs = 13;
+  constexpr int nPairs = 13+2+4;
+  static_assert(nPairs<=CAConstants::maxNumberOfLayerPairs());
+
+// start constants
+// clang-format off 
+
   CONSTANT_VAR const uint8_t layerPairs[2 * nPairs] = {
-      0,
-      1,
-      1,
-      2,
-      2,
-      3,
-      // 0, 4,  1, 4,  2, 4,  4, 5,  5, 6,
-      0,
-      7,
-      1,
-      7,
-      2,
-      7,
-      7,
-      8,
-      8,
-      9,  // neg
-      0,
-      4,
-      1,
-      4,
-      2,
-      4,
-      4,
-      5,
-      5,
-      6,  // pos
+      0,1, 0,4, 0,7, // BPIX1 (3)
+      1,2, 1,4, 1,7, // BPIX2 (5)
+      4,5, 7,8,      // FPIX1 (8)
+      2,3, 2,4, 2,7, 5,6, 8,9,  // BPIX3 & FPIX2 (13)
+      0,2, 1,3,      // Jumping Barrel (15)
+      0,5, 0,8,      // Jumping Forward (BPIX1,FPIX2)
+      4,6, 7,9       // Jumping Forward (19)
   };
 
   constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
   constexpr int16_t phi0p06 = 626;  // round(625.82270...) = phi2short(0.06);
   constexpr int16_t phi0p07 = 730;  // round(730.12648...) = phi2short(0.07);
 
-  CONSTANT_VAR const int16_t phicuts[nPairs]{phi0p05,
-                                             phi0p05,
-                                             phi0p06,
-                                             phi0p07,
-                                             phi0p06,
-                                             phi0p06,
-                                             phi0p05,
-                                             phi0p05,
-                                             phi0p07,
-                                             phi0p06,
-                                             phi0p06,
-                                             phi0p05,
-                                             phi0p05};
+  CONSTANT_VAR const int16_t phicuts[nPairs]{
+     phi0p05, phi0p07, phi0p07, 
+     phi0p05, phi0p06, phi0p06,
+     phi0p05, phi0p05,
+     phi0p06, phi0p06, phi0p06, phi0p05, phi0p05,
+     phi0p05, phi0p05, phi0p05,phi0p05, phi0p05,phi0p05};
+//   phi0p07, phi0p07, phi0p06,phi0p06, phi0p06,phi0p06};  // relaxed cuts
 
-  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.};
+  CONSTANT_VAR float const minz[nPairs] = {-20.,0.,-30., -22.,10.,-30., -70.,-70., -22.,15.,-30, -70.,-70., -20.,-22., 0,-30., -70.,-70.};
+  CONSTANT_VAR float const maxz[nPairs] = { 20.,30.,0.,   22.,30.,-10.,  70.,70.,   22.,30.,-15., 70., 70.,  20.,22., 30.,0.,  70.,70.};
+  CONSTANT_VAR float const maxr[nPairs] = {20.,9.,9., 20.,7.,7., 5.,5., 20.,6.,6., 5., 5., 20.,20.,9.,9., 9.,9.}; 
 
-  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.};
-
-  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5.};
+// end constants
+// clang-format on
 
   constexpr uint32_t MaxNumOfDoublets = CAConstants::maxNumberOfDoublets();  // not really relevant
 
@@ -79,6 +59,7 @@ namespace gpuPixelDoublets {
                                CellNeighbors* cellNeighborsContainer,
                                CellTracksVector* cellTracks,
                                CellTracks* cellTracksContainer) {
+    assert(isOuterHitOfCell);
     int first = blockIdx.x * blockDim.x + threadIdx.x;
     for (int i = first; i < nHits; i += gridDim.x * blockDim.x)
       isOuterHitOfCell[i].reset();
@@ -95,13 +76,14 @@ namespace gpuPixelDoublets {
                                                                     CellTracksVector* cellTracks,
                                                                     TrackingRecHit2DSOAView const* __restrict__ hhp,
                                                                     GPUCACell::OuterHitOfCell* isOuterHitOfCell,
+                                                                    int nActualPairs,
                                                                     bool ideal_cond,
                                                                     bool doClusterCut,
                                                                     bool doZCut,
                                                                     bool doPhiCut) {
     auto const& __restrict__ hh = *hhp;
     doubletsFromHisto(layerPairs,
-                      nPairs,
+                      nActualPairs,
                       cells,
                       nCells,
                       cellNeighbors,

--- a/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
@@ -13,7 +13,7 @@ class TrackingRecHit2DSOAView;
 
 namespace pixelTuplesHeterogeneousProduct {
 
-  enum Quality : uint8_t { bad, dup, loose, strict, tight, highPurity };
+  enum Quality : uint8_t { bad=0, dup, loose, strict, tight, highPurity };
 
   using CPUProduct = int;  // dummy
 


### PR DESCRIPTION
Implement "full" pixel triplets reconstruction

default is still quadruplets: no regression w/r/t baseline. eventually a bit slower due to additional infrastructure

to switch triplets: set
```process.pixelTracksHitQuadruplets.minHitsPerNtuplet = 3```


new configurables
```
# set to False to add jumping doublets in the forward (just FPIX1,FPIX3)
process.pixelTracksHitQuadruplets.noForwardTriplets = True
# set to True to enable three iterations of _find_ntuples_ 
# each NOT using doublets already used in previous ones
process.pixelTracksHitQuadruplets.doIterations = False
```

MTV for Single Muon pt-flat ideal
http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_NF/plots_pixel_pixel/effandfakePtEtaPhi.pdf

MTV for Single Muon pt50 realistic 
http://innocent.home.cern.ch/innocent/RelVal/SingleMu50Real_gpuNF/plots_pixel_pixel/effandfakePtEtaPhi.pdf
MTV for ttbar PU50 ideal
http://innocent.home.cern.ch/innocent/RelVal/pixOnlyPU50_gpuNF/plots_pixel_pixel/effandfakePtEtaPhi.pdf

timing (usual HLTPhysics 2018) after f31f13c
on workergpu11 Tesla V100-PCIE-16GB
baseline  1406.5 ±  12.0 ev/s
quadruplets 1261.6 ±   5.0 ev/s
triplets  1056.6 ±   1.7 ev/s
forward-triplets  1012.6 ±   3.8 ev/s
iterative forward-triplets 859.2 ±   1.9 ev/s

NB this is a V100: the cost of fitting is lower: on T4 I would expect a worse performance for adding forward-triplets as it mostly add triplets to be fit.
Confirmed my hypothesis that iterations will make the workflow just slower.
I will try to make optional some of the additional operations needed by iterations to gain speed

I would consider this as a reference point.
Optimization can come later

