### PR TITLE
Build seeds directly from cpu product

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
@@ -189,6 +189,37 @@ namespace Rfit {
     circle.par = par_pak;
   }
 
+  // transformation between the "perigee" to cmssw localcoord frame
+  // the plane of the latter is the perigee plane...
+  // from   //!<(phi,Tip,pt,cotan(theta)),Zip)
+  // to q/p,dx/dz,dy/dz,x,z
+  template<typename V5, typename M5>
+  __host__ __device__ inline void transfromToPerigeePlane(V5 const & ip, M5 const & icov, V5 & op, M5 & ocov, double charge) {
+
+    auto sinTheta2 = 1./(1.+ip(3)*ip(3));
+    auto sinTheta = std::sqrt(sinTheta2);
+    auto cosTheta = ip(3)*sinTheta;
+    auto tipSignNeg = -std::copysign(1.,ip(1));
+
+    op(0) = charge*sinTheta/ip(2);
+    op(1) = 0.;
+    op(2) = tipSignNeg*ip(3);
+    op(3) = std::abs(ip(1));
+    op(4) = tipSignNeg*ip(4);
+
+    Matrix5d J = Matrix5d::Zero();
+
+    J(0,2) = -charge*sinTheta/(ip(2)*ip(2));
+    J(0,3) = -charge*sinTheta2*cosTheta/ip(2);
+    J(1,0) = 1.;
+    J(2,3) = tipSignNeg;
+    J(3,1) = -tipSignNeg;
+    J(4,4) = tipSignNeg;
+
+    ocov=  J*icov*J.transpose();
+
+  }
+
 }  // namespace Rfit
 
 #endif  // RecoPixelVertexing_PixelTrackFitting_interface_FitUtils_h

