### PR TITLE
Backport #27220: add the ability to use a seed just as a 5DHit

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -17,6 +17,16 @@ from HLTrigger.Configuration.common import *
 #                     pset.minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone'))
 #     return process
 
+# use 5DHit as seed
+def customiseFor27220(process):
+   for pset in process._Process__psets.values():
+       if hasattr(pset,'ComponentType'):
+             if (pset.ComponentType == 'CkfTrajectoryBuilder' or 
+                 pset.ComponentType == 'GroupedCkfTrajectoryBuilder' or
+                 pset.ComponentType == 'MuonCkfTrajectoryBuilder'):
+                 if not hasattr(pset,'seedAs5DHit'):
+                     pset.seedAs5DHit = cms.bool(False)
+   return process
 
 def customiseFor2017DtUnpacking(process):
     """Adapt the HLT to run the legacy DT unpacking
@@ -52,6 +62,6 @@ def customiseFor2017DtUnpacking(process):
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
-    # process = customiseFor12718(process)
+    process = customiseFor27220(process)
 
     return process

--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
@@ -17,4 +17,4 @@ TrajectoryBuilderForConversions.maxCand = 5
 TrajectoryBuilderForConversions.lostHitPenalty = 30.
 TrajectoryBuilderForConversions.intermediateCleaning = True
 TrajectoryBuilderForConversions.alwaysUseInvalidHits = True
-
+TrajectoryBuilderForConversions.seedAs5DHit  = False

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -7,7 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 
-#include<cassert>
+#include <cassert>
 #include "TrackingTools/PatternTools/interface/TempTrajectory.h"
 
 class CkfDebugger;
@@ -53,13 +53,12 @@ namespace edm {
 class BaseCkfTrajectoryBuilder : public TrajectoryBuilder {
 protected:
   // short names
-  typedef FreeTrajectoryState         FTS;
-  typedef TrajectoryStateOnSurface    TSOS;
-  typedef TrajectoryMeasurement       TM;
-  typedef std::pair<TSOS,std::vector<const DetLayer*> > StateAndLayers;
+  typedef FreeTrajectoryState FTS;
+  typedef TrajectoryStateOnSurface TSOS;
+  typedef TrajectoryMeasurement TM;
+  typedef std::pair<TSOS, std::vector<const DetLayer*> > StateAndLayers;
 
 public:
-
   typedef std::vector<Trajectory> TrajectoryContainer;
   typedef std::vector<TempTrajectory> TempTrajectoryContainer;
   typedef TrajectoryContainer::iterator TrajectoryIterator;
@@ -67,112 +66,119 @@ public:
   // Claims ownership of TrajectoryFilter pointers
   BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf,
                            std::unique_ptr<TrajectoryFilter> filter,
-                           std::unique_ptr<TrajectoryFilter> inOutFilter=nullptr);
-  BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder &) = delete;
+                           std::unique_ptr<TrajectoryFilter> inOutFilter = nullptr);
+  BaseCkfTrajectoryBuilder(const BaseCkfTrajectoryBuilder&) = delete;
   BaseCkfTrajectoryBuilder& operator=(const BaseCkfTrajectoryBuilder&) = delete;
   ~BaseCkfTrajectoryBuilder() override;
 
   // new interface returning the start Trajectory...
-  virtual TempTrajectory buildTrajectories (const TrajectorySeed& seed,
-					    TrajectoryContainer &ret,
-					    unsigned int& nCandPerSeed,
-					    const TrajectoryFilter*) const  { assert(0==1); return TempTrajectory();}
-  
-  
-  virtual void  rebuildTrajectories(TempTrajectory const& startingTraj, const TrajectorySeed& seed,
-				    TrajectoryContainer& result) const { assert(0==1);}
+  virtual TempTrajectory buildTrajectories(const TrajectorySeed& seed,
+                                           TrajectoryContainer& ret,
+                                           unsigned int& nCandPerSeed,
+                                           const TrajectoryFilter*) const {
+    assert(0 == 1);
+    return TempTrajectory();
+  }
 
+  virtual void rebuildTrajectories(TempTrajectory const& startingTraj,
+                                   const TrajectorySeed& seed,
+                                   TrajectoryContainer& result) const {
+    assert(0 == 1);
+  }
 
-  void setNavigationSchool(NavigationSchool const * nv) { theNavigationSchool=nv;}
+  void setNavigationSchool(NavigationSchool const* nv) { theNavigationSchool = nv; }
 
-  void setEvent(const edm::Event& event) const override ;
+  void setEvent(const edm::Event& event) const override;
   void unset() const override;
 
-  void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup, const MeasurementTrackerEvent *data);
+  void setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup, const MeasurementTrackerEvent* data);
 
-  virtual void setDebugger( CkfDebugger * dbg) const {;}
- 
+  virtual void setDebugger(CkfDebugger* dbg) const { ; }
+
   /** Maximum number of lost hits per trajectory candidate. */
   //  int 		maxLostHit()		{return theMaxLostHit;}
 
   /** Maximum number of consecutive lost hits per trajectory candidate. */
   //  int 		maxConsecLostHit()	{return theMaxConsecLostHit;}
 
+  const TransientTrackingRecHitBuilder* hitBuilder() const { return theTTRHBuilder; }
 
-  const TransientTrackingRecHitBuilder* hitBuilder() const { return theTTRHBuilder;}
-
- protected:    
-  static std::unique_ptr<TrajectoryFilter> createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC);
+protected:
+  static std::unique_ptr<TrajectoryFilter> createTrajectoryFilter(const edm::ParameterSet& pset,
+                                                                  edm::ConsumesCollector& iC);
 
   virtual void setEvent_(const edm::Event& iEvent, const edm::EventSetup& iSetup) = 0;
 
-  //methods for dubugging 
-  virtual bool analyzeMeasurementsDebugger(Trajectory& traj, const std::vector<TrajectoryMeasurement>& meas,
-					   const MeasurementTrackerEvent* theMeasurementTracker, 
-					   const Propagator* theForwardPropagator, 
-					   const Chi2MeasurementEstimatorBase* theEstimator, 
-					   const TransientTrackingRecHitBuilder * theTTRHBuilder) const {return true;} 
-  virtual bool analyzeMeasurementsDebugger(TempTrajectory& traj, const std::vector<TrajectoryMeasurement>& meas,
-					   const MeasurementTrackerEvent* theMeasurementTracker, 
-					   const Propagator* theForwardPropagator, 
-					   const Chi2MeasurementEstimatorBase* theEstimator, 
-					   const TransientTrackingRecHitBuilder * theTTRHBuilder) const {return true;} 
-  virtual void fillSeedHistoDebugger(std::vector<TrajectoryMeasurement>::iterator begin, 
-                                     std::vector<TrajectoryMeasurement>::iterator end) const {;}
+  //methods for dubugging
+  virtual bool analyzeMeasurementsDebugger(Trajectory& traj,
+                                           const std::vector<TrajectoryMeasurement>& meas,
+                                           const MeasurementTrackerEvent* theMeasurementTracker,
+                                           const Propagator* theForwardPropagator,
+                                           const Chi2MeasurementEstimatorBase* theEstimator,
+                                           const TransientTrackingRecHitBuilder* theTTRHBuilder) const {
+    return true;
+  }
+  virtual bool analyzeMeasurementsDebugger(TempTrajectory& traj,
+                                           const std::vector<TrajectoryMeasurement>& meas,
+                                           const MeasurementTrackerEvent* theMeasurementTracker,
+                                           const Propagator* theForwardPropagator,
+                                           const Chi2MeasurementEstimatorBase* theEstimator,
+                                           const TransientTrackingRecHitBuilder* theTTRHBuilder) const {
+    return true;
+  }
+  virtual void fillSeedHistoDebugger(std::vector<TrajectoryMeasurement>::iterator begin,
+                                     std::vector<TrajectoryMeasurement>::iterator end) const {
+    ;
+  }
 
- protected:
-
-  TempTrajectory createStartingTrajectory( const TrajectorySeed& seed) const;
+protected:
+  TempTrajectory createStartingTrajectory(const TrajectorySeed& seed) const;
 
   /** Called after each new hit is added to the trajectory, to see if building this track should be continued */
   // If inOut is true, this is being called part-way through tracking, after the in-out tracking phase is complete.
   // If inOut is false, it is called at the end of tracking.
-  bool toBeContinued( TempTrajectory& traj, bool inOut = false) const;
+  bool toBeContinued(TempTrajectory& traj, bool inOut = false) const;
 
   /** Called at end of track building, to see if track should be kept */
-  bool qualityFilter( const TempTrajectory& traj, bool inOut = false) const;
-  
-  void addToResult(boost::shared_ptr<const TrajectorySeed> const & seed, TempTrajectory& traj, TrajectoryContainer& result, bool inOut = false) const;    
-  void addToResult( TempTrajectory const& traj, TempTrajectoryContainer& result, bool inOut = false) const;    
-  void moveToResult( TempTrajectory&& traj, TempTrajectoryContainer& result, bool inOut = false) const;    
+  bool qualityFilter(const TempTrajectory& traj, bool inOut = false) const;
+
+  void addToResult(boost::shared_ptr<const TrajectorySeed> const& seed,
+                   TempTrajectory& traj,
+                   TrajectoryContainer& result,
+                   bool inOut = false) const;
+  void addToResult(TempTrajectory const& traj, TempTrajectoryContainer& result, bool inOut = false) const;
+  void moveToResult(TempTrajectory&& traj, TempTrajectoryContainer& result, bool inOut = false) const;
 
   StateAndLayers findStateAndLayers(const TrajectorySeed& seed, const TempTrajectory& traj) const;
 
- private:
-  void seedMeasurements(const TrajectorySeed& seed, TempTrajectory & result) const;
+private:
+  void seedMeasurements(const TrajectorySeed& seed, TempTrajectory& result, bool as5D) const;
 
- protected:
-  void setData(const MeasurementTrackerEvent *data) ;
+protected:
+  void setData(const MeasurementTrackerEvent* data);
 
-  const Propagator *forwardPropagator(const TrajectorySeed& seed) const {
+  const Propagator* forwardPropagator(const TrajectorySeed& seed) const {
     return seed.direction() == alongMomentum ? thePropagatorAlong : thePropagatorOpposite;
   }
-  const Propagator *backwardPropagator(const TrajectorySeed& seed) const {
+  const Propagator* backwardPropagator(const TrajectorySeed& seed) const {
     return seed.direction() == alongMomentum ? thePropagatorOpposite : thePropagatorAlong;
   }
 
- protected:
+protected:
   typedef TrackingComponentsRecord Chi2MeasurementEstimatorRecord;
 
-  const TrajectoryStateUpdator*         theUpdator;
-  const Propagator*                     thePropagatorAlong;
-  const Propagator*                     thePropagatorOpposite;
-  const Chi2MeasurementEstimatorBase*   theEstimator;
-  const TransientTrackingRecHitBuilder* theTTRHBuilder;
-  const MeasurementTrackerEvent*        theMeasurementTracker;
-  const NavigationSchool *              theNavigationSchool = nullptr;
+  const TrajectoryStateUpdator* theUpdator = nullptr;
+  const Propagator* thePropagatorAlong = nullptr;
+  const Propagator* thePropagatorOpposite = nullptr;
+  const Chi2MeasurementEstimatorBase* theEstimator = nullptr;
+  const TransientTrackingRecHitBuilder* theTTRHBuilder = nullptr;
+  const MeasurementTrackerEvent* theMeasurementTracker = nullptr;
+  const NavigationSchool* theNavigationSchool = nullptr;
 
+private:
+  bool theSeedAs5DHit;
 
- private:
-  //  int theMaxLostHit;            /**< Maximum number of lost hits per trajectory candidate.*/
-  //  int theMaxConsecLostHit;      /**< Maximum number of consecutive lost hits 
-  //                                     per trajectory candidate. */
-  //  int theMinimumNumberOfHits;   /**< Minimum number of hits for a trajectory to be returned.*/
-  //  float theChargeSignificance;  /**< Value to declare (q/p)/sig(q/p) significant. Negative: ignore. */
-
-  //  TrajectoryFilter*              theMinPtCondition;
-  //  TrajectoryFilter*              theMaxHitsCondition;
-  std::unique_ptr<TrajectoryFilter> theFilter; /** Filter used at end of complete tracking */
+  std::unique_ptr<TrajectoryFilter> theFilter;      /** Filter used at end of complete tracking */
   std::unique_ptr<TrajectoryFilter> theInOutFilter; /** Filter used at end of in-out tracking */
 
   // for EventSetup
@@ -182,6 +188,5 @@ public:
   const std::string theEstimatorName;
   const std::string theRecHitBuilderName;
 };
-
 
 #endif

--- a/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/CkfTrajectoryBuilder_cfi.py
@@ -18,7 +18,8 @@ CkfTrajectoryBuilder = cms.PSet(
     propagatorOpposite = cms.string('PropagatorWithMaterialOpposite'),
 #    propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
     lostHitPenalty = cms.double(30.0),
-    #SharedSeedCheck = cms.bool(False)
+    #SharedSeedCheck = cms.bool(False),
+    seedAs5DHit  = cms.bool(False)
 )
 
 

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -37,7 +37,8 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
 #    propagatorOpposite = cms.string('PropagatorWithMaterialParabolicMfOpposite'),
     # Out-in tracking will not be attempted unless this many hits
     # are on track after in-out tracking phase.
-    minNrOfHitsForRebuild = cms.int32(5)
+    minNrOfHitsForRebuild = cms.int32(5),
+    seedAs5DHit  = cms.bool(False)
 )
 
 

--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -6,7 +6,6 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 
-  
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
@@ -27,76 +26,74 @@
 
 BaseCkfTrajectoryBuilder::BaseCkfTrajectoryBuilder(const edm::ParameterSet& conf,
                                                    std::unique_ptr<TrajectoryFilter> filter,
-                                                   std::unique_ptr<TrajectoryFilter> inOutFilter):
-  theUpdator(nullptr),
-  thePropagatorAlong(nullptr),
-  thePropagatorOpposite(nullptr),
-  theEstimator(nullptr),
-  theTTRHBuilder(nullptr),
-  theMeasurementTracker(nullptr),
-  theFilter(std::move(filter)),
-  theInOutFilter(std::move(inOutFilter)),
-  theUpdatorName(conf.getParameter<std::string>("updator")),
-  thePropagatorAlongName(conf.getParameter<std::string>("propagatorAlong")),
-  thePropagatorOppositeName(conf.getParameter<std::string>("propagatorOpposite")),
-  theEstimatorName(conf.getParameter<std::string>("estimator")),
-  theRecHitBuilderName(conf.getParameter<std::string>("TTRHBuilder"))
-{
-  if (conf.exists("clustersToSkip")) edm::LogError("BaseCkfTrajectoryBuilder") << "ERROR: " << typeid(*this).name() << " has a clustersToSkip parameter set";
+                                                   std::unique_ptr<TrajectoryFilter> inOutFilter)
+    : theSeedAs5DHit(conf.getParameter<bool>("seedAs5DHit")),
+      theFilter(std::move(filter)),
+      theInOutFilter(std::move(inOutFilter)),
+      theUpdatorName(conf.getParameter<std::string>("updator")),
+      thePropagatorAlongName(conf.getParameter<std::string>("propagatorAlong")),
+      thePropagatorOppositeName(conf.getParameter<std::string>("propagatorOpposite")),
+      theEstimatorName(conf.getParameter<std::string>("estimator")),
+      theRecHitBuilderName(conf.getParameter<std::string>("TTRHBuilder")) {
+  if (conf.exists("clustersToSkip"))
+    edm::LogError("BaseCkfTrajectoryBuilder")
+        << "ERROR: " << typeid(*this).name() << " has a clustersToSkip parameter set";
 }
 
+BaseCkfTrajectoryBuilder::~BaseCkfTrajectoryBuilder() {}
 
-BaseCkfTrajectoryBuilder::~BaseCkfTrajectoryBuilder(){
+std::unique_ptr<TrajectoryFilter> BaseCkfTrajectoryBuilder::createTrajectoryFilter(const edm::ParameterSet& pset,
+                                                                                   edm::ConsumesCollector& iC) {
+  return std::unique_ptr<TrajectoryFilter>{
+      TrajectoryFilterFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC)};
 }
 
-std::unique_ptr<TrajectoryFilter> BaseCkfTrajectoryBuilder::createTrajectoryFilter(const edm::ParameterSet& pset, edm::ConsumesCollector& iC) {
-  return std::unique_ptr<TrajectoryFilter>{TrajectoryFilterFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC)};
-}
-
-void
-BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed,  TempTrajectory & result) const
-{
-  
-
+#include "RecoTracker/TransientTrackingRecHit/interface/TRecHit5DParamConstraint.h"
+void BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed, TempTrajectory& result, bool as5D) const {
   TrajectorySeed::range hitRange = seed.recHits();
 
-  PTrajectoryStateOnDet pState( seed.startingState());
+  PTrajectoryStateOnDet pState(seed.startingState());
   const GeomDet* gdet = theMeasurementTracker->geomTracker()->idToDet(pState.detId());
-  TSOS outerState = trajectoryStateTransform::transientState(pState, &(gdet->surface()),
-							     forwardPropagator(seed)->magneticField());
+  TSOS outerState =
+      trajectoryStateTransform::transientState(pState, &(gdet->surface()), forwardPropagator(seed)->magneticField());
 
+  if (as5D) {
+    TrackingRecHit::RecHitPointer recHit(new TRecHit5DParamConstraint(*gdet, outerState));
+    TSOS invalidState(gdet->surface());
+    auto hitLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(pState.detId());
+    result.emplace(invalidState, outerState, recHit, 0, hitLayer);
+    return;
+  }
 
   for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
- 
     TrackingRecHit::RecHitPointer recHit = ihit->cloneSH();
     const GeomDet* hitGeomDet = recHit->det();
- 
-    const DetLayer* hitLayer = 
-      theMeasurementTracker->geometricSearchTracker()->detLayer(ihit->geographicalId());
 
-    TSOS invalidState( hitGeomDet->surface());
+    const DetLayer* hitLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(ihit->geographicalId());
+
+    TSOS invalidState(hitGeomDet->surface());
     if (ihit == hitRange.second - 1) {
       // the seed trajectory state should correspond to this hit
       if (&gdet->surface() != &hitGeomDet->surface()) {
-	edm::LogError("CkfPattern") << "CkfTrajectoryBuilder error: the seed state is not on the surface of the detector of the last seed hit";
-	return; // FIXME: should throw exception
+        edm::LogError("CkfPattern")
+            << "CkfTrajectoryBuilder error: the seed state is not on the surface of the detector of the last seed hit";
+        return;  // FIXME: should throw exception
       }
 
       //TSOS updatedState = outerstate;
       result.emplace(invalidState, outerState, recHit, 0, hitLayer);
-    }
-    else {
-      TSOS innerState   = backwardPropagator(seed)->propagate(outerState,hitGeomDet->surface());
+    } else {
+      TSOS innerState = backwardPropagator(seed)->propagate(outerState, hitGeomDet->surface());
 
       // try to recover if propagation failed
-      if UNLIKELY(!innerState.isValid())
-        innerState =
-          trajectoryStateTransform::transientState(pState, &(hitGeomDet->surface()),
-                                                            forwardPropagator(seed)->magneticField());
+      if
+        UNLIKELY(!innerState.isValid())
+      innerState = trajectoryStateTransform::transientState(
+          pState, &(hitGeomDet->surface()), forwardPropagator(seed)->magneticField());
 
-      if(innerState.isValid()) {
-	TSOS innerUpdated = theUpdator->update(innerState,*recHit);
-	result.emplace(invalidState, innerUpdated, recHit, 0, hitLayer);
+      if (innerState.isValid()) {
+        TSOS innerUpdated = theUpdator->update(innerState, *recHit);
+        result.emplace(invalidState, innerUpdated, recHit, 0, hitLayer);
       }
     }
   }
@@ -104,35 +101,29 @@ BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed,  TempTraj
   // method for debugging
   // fix somehow
   // fillSeedHistoDebugger(result.begin(),result.end());
-
 }
 
+TempTrajectory BaseCkfTrajectoryBuilder::createStartingTrajectory(const TrajectorySeed& seed) const {
+  TempTrajectory result(seed.direction(), seed.nHits());
+  seedMeasurements(seed, result, theSeedAs5DHit);
 
-TempTrajectory BaseCkfTrajectoryBuilder::
-createStartingTrajectory( const TrajectorySeed& seed) const
-{
-  TempTrajectory result(seed.direction(),seed.nHits());
-  seedMeasurements(seed, result);
+  LogDebug("CkfPattern") << " initial trajectory from the seed: " << PrintoutHelper::dumpCandidate(result, true);
 
-  LogDebug("CkfPattern")
-    <<" initial trajectory from the seed: "<<PrintoutHelper::dumpCandidate(result,true);
-  
   return result;
 }
 
-
-bool BaseCkfTrajectoryBuilder::toBeContinued (TempTrajectory& traj, bool inOut) const
-{
-  if UNLIKELY(traj.measurements().size() > 400) {
-    edm::LogError("BaseCkfTrajectoryBuilder_InfiniteLoop");
-    LogTrace("BaseCkfTrajectoryBuilder_InfiniteLoop") << 
-              "Cropping Track After 400 Measurements:\n" <<
-              "   Last predicted state: " << traj.lastMeasurement().predictedState() << "\n" <<
-              "   Last layer subdetector: " << (traj.lastLayer() ? traj.lastLayer()->subDetector() : -1) << "\n" <<
-              "   Found hits: " << traj.foundHits() << ", lost hits: " << traj.lostHits() << "\n\n";
-    return false;
-  }
-  // Called after each new hit is added to the trajectory, to see if it is 
+bool BaseCkfTrajectoryBuilder::toBeContinued(TempTrajectory& traj, bool inOut) const {
+  if
+    UNLIKELY(traj.measurements().size() > 400) {
+      edm::LogError("BaseCkfTrajectoryBuilder_InfiniteLoop");
+      LogTrace("BaseCkfTrajectoryBuilder_InfiniteLoop")
+          << "Cropping Track After 400 Measurements:\n"
+          << "   Last predicted state: " << traj.lastMeasurement().predictedState() << "\n"
+          << "   Last layer subdetector: " << (traj.lastLayer() ? traj.lastLayer()->subDetector() : -1) << "\n"
+          << "   Found hits: " << traj.foundHits() << ", lost hits: " << traj.lostHits() << "\n\n";
+      return false;
+    }
+  // Called after each new hit is added to the trajectory, to see if it is
   // worth continuing to build this track candidate.
   if (inOut) {
     // if (theInOutFilter == 0) edm::LogError("CkfPattern") << "CkfTrajectoryBuilder error: trying to use dedicated filter for in-out tracking phase, when none specified";
@@ -142,9 +133,7 @@ bool BaseCkfTrajectoryBuilder::toBeContinued (TempTrajectory& traj, bool inOut) 
   }
 }
 
-
- bool BaseCkfTrajectoryBuilder::qualityFilter( const TempTrajectory& traj, bool inOut) const
-{
+bool BaseCkfTrajectoryBuilder::qualityFilter(const TempTrajectory& traj, bool inOut) const {
   // Called after building a trajectory is completed, to see if it is good enough
   // to keep.
   if (inOut) {
@@ -155,98 +144,97 @@ bool BaseCkfTrajectoryBuilder::toBeContinued (TempTrajectory& traj, bool inOut) 
   }
 }
 
-
-void 
-BaseCkfTrajectoryBuilder::addToResult (boost::shared_ptr<const TrajectorySeed> const & seed, TempTrajectory& tmptraj, 
-				       TrajectoryContainer& result,
-                                       bool inOut) const
-{
+void BaseCkfTrajectoryBuilder::addToResult(boost::shared_ptr<const TrajectorySeed> const& seed,
+                                           TempTrajectory& tmptraj,
+                                           TrajectoryContainer& result,
+                                           bool inOut) const {
   // quality check
-  if ( !qualityFilter(tmptraj, inOut) )  return;
+  if (!qualityFilter(tmptraj, inOut))
+    return;
   Trajectory traj = tmptraj.toTrajectory();
   traj.setSharedSeed(seed);
   // discard latest dummy measurements
-  while (!traj.empty() && !traj.lastMeasurement().recHit()->isValid()) traj.pop();
-  LogDebug("CkfPattern")<<inOut<<"=inOut option. pushing a Trajectory with: "<<traj.foundHits()<<" found hits. "<<traj.lostHits()
-			<<" lost hits. Popped :"<<(tmptraj.measurements().size())-(traj.measurements().size())<<" hits.";
+  while (!traj.empty() && !traj.lastMeasurement().recHit()->isValid())
+    traj.pop();
+  LogDebug("CkfPattern") << inOut << "=inOut option. pushing a Trajectory with: " << traj.foundHits() << " found hits. "
+                         << traj.lostHits()
+                         << " lost hits. Popped :" << (tmptraj.measurements().size()) - (traj.measurements().size())
+                         << " hits.";
   result.push_back(std::move(traj));
 }
 
-
-void 
-BaseCkfTrajectoryBuilder::addToResult (TempTrajectory const & tmptraj, 
-				       TempTrajectoryContainer& result,
-                                       bool inOut) const
-{
+void BaseCkfTrajectoryBuilder::addToResult(TempTrajectory const& tmptraj,
+                                           TempTrajectoryContainer& result,
+                                           bool inOut) const {
   // quality check
-  if ( !qualityFilter(tmptraj, inOut) )  return;
+  if (!qualityFilter(tmptraj, inOut))
+    return;
   // discard latest dummy measurements
   TempTrajectory traj = tmptraj;
-  while (!traj.empty() && !traj.lastMeasurement().recHit()->isValid()) traj.pop();
-  LogDebug("CkfPattern")<<inOut<<"=inOut option. pushing a TempTrajectory with: "<<traj.foundHits()<<" found hits. "<<traj.lostHits()
-			<<" lost hits. Popped :"<<(tmptraj.measurements().size())-(traj.measurements().size())<<" hits.";
+  while (!traj.empty() && !traj.lastMeasurement().recHit()->isValid())
+    traj.pop();
+  LogDebug("CkfPattern") << inOut << "=inOut option. pushing a TempTrajectory with: " << traj.foundHits()
+                         << " found hits. " << traj.lostHits()
+                         << " lost hits. Popped :" << (tmptraj.measurements().size()) - (traj.measurements().size())
+                         << " hits.";
   result.push_back(std::move(traj));
 }
 
-void 
-BaseCkfTrajectoryBuilder::moveToResult (TempTrajectory&& traj, 
-				       TempTrajectoryContainer& result,
-                                       bool inOut) const
-{
+void BaseCkfTrajectoryBuilder::moveToResult(TempTrajectory&& traj, TempTrajectoryContainer& result, bool inOut) const {
   // quality check
-  if ( !qualityFilter(traj, inOut) )  return;
+  if (!qualityFilter(traj, inOut))
+    return;
   // discard latest dummy measurements
-  while (!traj.empty() && !traj.lastMeasurement().recHitR().isValid()) traj.pop();
-  LogDebug("CkfPattern")<<inOut<<"=inOut option. pushing a TempTrajectory with: "<<traj.foundHits()<<" found hits. "<<traj.lostHits();
-    //			<<" lost hits. Popped :"<<(ttraj.measurements().size())-(traj.measurements().size())<<" hits.";
+  while (!traj.empty() && !traj.lastMeasurement().recHitR().isValid())
+    traj.pop();
+  LogDebug("CkfPattern") << inOut << "=inOut option. pushing a TempTrajectory with: " << traj.foundHits()
+                         << " found hits. " << traj.lostHits();
+  //			<<" lost hits. Popped :"<<(ttraj.measurements().size())-(traj.measurements().size())<<" hits.";
   result.push_back(std::move(traj));
 }
 
+BaseCkfTrajectoryBuilder::StateAndLayers BaseCkfTrajectoryBuilder::findStateAndLayers(
+    const TrajectorySeed& seed, const TempTrajectory& traj) const {
+  if (traj.empty()) {
+    //set the currentState to be the one from the trajectory seed starting point
+    PTrajectoryStateOnDet const& ptod = seed.startingState();
+    DetId id(ptod.detId());
+    const GeomDet* g = theMeasurementTracker->geomTracker()->idToDet(id);
+    const Surface* surface = &g->surface();
 
-
-BaseCkfTrajectoryBuilder::StateAndLayers
-BaseCkfTrajectoryBuilder::findStateAndLayers(const TrajectorySeed& seed, const TempTrajectory& traj) const
-{
-  if (traj.empty())
-    {
-      //set the currentState to be the one from the trajectory seed starting point
-      PTrajectoryStateOnDet const & ptod = seed.startingState();
-      DetId id(ptod.detId());
-      const GeomDet * g = theMeasurementTracker->geomTracker()->idToDet(id);                    
-      const Surface * surface=&g->surface();
-      
-      
-      TSOS currentState(trajectoryStateTransform::transientState(ptod,surface,forwardPropagator(seed)->magneticField()));      
-      const DetLayer* lastLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(id);      
-      return StateAndLayers(currentState,theNavigationSchool->nextLayers(*lastLayer,*currentState.freeState(), traj.direction()) );
-    }
-  else
-    {  
-      TSOS const & currentState = traj.lastMeasurement().updatedState();
-      return StateAndLayers(currentState,theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction()) );
-    }
+    TSOS currentState(
+        trajectoryStateTransform::transientState(ptod, surface, forwardPropagator(seed)->magneticField()));
+    const DetLayer* lastLayer = theMeasurementTracker->geometricSearchTracker()->detLayer(id);
+    return StateAndLayers(currentState,
+                          theNavigationSchool->nextLayers(*lastLayer, *currentState.freeState(), traj.direction()));
+  } else {
+    TSOS const& currentState = traj.lastMeasurement().updatedState();
+    return StateAndLayers(
+        currentState, theNavigationSchool->nextLayers(*traj.lastLayer(), *currentState.freeState(), traj.direction()));
+  }
 }
 
-void BaseCkfTrajectoryBuilder::setData(const MeasurementTrackerEvent *data) 
-{
-    // possibly do some sanity check here
-    theMeasurementTracker = data;
+void BaseCkfTrajectoryBuilder::setData(const MeasurementTrackerEvent* data) {
+  // possibly do some sanity check here
+  theMeasurementTracker = data;
 }
 
-void BaseCkfTrajectoryBuilder::setEvent(const edm::Event& event) const
-{
-    std::cerr << "ERROR SetEvent called on " << typeid(*this).name() << ( theMeasurementTracker ? " with valid " : "witout any ") << "MeasurementTrackerEvent" << std::endl;
+void BaseCkfTrajectoryBuilder::setEvent(const edm::Event& event) const {
+  std::cerr << "ERROR SetEvent called on " << typeid(*this).name()
+            << (theMeasurementTracker ? " with valid " : "witout any ") << "MeasurementTrackerEvent" << std::endl;
 }
 
-void BaseCkfTrajectoryBuilder::unset() const
-{
-    std::cerr << "ERROR unSet called on " << typeid(*this).name() << ( theMeasurementTracker ? " with valid " : "witout any ") << "MeasurementTrackerEvent" << std::endl;
+void BaseCkfTrajectoryBuilder::unset() const {
+  std::cerr << "ERROR unSet called on " << typeid(*this).name()
+            << (theMeasurementTracker ? " with valid " : "witout any ") << "MeasurementTrackerEvent" << std::endl;
 }
 
-void BaseCkfTrajectoryBuilder::setEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup, const MeasurementTrackerEvent *data) {
+void BaseCkfTrajectoryBuilder::setEvent(const edm::Event& iEvent,
+                                        const edm::EventSetup& iSetup,
+                                        const MeasurementTrackerEvent* data) {
   edm::ESHandle<TrajectoryStateUpdator> updatorHandle;
-  edm::ESHandle<Propagator>             propagatorAlongHandle;
-  edm::ESHandle<Propagator>             propagatorOppositeHandle;
+  edm::ESHandle<Propagator> propagatorAlongHandle;
+  edm::ESHandle<Propagator> propagatorOppositeHandle;
   edm::ESHandle<Chi2MeasurementEstimatorBase> estimatorHandle;
   edm::ESHandle<TransientTrackingRecHitBuilder> recHitBuilderHandle;
 
@@ -263,7 +251,9 @@ void BaseCkfTrajectoryBuilder::setEvent(const edm::Event& iEvent, const edm::Eve
   theTTRHBuilder = recHitBuilderHandle.product();
 
   setData(data);
-  if(theFilter) theFilter->setEvent(iEvent, iSetup);
-  if(theInOutFilter) theInOutFilter->setEvent(iEvent, iSetup);
+  if (theFilter)
+    theFilter->setEvent(iEvent, iSetup);
+  if (theInOutFilter)
+    theInOutFilter->setEvent(iEvent, iSetup);
   setEvent_(iEvent, iSetup);
 }


### PR DESCRIPTION
Backport #27220: add the ability to use a seed just as a 5DHit:

> With this PR we add the ability (controlled by a configurable in the trajectory builder) to use the seed ad a 5DHit.
> It targets mainly HLT when the seeds come from an outside source.
> w/r/t standard hitless seeds it allows to fully use the seed information in the trajectory fit.
> 
> while technically working it will require to be really operational:
>    - seeds with a meaningful covariance matrix
>    - retuning of the trajectory filter
>    - retuning of the track classifier
>    - and most probably additional work at level of HitPattern and of clients that rely on specific hits to be present in the track
> 
> tested offline and hit with default configuration and with 5DHit switched on.