--- a/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
@@ -194,7 +194,7 @@ namespace Rfit {
   // from   //!<(phi,Tip,pt,cotan(theta)),Zip)
   // to q/p,dx/dz,dy/dz,x,z
   template<typename V5, typename M5>
-  __host__ __device__ inline void transfromToPerigeePlane(V5 const & ip, M5 const & icov, V5 & op, M5 & ocov, double charge) {
+  __host__ __device__ inline void transformToPerigeePlane(V5 const & ip, M5 const & icov, V5 & op, M5 & ocov, double charge) {
 
     auto sinTheta2 = 1./(1.+ip(3)*ip(3));
     auto sinTheta = std::sqrt(sinTheta2);

--- a/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h
@@ -199,22 +199,21 @@ namespace Rfit {
     auto sinTheta2 = 1./(1.+ip(3)*ip(3));
     auto sinTheta = std::sqrt(sinTheta2);
     auto cosTheta = ip(3)*sinTheta;
-    auto tipSignNeg = -std::copysign(1.,ip(1));
 
     op(0) = charge*sinTheta/ip(2);
     op(1) = 0.;
-    op(2) = tipSignNeg*ip(3);
-    op(3) = std::abs(ip(1));
-    op(4) = tipSignNeg*ip(4);
+    op(2) = -ip(3);
+    op(3) = ip(1);
+    op(4) = -ip(4);
 
     Matrix5d J = Matrix5d::Zero();
 
     J(0,2) = -charge*sinTheta/(ip(2)*ip(2));
     J(0,3) = -charge*sinTheta2*cosTheta/ip(2);
     J(1,0) = 1.;
-    J(2,3) = tipSignNeg;
-    J(3,1) = -tipSignNeg;
-    J(4,4) = tipSignNeg;
+    J(2,3) = -1.;
+    J(3,1) = 1.;
+    J(4,4) = -1;
 
     ocov=  J*icov*J.transpose();
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromCUDA.cc
@@ -160,8 +160,8 @@ void PixelTrackProducerFromCUDA::produceGPUCuda(edm::HeterogeneousEvent &iEvent,
 
     LocalTrajectoryParameters lpar(opar(0),opar(1),opar(2),opar(3),opar(4),1.);
     AlgebraicSymMatrix55 m;
-    LocalTrajectoryError error(m);
     for(int i=0; i<5; ++i) for (int j=i; j<5; ++j) m(i,j) = ocov(i,j);
+    LocalTrajectoryError error(m);
 
     float sp = std::sin(phi);
     float cp = std::cos(phi);

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromCUDA.cc
@@ -163,7 +163,7 @@ void PixelTrackProducerFromCUDA::produceGPUCuda(edm::HeterogeneousEvent &iEvent,
 
     Rfit::Vector5d opar;
     Rfit::Matrix5d ocov;
-    Rfit::transfromToPerigeePlane(fittedTrack.par,fittedTrack.cov,opar,ocov,iCharge);
+    Rfit::transformToPerigeePlane(fittedTrack.par,fittedTrack.cov,opar,ocov,iCharge);
 
     LocalTrajectoryParameters lpar(opar(0),opar(1),opar(2),opar(3),opar(4),1.);
     AlgebraicSymMatrix55 m;

--- a/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
@@ -78,7 +78,11 @@
   <flags CXXFLAGS="-g"/>
 </bin>
 
-<bin file="testEigenJacobian.cpp">
+<bin file="testEigenJacobian.cpp">  
+  <use   name="DataFormats/GeometrySurface"/>
+  <use   name="TrackingTools/AnalyticalJacobians"/>
+  <use   name="TrackingTools/TrajectoryParametrization"/>
+  <use   name="MagneticField/Engine"/>
   <use name="eigen"/>
   <use name="cuda"/>
   <flags CXXFLAGS="-g"/>

--- a/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
+++ b/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
@@ -4,11 +4,21 @@
 using Rfit::Vector5d;
 using Rfit::Matrix5d;
 
+// transformation between the "perigee" to cmssw localcoord frame
+// the plane of the latter is the perigee plane...
+// from   //!<(phi,Tip,pt,cotan(theta)),Zip)
+// to 1/p,dx/dz,dy/dz,x,z
 
-Vector5d transf(Vector5d  p) {
+Vector5d transf(Vector5d  const & p) {
+  Vector5d op;
+  auto tipSignNeg = -std::copysign(1.,p(1));
   auto sinTheta = 1/std::sqrt(1+p(3)*p(3));
-  p(2) = sinTheta/p(2);
-  return p;
+  op(0) = sinTheta/p(2);
+  op(1) = 0.;
+  op(2) = tipSignNeg*p(3);
+  op(3) = std::abs(p(1));
+  op(4) = tipSignNeg*p(4);
+  return op;
 }
 
 Matrix5d transfFast(Matrix5d cov, Vector5d const &  p) {
@@ -28,13 +38,27 @@ Matrix5d transfFast(Matrix5d cov, Vector5d const &  p) {
 }
 
 Matrix5d Jacobian(Vector5d const &  p) {
+/*
+  op(0) = sinTheta/p(2);
+  op(1) = 0.;
+  op(2) = tipSignNeg*p(3);
+  op(3) = std::abs(p(1));
+  op(4) = tipSignNeg*p(4);
+*/
 
-  Matrix5d J = Matrix5d::Identity();
+  Matrix5d J = Matrix5d::Zero();
 
   auto sinTheta2 = 1/(1+p(3)*p(3));
   auto sinTheta = std::sqrt(sinTheta2);
-  J(2,2) = -sinTheta/(p(2)*p(2));
-  J(2,3) = -sinTheta2*sinTheta*p(3)/p(2);
+  auto cosTheta = p(3)*sinTheta;
+  auto tipSignNeg = -std::copysign(1.,p(1));
+
+  J(0,2) = -sinTheta/(p(2)*p(2));
+  J(0,3) = -sinTheta2*cosTheta/p(2);
+  J(1,0) = 1.;
+  J(2,3) = tipSignNeg;
+  J(3,1) = -tipSignNeg;
+  J(4,4) = tipSignNeg;
   return J;
 }
 
@@ -46,8 +70,15 @@ Matrix5d transf(Matrix5d const & cov, Matrix5d const& J) {
 
 Matrix5d loadCov(Vector5d const & e) {
 
-  Matrix5d cov = Matrix5d::Zero();
+  Matrix5d cov;
   for (int i=0; i<5; ++i) cov(i,i) = e(i)*e(i);
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < i; ++j) {
+      double v = 0.3*std::sqrt( cov(i,i) * cov(j,j) ); // this makes the matrix pos defined
+      cov(i,j) = (i+j)%2 ? -0.4*v  : 0.1*v;
+      cov(j,i) = cov(i,j);
+    }
+   }
   return cov;
 }
 
@@ -55,15 +86,20 @@ Matrix5d loadCov(Vector5d const & e) {
 #include<iostream>
 int main() {
 
-  //!<(phi,Tip,pt,cotan(theta)),Zip)
+  for (auto stip=-1; stip<2; stip+=2)
+  for (auto szip=-1; szip<2; szip+=2) {
   Vector5d par0; par0 << 0.2,0.1,3.5,0.8,0.1;
   Vector5d del0; del0 << 0.01,0.01,0.035,-0.03,-0.01;
+  //!<(phi,Tip,pt,cotan(theta)),Zip)
+    par0(1) *= stip;
+    par0(4) *= szip;
 
   Matrix5d J = Jacobian(par0);
 
 
   Vector5d par1 = transf(par0);
   Vector5d par2 = transf(par0+del0);
+  // not accurate as the perigee plane move as well...
   Vector5d del1 = par2-par1; 
 
   Matrix5d cov0 = loadCov(del0);
@@ -86,7 +122,9 @@ int main() {
   std::cout << "cov0\n" << cov0 << std::endl;
   std::cout << "cov1\n" << cov1 << std::endl;
   std::cout << "cov2\n" << cov2 << std::endl;
+  std::cout << std::endl << "----------" << std::endl;
 
+  } // lopp over signs
 
   return 0;
 

--- a/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
+++ b/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
@@ -85,7 +85,7 @@ int main() {
 
   // Matrix5d covf = transfFast(cov0,par0);
 
-  Rfit::transfromToPerigeePlane(par0,cov0,par1,cov1,charge);
+  Rfit::transformToPerigeePlane(par0,cov0,par1,cov1,charge);
 
   std::cout << "cov1\n" << cov1 << std::endl;
 

--- a/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
+++ b/RecoPixelVertexing/PixelTrackFitting/test/testEigenJacobian.cpp
@@ -93,16 +93,14 @@ int main() {
   LocalTrajectoryParameters lpar(par1(0),par1(1),par1(2),par1(3),par1(4),1.);
   AlgebraicSymMatrix55 m;
   for(int i=0; i<5; ++i) for (int j=i; j<5; ++j) m(i,j) = cov1(i,j);
-  //LocalTrajectoryError error(m);
 
-    float tipSign = std::copysign(1.,par0(1));
     float phi = par0(0);
     float sp = std::sin(phi);
     float cp = std::cos(phi);
     Surface::RotationType rot(
-                            sp*tipSign, -cp*tipSign,           0,
-                            0         ,           0,    -tipSign,
-                            cp        ,  sp        ,           0);
+                              sp, -cp,    0,
+                               0,   0, -1.f,
+                              cp,  sp,    0);
 
   Surface::PositionType bs(0., 0., 0.);
   Plane plane(bs,rot);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -216,6 +216,7 @@ void CAHitQuadrupletGeneratorGPU::deallocateOnGPU() {
   cudaFree(gpu_.apc_d);
   cudaFree(gpu_d);
   cudaFreeHost(tuples_);
+  cudaFreeHost(hitDetIndices_);
   cudaFreeHost(helix_fit_results_);
   cudaFreeHost(quality_);
 }
@@ -238,6 +239,7 @@ void CAHitQuadrupletGeneratorGPU::allocateOnGPU() {
   cudaCheck(cudaMemcpy(gpu_d, &gpu_, sizeof(TuplesOnGPU), cudaMemcpyDefault));
 
   cudaCheck(cudaMallocHost(&tuples_, sizeof(TuplesOnGPU::Container)));
+  cudaCheck(cudaMallocHost(&hitDetIndices_, sizeof(TuplesOnGPU::Container)));
   cudaCheck(cudaMallocHost(&helix_fit_results_, sizeof(Rfit::helix_fit) * maxNumberOfQuadruplets_));
   cudaCheck(cudaMallocHost(&quality_, sizeof(Quality) * maxNumberOfQuadruplets_));
 
@@ -260,6 +262,8 @@ void CAHitQuadrupletGeneratorGPU::launchKernels(HitsOnCPU const &hh,
   if (transferToCPU) {
     cudaCheck(cudaMemcpyAsync(
         tuples_, gpu_.tuples_d, sizeof(TuplesOnGPU::Container), cudaMemcpyDeviceToHost, cudaStream.id()));
+
+    kernels.fillHitIndices(hh, gpu_, hitDetIndices_, cudaStream);
 
     cudaCheck(cudaMemcpyAsync(helix_fit_results_,
                               gpu_.helix_fit_results_d,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -263,7 +263,7 @@ void CAHitQuadrupletGeneratorGPU::launchKernels(HitsOnCPU const &hh,
     cudaCheck(cudaMemcpyAsync(
         tuples_, gpu_.tuples_d, sizeof(TuplesOnGPU::Container), cudaMemcpyDeviceToHost, cudaStream.id()));
 
-    kernels.fillHitIndices(hh, gpu_, hitDetIndices_, cudaStream);
+    kernels.fillHitDetIndices(hh, gpu_, hitDetIndices_, cudaStream);
 
     cudaCheck(cudaMemcpyAsync(helix_fit_results_,
                               gpu_.helix_fit_results_d,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.h
@@ -71,7 +71,7 @@ public:
                    cuda::stream_t<>& cudaStream);
 
   TuplesOnCPU getOutput() const {
-    return TuplesOnCPU{std::move(indToEdm), hitsOnCPU->view(), tuples_, helix_fit_results_, quality_, gpu_d, nTuples_};
+    return TuplesOnCPU{std::move(indToEdm), hitsOnCPU->view(), tuples_, hitDetIndices_, helix_fit_results_, quality_, gpu_d, nTuples_};
   }
 
   void cleanup(cudaStream_t stream);
@@ -100,6 +100,7 @@ private:
   std::vector<uint32_t> indToEdm;  // index of tuple in reco tracks....
   TuplesOnGPU* gpu_d = nullptr;    // copy of the structure on the gpu itself: this is the "Product"
   TuplesOnGPU::Container* tuples_ = nullptr;
+  TuplesOnGPU::Container* hitDetIndices_ = nullptr;
   Rfit::helix_fit* helix_fit_results_ = nullptr;
   Quality* quality_ = nullptr;
   uint32_t nTuples_ = 0;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -381,9 +381,10 @@ __global__ void kernel_fillHitInTracks(TuplesOnGPU::Container const *__restrict_
   }
 }
 
-__global__ void kernel_fillHitIndices(TuplesOnGPU::Container const *__restrict__ tuples,
+__global__ void kernel_fillHitDetIndices(TuplesOnGPU::Container const *__restrict__ tuples,
                                       TrackingRecHit2DSOAView const *__restrict__ hhp,
                                       TuplesOnGPU::Container *__restrict__ hitDetIndices) {
+
   int first = blockDim.x * blockIdx.x + threadIdx.x;
   // copy offsets
   for (int idx = first, ntot = tuples->totbins(); idx < ntot; idx += gridDim.x * blockDim.x) {
@@ -391,12 +392,14 @@ __global__ void kernel_fillHitIndices(TuplesOnGPU::Container const *__restrict__
   }
   // fill hit indices
   auto const & hh = *hhp;
+  auto nhits = hh.nHits();
   for (int idx = first, ntot = tuples->size(); idx < ntot; idx += gridDim.x * blockDim.x) {
+    assert(tuples->bins[idx]<nhits);
     hitDetIndices->bins[idx] = hh.detectorIndex(tuples->bins[idx]);
   }
 }
 
-void CAHitQuadrupletGeneratorKernels::fillHitIndices(HitsOnCPU const &hh,
+void CAHitQuadrupletGeneratorKernels::fillHitDetIndices(HitsOnCPU const &hh,
                                                      TuplesOnGPU &tuples,
                                                      TuplesOnGPU::Container * hitDetIndices,
                                                      cuda::stream_t<> &stream) {
@@ -407,9 +410,16 @@ void CAHitQuadrupletGeneratorKernels::fillHitIndices(HitsOnCPU const &hh,
   auto blockSize=128;
   auto numberOfBlocks = (TuplesOnGPU::Container::capacity() + blockSize - 1) / blockSize;
 
-  kernel_fillHitIndices<<<numberOfBlocks,blockSize,0,stream.id()>>>(tuples.tuples_d, hh.view(),hitDetIndices_d.get());
+
+  kernel_fillHitDetIndices<<<numberOfBlocks,blockSize,0,stream.id()>>>(tuples.tuples_d, hh.view(),hitDetIndices_d.get());
+  cudaCheck(cudaGetLastError());
+  assert(hitDetIndices);
   cudaCheck(cudaMemcpyAsync(
         hitDetIndices, hitDetIndices_d.get(), sizeof(TuplesOnGPU::Container), cudaMemcpyDeviceToHost, stream.id()));
+#ifdef GPU_DEBUG
+    cudaDeviceSynchronize();
+    cudaCheck(cudaGetLastError());
+#endif
 }
 
 __global__ void kernel_doStatsForHitInTracks(CAHitQuadrupletGeneratorKernels::HitToTuple const *__restrict__ hitToTuple,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -89,6 +89,8 @@ public:
 
   void classifyTuples(HitsOnCPU const& hh, TuplesOnGPU& tuples_d, cudaStream_t cudaStream);
 
+  void fillHitIndices(HitsOnCPU const &hh, TuplesOnGPU &tuples, TuplesOnGPU::Container * hitDetIndices, cuda::stream_t<>& stream);
+
   void buildDoublets(HitsOnCPU const& hh, cuda::stream_t<>& stream);
   void allocateOnGPU();
   void deallocateOnGPU();

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -89,7 +89,7 @@ public:
 
   void classifyTuples(HitsOnCPU const& hh, TuplesOnGPU& tuples_d, cudaStream_t cudaStream);
 
-  void fillHitIndices(HitsOnCPU const &hh, TuplesOnGPU &tuples, TuplesOnGPU::Container * hitDetIndices, cuda::stream_t<>& stream);
+  void fillHitDetIndices(HitsOnCPU const &hh, TuplesOnGPU &tuples, TuplesOnGPU::Container * hitDetIndices, cuda::stream_t<>& stream);
 
   void buildDoublets(HitsOnCPU const& hh, cuda::stream_t<>& stream);
   void allocateOnGPU();

--- a/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
@@ -38,6 +38,8 @@ namespace pixelTuplesHeterogeneousProduct {
 
     Container const* tuples = nullptr;
 
+    Container const* detIndices = nullptr;
+
     Rfit::helix_fit const* helix_fit_results = nullptr;
     Quality* quality = nullptr;
 

--- a/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/plugins/BuildFile.xml
@@ -1,3 +1,7 @@
+<use name="cuda"/>
+<use name="HeterogeneousCore/CUDACore"/>
+<use name="HeterogeneousCore/Producer"/>
+<use name="HeterogeneousCore/Product"/>
 <use   name="CommonTools/RecoAlgos"/>
 <use   name="RecoTracker/TkSeedGenerator"/>
 <use   name="RecoTracker/TkTrackingRegions"/>

--- a/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromCuda.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromCuda.cc
@@ -1,0 +1,185 @@
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "HeterogeneousCore/CUDACore/interface/GPUCuda.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
+#include "RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCurvilinear.h"
+#include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
+#include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+
+#include "RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h"
+
+/*
+  produces seeds directly from cuda produced tuples
+*/
+class SeedProducerFromCuda
+    : public HeterogeneousEDProducer<heterogeneous::HeterogeneousDevices<heterogeneous::GPUCuda, heterogeneous::CPU>> {
+public:
+  using Input = pixelTuplesHeterogeneousProduct::HeterogeneousPixelTuples;
+  using TuplesOnCPU = pixelTuplesHeterogeneousProduct::TuplesOnCPU;
+
+  explicit SeedProducerFromCuda(const edm::ParameterSet &iConfig);
+  ~SeedProducerFromCuda() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+  void beginStreamGPUCuda(edm::StreamID streamId, cuda::stream_t<> &cudaStream) override {}
+  void acquireGPUCuda(const edm::HeterogeneousEvent &iEvent,
+                      const edm::EventSetup &iSetup,
+                      cuda::stream_t<> &cudaStream) override;
+  void produceGPUCuda(edm::HeterogeneousEvent &iEvent,
+                      const edm::EventSetup &iSetup,
+                      cuda::stream_t<> &cudaStream) override;
+  void produceCPU(edm::HeterogeneousEvent &iEvent, const edm::EventSetup &iSetup) override;
+
+private:
+  TuplesOnCPU const *tuples_ = nullptr;
+
+  edm::EDGetTokenT<reco::BeamSpot> tBeamSpot_;
+  edm::EDGetTokenT<HeterogeneousProduct> gpuToken_;
+};
+
+SeedProducerFromCuda::SeedProducerFromCuda(const edm::ParameterSet &iConfig)
+    : HeterogeneousEDProducer(iConfig),
+      tBeamSpot_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      gpuToken_(consumes<HeterogeneousProduct>(iConfig.getParameter<edm::InputTag>("src")))
+{
+    produces<TrajectorySeedCollection>();
+}
+
+void SeedProducerFromCuda::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("src", edm::InputTag("pixelTracksHitQuadruplets"));
+
+  HeterogeneousEDProducer::fillPSetDescription(desc);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void SeedProducerFromCuda::acquireGPUCuda(const edm::HeterogeneousEvent &iEvent,
+                                                const edm::EventSetup &iSetup,
+                                                cuda::stream_t<> &cudaStream) {
+  edm::Handle<TuplesOnCPU> gh;
+  iEvent.getByToken<Input>(gpuToken_, gh);
+  //auto const & gTuples = *gh;
+  // std::cout << "tuples from gpu " << gTuples.nTuples << std::endl;
+
+  tuples_ = gh.product();
+}
+
+void SeedProducerFromCuda::produceGPUCuda(edm::HeterogeneousEvent &iEvent,
+                                                const edm::EventSetup &iSetup,
+                                                cuda::stream_t<> &cudaStream) {
+
+  // std::cout << "Converting gpu helix to trajectory seed" << std::endl;
+
+  edm::ESHandle<MagneticField> fieldESH;
+  iSetup.get<IdealMagneticFieldRecord>().get(fieldESH);
+
+  edm::ESHandle<TrackerGeometry> tracker;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  auto const & dus = tracker->detUnits();
+
+  edm::ESHandle<Propagator>  propagatorHandle;
+  iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial",propagatorHandle);
+  const Propagator*  propagator = &(*propagatorHandle);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+
+
+  edm::Handle<reco::BeamSpot> bsHandle;
+  iEvent.getByToken(tBeamSpot_, bsHandle);
+  const auto &bsh = *bsHandle;
+  // std::cout << "beamspot " << bsh.x0() << ' ' << bsh.y0() << ' ' << bsh.z0() << std::endl;
+  GlobalPoint bs(bsh.x0(), bsh.y0(), bsh.z0());
+
+  auto const & detIndices =  *tuples_->detIndices;
+  for (uint32_t it = 0; it < tuples_->nTuples; ++it) {
+    auto q = tuples_->quality[it];
+    if (q != pixelTuplesHeterogeneousProduct::loose)
+      continue;                           // FIXME
+    // fill hits with invalid just to hold the detId
+    auto nHits = detIndices.size(it);
+    auto b = detIndices.begin(it);
+    edm::OwnVector<TrackingRecHit> hits;
+    for (unsigned int iHit = 0; iHit < nHits; ++iHit) {
+      auto const * det =  dus[*(b+iHit)];
+      // FIXME at some point get a proper type ...
+      hits.push_back(new InvalidTrackingRecHit(*det,TrackingRecHit::bad));
+    }
+
+    // mind: this values are respect the beamspot!
+    auto const &fittedTrack = tuples_->helix_fit_results[it];
+
+    // std::cout << "tk " << it << ": " << fittedTrack.q << ' ' << fittedTrack.par[2] << ' ' << std::sqrt(fittedTrack.cov(2, 2)) << std::endl;
+
+    auto iCharge = fittedTrack.q;
+    float phi = fittedTrack.par(0);
+
+    Rfit::Vector5d opar;
+    Rfit::Matrix5d ocov;
+    Rfit::transfromToPerigeePlane(fittedTrack.par,fittedTrack.cov,opar,ocov,iCharge);
+
+    LocalTrajectoryParameters lpar(opar(0),opar(1),opar(2),opar(3),opar(4),1.);
+    AlgebraicSymMatrix55 m;
+    for(int i=0; i<5; ++i) for (int j=i; j<5; ++j) m(i,j) = ocov(i,j);
+
+    float sp = std::sin(phi);
+    float cp = std::cos(phi);
+    Surface::RotationType rot(
+                              sp, -cp,    0,
+                               0,   0, -1.f,
+                              cp,  sp,    0);
+
+    Plane impPointPlane(bs,rot);
+    GlobalTrajectoryParameters gp(impPointPlane.toGlobal(lpar.position()), 
+                                  impPointPlane.toGlobal(lpar.momentum()),lpar.charge(),fieldESH.product());
+    JacobianLocalToCurvilinear jl2c(impPointPlane,lpar,*fieldESH.product());
+
+    AlgebraicSymMatrix55 mo = ROOT::Math::Similarity(jl2c.jacobian(),m);
+
+    FreeTrajectoryState fts(gp, CurvilinearTrajectoryError(mo));
+
+    auto const & lastHit = hits.back();
+
+    TrajectoryStateOnSurface outerState = propagator->propagate(fts, *lastHit.surface());
+
+    if (!outerState.isValid()){
+      edm::LogError("SeedFromProtoTrack")<<" was trying to create a seed from:\n"<<fts<<"\n propagating to: " 
+                                         << lastHit.geographicalId().rawId();
+      continue;
+    }
+
+    auto const & pTraj = trajectoryStateTransform::persistentState(outerState, lastHit.geographicalId().rawId());
+
+    TrajectorySeed(pTraj, hits, alongMomentum);
+
+  }
+
+}
+
+void SeedProducerFromCuda::produceCPU(edm::HeterogeneousEvent &iEvent, const edm::EventSetup &iSetup) {
+  throw cms::Exception("NotImplemented") << "CPU version is no longer implemented";
+}
+
+DEFINE_FWK_MODULE(SeedProducerFromCuda);

--- a/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromCuda.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromCuda.cc
@@ -147,7 +147,7 @@ void SeedProducerFromCuda::produceGPUCuda(edm::HeterogeneousEvent &iEvent,
    
     Rfit::Vector5d opar;
     Rfit::Matrix5d ocov;
-    Rfit::transfromToPerigeePlane(fittedTrack.par,fittedTrack.cov,opar,ocov,iCharge);
+    Rfit::transformToPerigeePlane(fittedTrack.par,fittedTrack.cov,opar,ocov,iCharge);
 
     LocalTrajectoryParameters lpar(opar(0),opar(1),opar(2),opar(3),opar(4),1.);
     AlgebraicSymMatrix55 m;


### PR DESCRIPTION
The main object of this PR is a new producer to build TrajectorySeeds directly from GPU products
w/o any reference to CPU hits.

The seed is built from the helix kinematics + N Invalid hits that contain just the DetId 

To be properly integrated in a tracking workflow #27220 is required.

In addition we took the opportunity to use the full covariance matrix from the gpu fit and to add a configurable to filter on the minimum number of hits.
These changes have been applied to the PixelTrack producer as well (more factorization is possible)

Of course the standard two step PixelTrack+SeedFromProtoTrack is always available to produce seeds out of GPU fitted tuples...


tested with this snippet (transfer enabled, conversion disabled:
```python
# import seedProducerFromCuda
process.load("RecoTracker.TkSeedGenerator.seedProducerFromCuda_cfi")


# Path and EndPath definitions
process.raw2digi_step = cms.Path(process.RawToDigi_pixelOnly)
process.reconstruction_step = cms.Path(process.reconstruction_pixelTrackingOnly+process.seedProducerFromCuda)
process.out = cms.OutputModule("AsciiOutputModule",
    outputCommands = cms.untracked.vstring(
        "keep *_seedProducerFromCuda_*_*",
    ),
    verbosity = cms.untracked.uint32(9),
)

process.outPath = cms.EndPath(process.out)

process.schedule = cms.Schedule(process.raw2digi_step, process.reconstruction_step, process.outPath)

process.pixelTracksHitQuadruplets.gpuEnableConversion = False
process.pixelTracks.gpuEnableConversion = False
process.pixelVertices.gpuEnableConversion = False
```

tbd: 
===
make proper DataFormats
convert producers to new framework
add more filters (region, PVs)

when?
=====
once more use cases are clarified

