### PR TITLE
Implement triplets in the pixel ntuplet producer

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h
@@ -9,6 +9,8 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include "Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h"
+
 
 namespace pixelCPEforGPU {
   struct ParamsOnGPU;
@@ -20,6 +22,8 @@ public:
   using hindex_type = uint16_t;  // if above is <=2^16
 
   using Hist = HistoContainer<int16_t, 128, gpuClustering::MaxNumClusters, 8 * sizeof(int16_t), uint16_t, 10>;
+
+  using AverageGeometry = phase1PixelTopology::AverageGeometry;
 
   friend class TrackingRecHit2DCUDA;
 
@@ -66,6 +70,10 @@ public:
   __device__ __forceinline__ Hist& phiBinner() { return *m_hist; }
   __device__ __forceinline__ Hist const& phiBinner() const { return *m_hist; }
 
+  __device__ __forceinline__ AverageGeometry & averageGeometry() { return *m_averageGeometry; }
+  __device__ __forceinline__ AverageGeometry const& averageGeometry() const { return *m_averageGeometry; }
+
+
 private:
   // local coord
   float *m_xl, *m_yl;
@@ -82,6 +90,7 @@ private:
   uint16_t* m_detInd;
 
   // supporting objects
+  AverageGeometry * m_averageGeometry; // owned (corrected for beam spot: not sure where to host it otherwise)
   pixelCPEforGPU::ParamsOnGPU const* m_cpeParams;  // forwarded from setup, NOT owned
   uint32_t const* m_hitsModuleStart;               // forwarded from clusters
 
@@ -133,6 +142,7 @@ private:
   cudautils::device::unique_ptr<float[]> m_store32;
 
   cudautils::device::unique_ptr<TrackingRecHit2DSOAView::Hist> m_HistStore;
+  cudautils::device::unique_ptr<TrackingRecHit2DSOAView::AverageGeometry> m_AverageGeometryStore;
 
   cudautils::device::unique_ptr<TrackingRecHit2DSOAView> m_view;
 

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
@@ -29,12 +29,14 @@ TrackingRecHit2DCUDA::TrackingRecHit2DCUDA(uint32_t nHits,
   m_store16 = cs->make_device_unique<uint16_t[]>(nHits * n16, stream);
   m_store32 = cs->make_device_unique<float[]>(nHits * n32 + 11, stream);
   m_HistStore = cs->make_device_unique<TrackingRecHit2DSOAView::Hist>(stream);
+  m_AverageGeometryStore = cs->make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
 
   auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
   auto get32 = [&](int i) { return m_store32.get() + i * nHits; };
 
   // copy all the pointers
   m_hist = view->m_hist = m_HistStore.get();
+  view->m_averageGeometry = m_AverageGeometryStore.get();
 
   view->m_cpeParams = cpeParams;
   view->m_hitsModuleStart = hitsModuleStart;

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
@@ -14,6 +14,10 @@ TrackingRecHit2DCUDA::TrackingRecHit2DCUDA(uint32_t nHits,
   auto view = cs->make_host_unique<TrackingRecHit2DSOAView>(stream);
   view->m_nHits = nHits;
   m_view = cs->make_device_unique<TrackingRecHit2DSOAView>(stream);
+  m_AverageGeometryStore = cs->make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
+  view->m_averageGeometry = m_AverageGeometryStore.get();
+  view->m_cpeParams = cpeParams;
+  view->m_hitsModuleStart = hitsModuleStart;
 
   // if empy do not bother
   if (0 == nHits) {
@@ -29,17 +33,12 @@ TrackingRecHit2DCUDA::TrackingRecHit2DCUDA(uint32_t nHits,
   m_store16 = cs->make_device_unique<uint16_t[]>(nHits * n16, stream);
   m_store32 = cs->make_device_unique<float[]>(nHits * n32 + 11, stream);
   m_HistStore = cs->make_device_unique<TrackingRecHit2DSOAView::Hist>(stream);
-  m_AverageGeometryStore = cs->make_device_unique<TrackingRecHit2DSOAView::AverageGeometry>(stream);
 
   auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
   auto get32 = [&](int i) { return m_store32.get() + i * nHits; };
 
   // copy all the pointers
   m_hist = view->m_hist = m_HistStore.get();
-  view->m_averageGeometry = m_AverageGeometryStore.get();
-
-  view->m_cpeParams = cpeParams;
-  view->m_hitsModuleStart = hitsModuleStart;
 
   view->m_xl = get32(0);
   view->m_yl = get32(1);

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -35,6 +35,8 @@ namespace phase1PixelTopology {
     "E-1", "E-2", "E-3"             // negative endcap
   };
 
+  constexpr uint32_t numberOfModulesInBarrel = 1184;
+  constexpr uint32_t numberOfLaddersInBarrel = numberOfModulesInBarrel/8;
 
   template<class Function, std::size_t... Indices>
   constexpr auto map_to_array_helper(Function f, std::index_sequence<Indices...>)

--- a/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/phase1PixelTopology.h
@@ -148,6 +148,18 @@ namespace phase1PixelTopology {
     return py+shift;
   }
 
+  //FIXME move it elsewhere?
+  struct AverageGeometry {
+    static constexpr auto numberOfLaddersInBarrel = phase1PixelTopology::numberOfLaddersInBarrel;
+    float ladderZ[numberOfLaddersInBarrel];
+    float ladderX[numberOfLaddersInBarrel];
+    float ladderY[numberOfLaddersInBarrel];
+    float ladderR[numberOfLaddersInBarrel];
+    float ladderMinZ[numberOfLaddersInBarrel];
+    float ladderMaxZ[numberOfLaddersInBarrel];
+    float endCapZ[2];  // just for pos and neg Layer1
+  };
+
 }
 
 #endif // Geometry_TrackerGeometryBuilder_phase1PixelTopology_h

--- a/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h
@@ -87,7 +87,7 @@ namespace GPU {
     inline constexpr T &operator[](int i) { return m_data[i]; }
     inline constexpr const T &operator[](int i) const { return m_data[i]; }
     inline constexpr void reset() { m_size = 0; }
-    inline constexpr int capacity() const { return maxSize; }
+    inline static constexpr int capacity() { return maxSize; }
     inline constexpr T const *data() const { return m_data; }
     inline constexpr void resize(int size) { m_size = size; }
     inline constexpr bool empty() const { return 0 == m_size; }

--- a/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
@@ -269,6 +269,10 @@ public:
   __device__ __host__ __forceinline__ void bulkFinalizeFill(AtomicPairCounter const &apc) {
     auto m = apc.get().m;
     auto n = apc.get().n;
+    if (m >= nbins()) { // overflow!
+      off[nbins()]=uint32_t(off[nbins()-1]);
+      return;
+    }
     auto first = m + blockDim.x * blockIdx.x + threadIdx.x;
     for (auto i = first; i < totbins(); i += gridDim.x * blockDim.x) {
       off[i] = n;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -12,7 +12,9 @@
 
 namespace gpuClustering {
 
+#ifdef GPU_DEBUG
   __device__ uint32_t gMaxHit=0;
+#endif
 
   __global__ void countModules(uint16_t const* __restrict__ id,
                                uint32_t* __restrict__ moduleStart,
@@ -273,10 +275,12 @@ namespace gpuClustering {
     if (threadIdx.x == 0) {
       nClustersInModule[thisModuleId] = foundClusters;
       moduleId[blockIdx.x] = thisModuleId;
+#ifdef GPU_DEBUG
       if (foundClusters>gMaxHit) {
          gMaxHit = foundClusters;
          if (foundClusters>8) printf("max hit %d in %d\n",foundClusters, thisModuleId);
       }
+#endif
 #ifdef GPU_DEBUG
       if (thisModuleId % 100 == 1)
           printf("%d clusters in module %d\n", foundClusters, thisModuleId);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -12,6 +12,8 @@
 
 namespace gpuClustering {
 
+  __device__ uint32_t gMaxHit=0;
+
   __global__ void countModules(uint16_t const* __restrict__ id,
                                uint32_t* __restrict__ moduleStart,
                                int32_t* __restrict__ clusterId,
@@ -271,9 +273,12 @@ namespace gpuClustering {
     if (threadIdx.x == 0) {
       nClustersInModule[thisModuleId] = foundClusters;
       moduleId[blockIdx.x] = thisModuleId;
+      if (foundClusters>gMaxHit) {
+         gMaxHit = foundClusters;
+         if (foundClusters>8) printf("max hit %d in %d\n",foundClusters, thisModuleId);
+      }
 #ifdef GPU_DEBUG
       if (thisModuleId % 100 == 1)
-        if (threadIdx.x == 0)
           printf("%d clusters in module %d\n", foundClusters, thisModuleId);
 #endif
     }

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
@@ -81,6 +81,7 @@ private:
   std::vector<pixelCPEforGPU::DetParams, CUDAHostAllocator<pixelCPEforGPU::DetParams>> m_detParamsGPU;
   pixelCPEforGPU::CommonParams m_commonParamsGPU;
   pixelCPEforGPU::LayerGeometry m_layerGeometry;
+  pixelCPEforGPU::AverageGeometry m_averageGeometry;
 
   struct GPUData {
     ~GPUData();

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -44,6 +44,17 @@ namespace pixelCPEforGPU {
     Frame frame;
   };
 
+
+ struct AverageGeometry {
+    static constexpr auto numberOfLaddersInBarrel = phase1PixelTopology::numberOfLaddersInBarrel;
+    float ladderZ[numberOfLaddersInBarrel];
+    float ladderR[numberOfLaddersInBarrel];
+    float ladderMinZ[numberOfLaddersInBarrel];
+    float ladderMaxZ[numberOfLaddersInBarrel];
+    float endCapZ[2];  // just for pos and neg Layer1
+ };
+
+
   struct LayerGeometry {
     uint32_t layerStart[phase1PixelTopology::numberOfLayers + 1];
     uint8_t layer[phase1PixelTopology::layerIndexSize];
@@ -53,6 +64,7 @@ namespace pixelCPEforGPU {
     CommonParams* m_commonParams;
     DetParams* m_detParams;
     LayerGeometry* m_layerGeometry;
+    AverageGeometry * m_averageGeometry;
 
     constexpr CommonParams const& __restrict__ commonParams() const {
       CommonParams const* __restrict__ l = m_commonParams;
@@ -63,6 +75,7 @@ namespace pixelCPEforGPU {
       return l[i];
     }
     constexpr LayerGeometry const& __restrict__ layerGeometry() const { return *m_layerGeometry; }
+    constexpr AverageGeometry const& __restrict__ averageGeometry() const { return *m_averageGeometry; }
 
     __device__ uint8_t layer(uint16_t id) const {
       return __ldg(m_layerGeometry->layer + id / phase1PixelTopology::maxModuleStride);

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -45,15 +45,7 @@ namespace pixelCPEforGPU {
   };
 
 
- struct AverageGeometry {
-    static constexpr auto numberOfLaddersInBarrel = phase1PixelTopology::numberOfLaddersInBarrel;
-    float ladderZ[numberOfLaddersInBarrel];
-    float ladderR[numberOfLaddersInBarrel];
-    float ladderMinZ[numberOfLaddersInBarrel];
-    float ladderMaxZ[numberOfLaddersInBarrel];
-    float endCapZ[2];  // just for pos and neg Layer1
- };
-
+  using phase1PixelTopology::AverageGeometry;
 
   struct LayerGeometry {
     uint32_t layerStart[phase1PixelTopology::numberOfLayers + 1];

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -59,8 +59,10 @@ namespace pixelgpudetails {
     cudaCheck(cudaGetLastError());
 
     // assuming full warp of threads is better than a smaller number...
-    setHitsLayerStart<<<1, 32, 0, stream.id()>>>(clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart());
-    cudaCheck(cudaGetLastError());
+    if (nHits) {
+      setHitsLayerStart<<<1, 32, 0, stream.id()>>>(clusters_d.clusModuleStart(), cpeParams, hits_d.hitsLayerStart());
+      cudaCheck(cudaGetLastError());
+    }
 
     if (nHits >= TrackingRecHit2DSOAView::maxHits()) {
       edm::LogWarning("PixelRecHitGPUKernel")
@@ -74,6 +76,13 @@ namespace pixelgpudetails {
           hits_d.phiBinner(), hws.get(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, stream.id());
       cudaCheck(cudaGetLastError());
     }
+
+    
+#ifdef GPU_DEBUG
+    cudaDeviceSynchronize();
+    cudaCheck(cudaGetLastError());
+#endif
+
     return hits_d;
   }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -30,6 +30,25 @@ namespace gpuPixelRecHits {
     auto const digis = *pdigis; // the copy is intentional!
     auto const & clusters = *pclusters;
 
+    // copy average geometry corrected by beamspot . FIXME (move it somewhere else???)
+    if (0==blockIdx.x) {
+      auto & agc = hits.averageGeometry();
+      auto const & ag  = cpeParams->averageGeometry();
+      for(int il=threadIdx.x, nl=TrackingRecHit2DSOAView::AverageGeometry::numberOfLaddersInBarrel; il<nl; il+=blockDim.x) {
+        agc.ladderZ[il] = ag.ladderZ[il] - bs->z; 
+        agc.ladderX[il] = ag.ladderX[il] - bs->x;
+        agc.ladderY[il] = ag.ladderY[il] - bs->y;
+        agc.ladderR[il] = sqrt(agc.ladderX[il]*agc.ladderX[il] + agc.ladderY[il]*agc.ladderY[il] );
+        agc.ladderMinZ[il] = ag.ladderMinZ[il] - bs->z;
+        agc.ladderMaxZ[il] = ag.ladderMaxZ[il] - bs->z;
+      }
+      if(0==threadIdx.x) {
+         agc.endCapZ[0] = ag.endCapZ[0] - bs->z;
+         agc.endCapZ[1] = ag.endCapZ[1] - bs->z;
+         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
+      }
+    }
+
     // to be moved in common namespace...
     constexpr uint16_t InvId = 9999;  // must be > MaxNumModules
     constexpr uint32_t MaxHitsInModule = pixelCPEforGPU::MaxHitsInModule;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -25,6 +25,9 @@ namespace gpuPixelRecHits {
     // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
     // not using views (passing a gazzilion of array pointers) seems to produce the fastest code (but it is harder to mantain)  
 
+    assert(phits);
+    assert(cpeParams);
+
     auto& hits = *phits;
 
     auto const digis = *pdigis; // the copy is intentional!
@@ -45,7 +48,7 @@ namespace gpuPixelRecHits {
       if(0==threadIdx.x) {
          agc.endCapZ[0] = ag.endCapZ[0] - bs->z;
          agc.endCapZ[1] = ag.endCapZ[1] - bs->z;
-         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
+//         printf("endcapZ %f %f\n",agc.endCapZ[0],agc.endCapZ[1]);
       }
     }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -284,12 +284,13 @@ void PixelCPEFast::fillParamsForGpu() {
   aveGeom.endCapZ[0] -= 1.5f;
   aveGeom.endCapZ[1] += 1.5f;
 
+  /*
   for (int jl=0, nl=phase1PixelTopology::numberOfLaddersInBarrel; jl<nl; ++jl) {
     std::cout << jl<<':'<<aveGeom.ladderR[jl] << '/'<< std::sqrt(aveGeom.ladderX[jl]*aveGeom.ladderX[jl]+aveGeom.ladderY[jl]*aveGeom.ladderY[jl]) 
                    <<','<<aveGeom.ladderZ[jl]<<','<<aveGeom.ladderMinZ[jl]<<','<<aveGeom.ladderMaxZ[jl]<< ' ';
   } std::cout<< std::endl;
   std::cout << aveGeom.endCapZ[0] << ' ' << aveGeom.endCapZ[1] << std::endl;
-  
+  */
 
   // fill Layer and ladders geometry
   memcpy(m_layerGeometry.layerStart, phase1PixelTopology::layerStart, sizeof(phase1PixelTopology::layerStart));

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -263,8 +263,15 @@ void PixelCPEFast::fillParamsForGpu() {
        aveGeom.ladderR[il] += 0.125*sqrt(g.frame.x()*g.frame.x()+g.frame.y()*g.frame.y());
   }
   assert(il+1==int(phase1PixelTopology::numberOfLaddersInBarrel));
+  // add half_module and tollerance
+  constexpr float module_length = 6.7f;
+  constexpr float module_tolerance = 0.2f;
+  for (int il=0, nl=phase1PixelTopology::numberOfLaddersInBarrel; il<nl; ++il) {
+    aveGeom.ladderMinZ[il] -= (0.5f*module_length-module_tolerance);
+    aveGeom.ladderMaxZ[il] += (0.5f*module_length-module_tolerance);
+  }
 
-  // compute "max z" for first layer in endcap
+  // compute "max z" for first layer in endcap (should we restrict to the outermost ring?)
   for (auto im=phase1PixelTopology::layerStart[4]; im<phase1PixelTopology::layerStart[5]; ++im) {
      auto const & g = m_detParamsGPU[im];
      aveGeom.endCapZ[0] = std::max(aveGeom.endCapZ[0],g.frame.z());
@@ -273,7 +280,9 @@ void PixelCPEFast::fillParamsForGpu() {
      auto const & g = m_detParamsGPU[im];
      aveGeom.endCapZ[1] = std::min(aveGeom.endCapZ[1],g.frame.z());
   }
- 
+  // correct for outer ring being closer
+  aveGeom.endCapZ[0] -= 1.5f;
+  aveGeom.endCapZ[1] += 1.5f;
 
   for (int jl=0, nl=phase1PixelTopology::numberOfLaddersInBarrel; jl<nl; ++jl) {
     std::cout << jl<<':'<<aveGeom.ladderR[jl] << '/'<< std::sqrt(aveGeom.ladderX[jl]*aveGeom.ladderX[jl]+aveGeom.ladderY[jl]*aveGeom.ladderY[jl]) 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -70,6 +70,7 @@ const pixelCPEforGPU::ParamsOnGPU* PixelCPEFast::getGPUProductAsync(cuda::stream
     cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_commonParams, sizeof(pixelCPEforGPU::CommonParams)));
     cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_detParams,
                          this->m_detParamsGPU.size() * sizeof(pixelCPEforGPU::DetParams)));
+    cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_averageGeometry, sizeof(pixelCPEforGPU::AverageGeometry)));
     cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_layerGeometry, sizeof(pixelCPEforGPU::LayerGeometry)));
     cudaCheck(cudaMalloc((void**)&data.d_paramsOnGPU, sizeof(pixelCPEforGPU::ParamsOnGPU)));
 
@@ -78,6 +79,11 @@ const pixelCPEforGPU::ParamsOnGPU* PixelCPEFast::getGPUProductAsync(cuda::stream
     cudaCheck(cudaMemcpyAsync(data.h_paramsOnGPU.m_commonParams,
                               &this->m_commonParamsGPU,
                               sizeof(pixelCPEforGPU::CommonParams),
+                              cudaMemcpyDefault,
+                              stream.id()));
+    cudaCheck(cudaMemcpyAsync(data.h_paramsOnGPU.m_averageGeometry,
+                              &this->m_averageGeometry,
+                              sizeof(pixelCPEforGPU::AverageGeometry),
                               cudaMemcpyDefault,
                               stream.id()));
     cudaCheck(cudaMemcpyAsync(data.h_paramsOnGPU.m_layerGeometry,
@@ -99,6 +105,9 @@ void PixelCPEFast::fillParamsForGpu() {
   m_commonParamsGPU.theThicknessE = m_DetParams.back().theThickness;
   m_commonParamsGPU.thePitchX = m_DetParams[0].thePitchX;
   m_commonParamsGPU.thePitchY = m_DetParams[0].thePitchY;
+
+  // zero average geometry
+  memset(&m_averageGeometry,0,sizeof(pixelCPEforGPU::AverageGeometry));
 
   uint32_t oldLayer = 0;
   uint32_t oldLadder = 0;
@@ -127,8 +136,8 @@ void PixelCPEFast::fillParamsForGpu() {
 
     //if (m_commonParamsGPU.theThickness!=p.theThickness)
     //  std::cout << i << (g.isBarrel ? "B " : "E ") << m_commonParamsGPU.theThickness<<"!="<<p.theThickness << std::endl;
-    auto ladder = ttopo_.pxbLadder(p.theDet->geographicalId());
 
+    auto ladder = ttopo_.pxbLadder(p.theDet->geographicalId());
     if (oldLayer != g.layer) {
       oldLayer = g.layer;
       // std::cout << "new layer at " << i << (g.isBarrel ? " B  " :  (g.isPosZ ? " E+ " : " E- ")) << g.layer << " starting at " << g.rawId << std::endl;
@@ -238,6 +247,38 @@ void PixelCPEFast::fillParamsForGpu() {
     }
   }
 
+  // compute ladder baricenter (only in global z) for the barrel
+  auto & aveGeom = m_averageGeometry;
+  int il=0;
+  for (int im=0, nm=phase1PixelTopology::numberOfModulesInBarrel; im<nm; ++im) {
+    auto const & g = m_detParamsGPU[im];
+    il = im/8;
+    assert(il<int(phase1PixelTopology::numberOfLaddersInBarrel));
+       auto z = g.frame.z();
+       aveGeom.ladderZ[il] += 0.125f*z;
+       aveGeom.ladderMinZ[il] = std::min(aveGeom.ladderMinZ[il], z);
+       aveGeom.ladderMaxZ[il] = std::max(aveGeom.ladderMaxZ[il], z);
+       aveGeom.ladderR[il] += 0.125*sqrt(g.frame.x()*g.frame.x()+g.frame.y()*g.frame.y());
+  }
+  assert(il+1==int(phase1PixelTopology::numberOfLaddersInBarrel));
+
+  // compute "max z" for first layer in endcap
+  for (auto im=phase1PixelTopology::layerStart[4]; im<phase1PixelTopology::layerStart[5]; ++im) {
+     auto const & g = m_detParamsGPU[im];
+     aveGeom.endCapZ[0] = std::max(aveGeom.endCapZ[0],g.frame.z());
+  }
+  for (auto im=phase1PixelTopology::layerStart[7]; im<phase1PixelTopology::layerStart[8]; ++im) {
+     auto const & g = m_detParamsGPU[im];
+     aveGeom.endCapZ[1] = std::min(aveGeom.endCapZ[1],g.frame.z());
+  }
+ 
+
+  for (int jl=0, nl=phase1PixelTopology::numberOfLaddersInBarrel; jl<nl; ++jl) {
+    std::cout << jl<<':'<<aveGeom.ladderR[jl] <<','<<aveGeom.ladderZ[jl]<<','<<aveGeom.ladderMinZ[jl]<<','<<aveGeom.ladderMaxZ[jl]<< ' ';
+  } std::cout<< std::endl;
+  std::cout << aveGeom.endCapZ[0] << ' ' << aveGeom.endCapZ[1] << std::endl;
+  
+
   // fill Layer and ladders geometry
   memcpy(m_layerGeometry.layerStart, phase1PixelTopology::layerStart, sizeof(phase1PixelTopology::layerStart));
   memcpy(m_layerGeometry.layer, phase1PixelTopology::layer.data(), phase1PixelTopology::layer.size());
@@ -249,6 +290,7 @@ PixelCPEFast::GPUData::~GPUData() {
   if (d_paramsOnGPU != nullptr) {
     cudaFree(h_paramsOnGPU.m_commonParams);
     cudaFree(h_paramsOnGPU.m_detParams);
+    cudaFree(h_paramsOnGPU.m_averageGeometry);
     cudaFree(d_paramsOnGPU);
   }
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -258,6 +258,8 @@ void PixelCPEFast::fillParamsForGpu() {
        aveGeom.ladderZ[il] += 0.125f*z;
        aveGeom.ladderMinZ[il] = std::min(aveGeom.ladderMinZ[il], z);
        aveGeom.ladderMaxZ[il] = std::max(aveGeom.ladderMaxZ[il], z);
+       aveGeom.ladderX[il] += 0.125f*g.frame.x();
+       aveGeom.ladderY[il] += 0.125f*g.frame.y();
        aveGeom.ladderR[il] += 0.125*sqrt(g.frame.x()*g.frame.x()+g.frame.y()*g.frame.y());
   }
   assert(il+1==int(phase1PixelTopology::numberOfLaddersInBarrel));
@@ -274,7 +276,8 @@ void PixelCPEFast::fillParamsForGpu() {
  
 
   for (int jl=0, nl=phase1PixelTopology::numberOfLaddersInBarrel; jl<nl; ++jl) {
-    std::cout << jl<<':'<<aveGeom.ladderR[jl] <<','<<aveGeom.ladderZ[jl]<<','<<aveGeom.ladderMinZ[jl]<<','<<aveGeom.ladderMaxZ[jl]<< ' ';
+    std::cout << jl<<':'<<aveGeom.ladderR[jl] << '/'<< std::sqrt(aveGeom.ladderX[jl]*aveGeom.ladderX[jl]+aveGeom.ladderY[jl]*aveGeom.ladderY[jl]) 
+                   <<','<<aveGeom.ladderZ[jl]<<','<<aveGeom.ladderMinZ[jl]<<','<<aveGeom.ladderMaxZ[jl]<< ' ';
   } std::cout<< std::endl;
   std::cout << aveGeom.endCapZ[0] << ' ' << aveGeom.endCapZ[1] << std::endl;
   

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -38,13 +38,16 @@ __global__ void kernelBLFastFit(TuplesOnGPU::Container const *__restrict__ found
 
   assert(pfast_fit);
   assert(foundNtuplets);
+  assert(tupleMultiplicity);
 
   // look in bin for this hit multiplicity
   auto local_start = (blockIdx.x * blockDim.x + threadIdx.x);
 
 #ifdef BROKENLINE_DEBUG
-  if (0 == local_start)
+  if (0 == local_start) {
+    printf("%d total Ntuple\n",foundNtuplets->nbins());
     printf("%d Ntuple of size %d for %d hits to fit\n", tupleMultiplicity->size(nHits), nHits, hitsInFit);
+  }
 #endif
 
   auto tuple_start = local_start + offset;

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="RecoPixelVertexing/PixelTriplets"/>
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TkTrackingRegions"/>
+
 <library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -12,9 +12,6 @@
 <use name="RecoPixelVertexing/PixelTriplets"/>
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TkTrackingRegions"/>
-<flags CXXFLAGS="-fno-math-errno"/>
-<flags CXXFLAGS="-g -DGPU_DEBUG"/>
-<flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 <library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -13,6 +13,8 @@
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TkTrackingRegions"/>
 <flags CXXFLAGS="-fno-math-errno"/>
+<flags CXXFLAGS="-g -DGPU_DEBUG"/>
+<flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 <library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -13,7 +13,6 @@
 <use name="RecoTracker/TkSeedingLayers"/>
 <use name="RecoTracker/TkTrackingRegions"/>
 <flags CXXFLAGS="-fno-math-errno"/>
-
 <library file="*.cu *.cc" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -44,7 +44,7 @@ namespace CAConstants {
   using tindex_type = uint16_t;  //  for tuples
 
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
-  using CellTracks = GPU::VecArray<tindex_type, 56>;
+  using CellTracks = GPU::VecArray<tindex_type, 42>;
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -18,7 +18,7 @@ namespace CAConstants {
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
-  constexpr uint32_t maxNumberOfTuples() { return 6 * 1024; }
+  constexpr uint32_t maxNumberOfTuples() { return 8 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -23,14 +23,14 @@ namespace CAConstants {
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
 #ifndef GPU_SMALL_EVENTS
-  constexpr uint32_t maxNumberOfDoublets() { return 262144; }
+  constexpr uint32_t maxNumberOfDoublets() { return 393216; }
   constexpr uint32_t maxCellsPerHit() { return 128; }
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 262144 / 2; }
+  constexpr uint32_t maxNumberOfDoublets() { return 393216 / 2; }
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 6 * 262144; }
+  constexpr uint32_t maxNumberOfDoublets() { return 4 * 393216; }
   constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
@@ -44,7 +44,7 @@ namespace CAConstants {
   using tindex_type = uint16_t;  //  for tuples
 
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
-  using CellTracks = GPU::VecArray<tindex_type, 42>;
+  using CellTracks = GPU::VecArray<tindex_type, 64>;
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -23,14 +23,14 @@ namespace CAConstants {
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
 #ifndef GPU_SMALL_EVENTS
-  constexpr uint32_t maxNumberOfDoublets() { return 512*1024; }
+  constexpr uint32_t maxNumberOfDoublets() { return 448*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128; }
 #else
   constexpr uint32_t maxNumberOfDoublets() { return  128*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 2*1024*1024; }
+  constexpr uint32_t maxNumberOfDoublets() { return 448*1024; }
   constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
@@ -44,7 +44,7 @@ namespace CAConstants {
   using tindex_type = uint16_t;  //  for tuples
 
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
-  using CellTracks = GPU::VecArray<tindex_type, 64>;
+  using CellTracks = GPU::VecArray<tindex_type, 56>;
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -18,7 +18,7 @@ namespace CAConstants {
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
-  constexpr uint32_t maxNumberOfTuples() { return 8 * 1024; }
+  constexpr uint32_t maxNumberOfTuples() { return 16 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
@@ -35,7 +35,7 @@ namespace CAConstants {
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
 
-  constexpr uint32_t maxNumberOfLayerPairs() { return 16; }
+  constexpr uint32_t maxNumberOfLayerPairs() { return 20; }
   constexpr uint32_t maxNumberOfLayers() { return 10; }
   constexpr uint32_t maxTuples() { return maxNumberOfTuples(); }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -18,7 +18,7 @@ namespace CAConstants {
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
-  constexpr uint32_t maxNumberOfTuples() { return 16 * 1024; }
+  constexpr uint32_t maxNumberOfTuples() { return 24 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
@@ -30,7 +30,7 @@ namespace CAConstants {
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 4 * 393216; }
+  constexpr uint32_t maxNumberOfDoublets() { return 8 * 393216; }
   constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -35,7 +35,7 @@ namespace CAConstants {
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
 
-  constexpr uint32_t maxNumberOfLayerPairs() { return 13; }
+  constexpr uint32_t maxNumberOfLayerPairs() { return 16; }
   constexpr uint32_t maxNumberOfLayers() { return 10; }
   constexpr uint32_t maxTuples() { return maxNumberOfTuples(); }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -23,14 +23,14 @@ namespace CAConstants {
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
 #ifndef GPU_SMALL_EVENTS
-  constexpr uint32_t maxNumberOfDoublets() { return 393216; }
+  constexpr uint32_t maxNumberOfDoublets() { return 512*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128; }
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 393216 / 2; }
+  constexpr uint32_t maxNumberOfDoublets() { return  128*1024; }
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 8 * 393216; }
+  constexpr uint32_t maxNumberOfDoublets() { return 2*1024*1024; }
   constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -103,8 +103,8 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<double>("hardCurvCut", 1.f / (0.35 * 87.f))->setComment("Cut on minimum curvature");
   desc.add<double>("dcaCutInnerTriplet", 0.15f)->setComment("Cut on origin radius when the inner hit is on BPix1");
   desc.add<double>("dcaCutOuterTriplet", 0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
-  desc.add<bool>("earlyFishbone", false);
-  desc.add<bool>("lateFishbone", true);
+  desc.add<bool>("earlyFishbone", true);
+  desc.add<bool>("lateFishbone", false);
   desc.add<bool>("idealConditions", true);
   desc.add<bool>("fillStatistics", false);
   desc.add<unsigned int>("minHitsPerNtuplet", 4);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -69,7 +69,6 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
               cfg.getParameter<bool>("doClusterCut"),
               cfg.getParameter<bool>("doZCut"),
               cfg.getParameter<bool>("doPhiCut"),
-              cfg.getParameter<bool>("doIterations"),
               cfg.getParameter<double>("ptmin"),
               cfg.getParameter<double>("CAThetaCutBarrel"),
               cfg.getParameter<double>("CAThetaCutForward"),
@@ -113,7 +112,6 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZCut", true);
   desc.add<bool>("doPhiCut", true);
-  desc.add<bool>("doIterations", false);
 
 
   edm::ParameterSetDescription trackQualityCuts;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -78,7 +78,15 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
       fitter(cfg.getParameter<bool>("fit5as4")),
       caThetaCut(cfg.getParameter<double>("CAThetaCut")),
       caPhiCut(cfg.getParameter<double>("CAPhiCut")),
-      caHardPtCut(cfg.getParameter<double>("CAHardPtCut")) {}
+      caHardPtCut(cfg.getParameter<double>("CAHardPtCut")) {
+
+#ifdef    DUMP_GPU_TK_TUPLES
+      printf("TK: %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
+             "tid", "qual", "nh","phi","tip","pt","cot","zip","eta","chil","chic",
+             "h1","h2","h3","h4","h5");
+#endif
+
+}
 
 void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription &desc) {
   desc.add<double>("CAThetaCut", 0.00125);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -61,6 +61,7 @@ constexpr unsigned int CAHitQuadrupletGeneratorGPU::minLayers;
 
 CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : kernels(cfg.getParameter<unsigned int>("minHitsPerNtuplet"),
+              cfg.getParameter<bool>("noForwardTriplets"),
               cfg.getParameter<bool>("earlyFishbone"),
               cfg.getParameter<bool>("lateFishbone"),
               cfg.getParameter<bool>("idealConditions"),
@@ -68,6 +69,7 @@ CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet
               cfg.getParameter<bool>("doClusterCut"),
               cfg.getParameter<bool>("doZCut"),
               cfg.getParameter<bool>("doPhiCut"),
+              cfg.getParameter<bool>("doIterations"),
               cfg.getParameter<double>("ptmin"),
               cfg.getParameter<double>("CAThetaCutBarrel"),
               cfg.getParameter<double>("CAThetaCutForward"),
@@ -106,10 +108,13 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<bool>("idealConditions", true);
   desc.add<bool>("fillStatistics", false);
   desc.add<unsigned int>("minHitsPerNtuplet", 4);
+  desc.add<bool>("noForwardTriplets", true);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZCut", true);
   desc.add<bool>("doPhiCut", true);
+  desc.add<bool>("doIterations", false);
+
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorGPU.cc
@@ -61,7 +61,7 @@ constexpr unsigned int CAHitQuadrupletGeneratorGPU::minLayers;
 
 CAHitQuadrupletGeneratorGPU::CAHitQuadrupletGeneratorGPU(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : kernels(cfg.getParameter<unsigned int>("minHitsPerNtuplet"),
-              cfg.getParameter<bool>("noForwardTriplets"),
+              cfg.getParameter<bool>("includeJumpingForwardDoublets"),
               cfg.getParameter<bool>("earlyFishbone"),
               cfg.getParameter<bool>("lateFishbone"),
               cfg.getParameter<bool>("idealConditions"),
@@ -108,7 +108,7 @@ void CAHitQuadrupletGeneratorGPU::fillDescriptions(edm::ParameterSetDescription 
   desc.add<bool>("idealConditions", true);
   desc.add<bool>("fillStatistics", false);
   desc.add<unsigned int>("minHitsPerNtuplet", 4);
-  desc.add<bool>("noForwardTriplets", true);
+  desc.add<bool>("includeJumpingForwardDoublets", false);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
   desc.add<bool>("doZCut", true);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -191,16 +191,16 @@ __global__ void kernel_connect(AtomicPairCounter *apc1,
   if (cellIndex >= (*nCells))
     return;
   auto & thisCell = cells[cellIndex];
-  if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
-    return;
+  //if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
+  //  return;
   auto innerHitId = thisCell.get_inner_hit_id();
   auto numberOfPossibleNeighbors = isOuterHitOfCell[innerHitId].size();
   auto vi = isOuterHitOfCell[innerHitId].data();
   for (auto j = first; j < numberOfPossibleNeighbors; j += stride) {
     auto otherCell = __ldg(vi + j);
-    if (cells[otherCell].theDoubletId < 0 ||
-        cells[otherCell].theUsed>1 )
-      continue;
+    // if (cells[otherCell].theDoubletId < 0 ||
+    //    cells[otherCell].theUsed>1 )
+    //  continue;
     if (thisCell.check_alignment(hh,
                                  cells[otherCell],
                                  ptmin,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -251,7 +251,8 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
   myStart[2] =  thisCell.theLayerPairId == 13 || thisCell.theLayerPairId == 14 || // barrel jumps...
                 thisCell.theLayerPairId == 15 || thisCell.theLayerPairId == 16;    // fw jumps...
   //
-  if (myStart[start]) {
+  auto doit = start>=0 ? myStart[start] : myStart[0]||myStart[1]||myStart[2];
+  if (doit) {
     GPUCACell::TmpTuple stack;
     stack.reset();
     thisCell.find_ntuplets(hh,
@@ -266,7 +267,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
 #endif
                            stack,
                            minHitsPerNtuplet, 
-                           0==start);
+                           myStart[0]);
     assert(stack.size() == 0);
     // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
   }
@@ -623,7 +624,9 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
 
   blockSize = 64;
   numberOfBlocks = (maxNumberOfDoublets_ + blockSize - 1) / blockSize;
-  for (int startLayer=0; startLayer<3; ++startLayer) {
+  int nIter = doIterations_ ? 3 : 1;
+  if (minHitsPerNtuplet_>3) nIter=1;
+  for (int startLayer=0; startLayer<nIter; ++startLayer) {
     kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                      device_theCells_.get(),
                                                                      device_nCells_,
@@ -631,7 +634,8 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                      gpu_.tuples_d,
                                                                      gpu_.apc_d,
                                                                      device_tupleMultiplicity_,
-                                                                     minHitsPerNtuplet_,startLayer);
+                                                                     minHitsPerNtuplet_,
+                                                                     doIterations_ ? startLayer : -1);
     cudaCheck(cudaGetLastError());
 
     kernel_mark_used<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
@@ -727,6 +731,14 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
   if (0 == nhits)
     return;  // protect against empty events
 
+  // FIXME avoid magic numbers
+  auto nActualPairs=gpuPixelDoublets::nPairs;
+  if (noForwardTriplets_) nActualPairs = 15;
+  if (minHitsPerNtuplet_>3) {
+    nActualPairs = 13;
+  }
+
+  assert(nActualPairs<=gpuPixelDoublets::nPairs);
   int stride = 1;
   int threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
   int blocks = (2 * nhits + threadsPerBlock - 1) / threadsPerBlock;
@@ -738,6 +750,7 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
                                                                          device_theCellTracks_,
                                                                          hh.view(),
                                                                          device_isOuterHitOfCell_.get(),
+                                                                         nActualPairs,
                                                                          idealConditions_,
                                                                          doClusterCut_,
                                                                          doZCut_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -165,28 +165,16 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
   if (thisCell.theDoubletId < 0)
     return;
 
-  float mc = 1000.f;
+  float mc = 10000.f;
   uint16_t im = 60000;
-  uint32_t maxNh = 0;
 
   auto score = [&](auto it) {
     return std::abs(hfit[it].par(1));  // tip
     // return hfit[it].chi2_line+hfit[it].chi2_circle;  //chi2
   };
 
-  // find maxNh
-  for (auto it : thisCell.tracks()) {
-    if (quality[it] != loose)
-      continue;
-    auto nh = foundNtuplets->size(it);
-    maxNh = std::max(nh, maxNh);
-  }
-
   // find min chi2
   for (auto it : thisCell.tracks()) {
-    auto nh = foundNtuplets->size(it);
-    if (nh != maxNh)
-      continue;
     if (quality[it] == loose && score(it) < mc) {
       mc = score(it);
       im = it;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -117,7 +117,15 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
   constexpr auto dup = pixelTuplesHeterogeneousProduct::dup;
   // constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
 
+  assert(nCells);
+
   auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
+
+#ifdef GPU_DEBUG
+  if (0==cellIndex)
+    printf("fastDuplicateRemover: %d cells\n",*nCells);
+#endif
+
 
   if (cellIndex >= (*nCells))
     return;
@@ -521,6 +529,10 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
 
+  // std::cout << "N hits " << nhits << std::endl;
+  if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
+
+
   if (nhits > 1 && earlyFishbone_) {
     auto nthTot = 64;
     auto stride = 4;
@@ -571,6 +583,13 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                      minHitsPerNtuplet_);
   cudaCheck(cudaGetLastError());
 
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
+
+  blockSize = 128;
   numberOfBlocks = (TuplesOnGPU::Container::totbins() + blockSize - 1) / blockSize;
   cudautils::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.apc_d, gpu_.tuples_d);
 
@@ -605,10 +624,12 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                         nhits,
                                                                         counters_);
     cudaCheck(cudaGetLastError());
-#ifdef GPU_DEBUG
-    cudaDeviceSynchronize();
-#endif
   }
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
 
   // kernel_print_found_ntuplets<<<1, 1, 0, cudaStream>>>(gpu_.tuples_d, 10);
 }
@@ -620,12 +641,19 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
   std::cout << "building Doublets out of " << nhits << " Hits" << std::endl;
 #endif
 
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
   // in principle we can use "nhits" to heuristically dimension the workspace...
   edm::Service<CUDAService> cs;
-  device_isOuterHitOfCell_ = cs->make_device_unique<GPUCACell::OuterHitOfCell[]>(nhits, stream);
+  device_isOuterHitOfCell_ = cs->make_device_unique<GPUCACell::OuterHitOfCell[]>(std::max(1U,nhits), stream);
+  assert(device_isOuterHitOfCell_.get());
   {
     int threadsPerBlock = 128;
-    int blocks = (nhits + threadsPerBlock - 1) / threadsPerBlock;
+    // at least one block!
+    int blocks = ( std::max(1U,nhits) + threadsPerBlock - 1) / threadsPerBlock;
     gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0, stream.id()>>>(device_isOuterHitOfCell_.get(),
                                                                                 nhits,
                                                                                 device_theCellNeighbors_,
@@ -636,6 +664,11 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
   }
 
   device_theCells_ = cs->make_device_unique<GPUCACell[]>(CAConstants::maxNumberOfDoublets(), stream);
+
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
 
   if (0 == nhits)
     return;  // protect against empty events
@@ -656,6 +689,12 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
                                                                          doZCut_,
                                                                          doPhiCut_);
   cudaCheck(cudaGetLastError());
+
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
+
 }
 
 void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
@@ -707,6 +746,9 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
     kernel_doStatsForTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples.tuples_d, tuples.quality_d, counters_);
     cudaCheck(cudaGetLastError());
   }
+#ifdef GPU_DEBUG
+    cudaDeviceSynchronize();
+#endif
 }
 
 __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters const *counters) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -112,6 +112,40 @@ __global__ void kernel_fishboneCleaner(GPUCACell const *cells,
     quality[it] = bad;
 }
 
+__global__ void kernel_earlyDuplicateRemover(GPUCACell const *cells,
+                                            uint32_t const *__restrict__ nCells,
+                                            TuplesOnGPU::Container *foundNtuplets,
+                                            pixelTuplesHeterogeneousProduct::Quality *quality) {
+  // constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
+  constexpr auto dup = pixelTuplesHeterogeneousProduct::dup;
+  // constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
+
+  assert(nCells);
+
+  auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (cellIndex >= (*nCells))
+    return;
+  auto const &thisCell = cells[cellIndex];
+  if (thisCell.theDoubletId < 0)
+    return;
+
+  uint32_t maxNh = 0;
+
+  // find maxNh
+  for (auto it : thisCell.tracks()) {
+    auto nh = foundNtuplets->size(it);
+    maxNh = std::max(nh, maxNh);
+  }
+
+  for (auto it : thisCell.tracks()) {
+    if (foundNtuplets->size(it) != maxNh)
+      quality[it] = dup;  //no race:  simple assignment of the same constant
+  }
+
+}
+
+
 __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
                                             uint32_t const *__restrict__ nCells,
                                             TuplesOnGPU::Container *foundNtuplets,
@@ -119,7 +153,7 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
                                             pixelTuplesHeterogeneousProduct::Quality *quality) {
   constexpr auto bad = pixelTuplesHeterogeneousProduct::bad;
   constexpr auto dup = pixelTuplesHeterogeneousProduct::dup;
-  // constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
+  constexpr auto loose = pixelTuplesHeterogeneousProduct::loose;
 
   assert(nCells);
 
@@ -142,22 +176,23 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
 
   // find maxNh
   for (auto it : thisCell.tracks()) {
-    if (quality[it] == bad)
+    if (quality[it] != loose)
       continue;
     auto nh = foundNtuplets->size(it);
     maxNh = std::max(nh, maxNh);
   }
+
   // find min chi2
   for (auto it : thisCell.tracks()) {
     auto nh = foundNtuplets->size(it);
     if (nh != maxNh)
       continue;
-    if (quality[it] != bad && score(it) < mc) {
+    if (quality[it] == loose && score(it) < mc) {
       mc = score(it);
       im = it;
     }
   }
-  // mark duplicates
+  // mark all other duplicates
   for (auto it : thisCell.tracks()) {
     if (quality[it] != bad && it != im)
       quality[it] = dup;  //no race:  simple assignment of the same constant
@@ -308,6 +343,7 @@ __global__ void kernel_countMultiplicity(TuplesOnGPU::Container const *__restric
   if (nhits < 3)
     return;
   if (quality[it] == pixelTuplesHeterogeneousProduct::dup) return;
+  assert(quality[it] == pixelTuplesHeterogeneousProduct::bad);
   if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
   assert(nhits<8);
   tupleMultiplicity->countDirect(nhits);
@@ -682,6 +718,12 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   blockSize = 128;
   numberOfBlocks = (TuplesOnGPU::Container::totbins() + blockSize - 1) / blockSize;
   cudautils::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.apc_d, gpu_.tuples_d);
+
+  // remove duplicates (tracks that share a doublet)
+  numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
+  kernel_earlyDuplicateRemover<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
+      device_theCells_.get(), device_nCells_, gpu_.tuples_d, gpu_.quality_d);
+  cudaCheck(cudaGetLastError());
 
   blockSize = 128;
   numberOfBlocks = (CAConstants::maxTuples() + blockSize - 1) / blockSize;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -230,8 +230,12 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
   __syncthreads();
 #endif
 
-  if (thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
-      thisCell.theLayerPairId == 8) {  // inner layer is 0 FIXME
+  bool start0 =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
+                 thisCell.theLayerPairId == 8;  // inner layer is 0 FIXME
+  bool start1 =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
+                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11;
+                 // inner layer is "1" FIXME
+  if (start0 || start1) {
     GPUCACell::TmpTuple stack;
     stack.reset();
     thisCell.find_ntuplets(hh,
@@ -245,7 +249,8 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                            *tupleMultiplicity,
 #endif
                            stack,
-                           minHitsPerNtuplet);
+                           minHitsPerNtuplet, 
+                           start0);
     assert(stack.size() == 0);
     // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
   }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -597,18 +597,6 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
 
 
-  if (nhits > 1 && earlyFishbone_) {
-    auto nthTot = 64;
-    auto stride = 4;
-    auto blockSize = nthTot / stride;
-    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
-    dim3 blks(1, numberOfBlocks, 1);
-    dim3 thrs(stride, blockSize, 1);
-    fishbone<<<blks, thrs, 0, cudaStream>>>(
-        hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
-    cudaCheck(cudaGetLastError());
-  }
-
   auto nthTot = 64;
   auto stride = 4;
   auto blockSize = nthTot / stride;
@@ -636,6 +624,21 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
       dcaCutInnerTriplet_,
       dcaCutOuterTriplet_);
   cudaCheck(cudaGetLastError());
+
+
+  if (nhits > 1 && earlyFishbone_) {
+    auto nthTot = 128;
+    auto stride = 16;
+    auto blockSize = nthTot / stride;
+    auto numberOfBlocks = (nhits + blockSize - 1) / blockSize;
+    dim3 blks(1, numberOfBlocks, 1);
+    dim3 thrs(stride, blockSize, 1);
+    fishbone<<<blks, thrs, 0, cudaStream>>>(
+        hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
+    cudaCheck(cudaGetLastError());
+  }
+
+
 
 
   blockSize = 64;
@@ -792,11 +795,13 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
       tuples.tuples_d, tuples.helix_fit_results_d, cuts_, tuples.quality_d);
   cudaCheck(cudaGetLastError());
 
-  // apply fishbone cleaning to good tracks
-  numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
-  kernel_fishboneCleaner<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
-      device_theCells_.get(), device_nCells_, tuples.quality_d);
-  cudaCheck(cudaGetLastError());
+  if (lateFishbone_) {
+    // apply fishbone cleaning to good tracks
+    numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;
+    kernel_fishboneCleaner<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
+        device_theCells_.get(), device_nCells_, tuples.quality_d);
+    cudaCheck(cudaGetLastError());
+  }
 
   // remove duplicates (tracks that share a doublet)
   numberOfBlocks = (CAConstants::maxNumberOfDoublets() + blockSize - 1) / blockSize;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -261,12 +261,10 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     local.zero();
   __syncthreads();
 #endif
-  // this stuff needs optimization....
+  // this stuff may need further optimization....
   bool myStart[3];
-  myStart[0] =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
-                thisCell.theLayerPairId == 8;  // inner layer is 0
-  myStart[1] =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
-                thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11; // inner layer is "1"
+  myStart[0] =  thisCell.theLayerPairId <3; // inner layer is "0"
+  myStart[1] =  thisCell.theLayerPairId >2 && thisCell.theLayerPairId <8; // inner layer is "1"
   myStart[2] =  thisCell.theLayerPairId > 12;  // jumps
   //
   auto doit = start>=0 ? myStart[start] : myStart[0]||myStart[1]||myStart[2];

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -82,7 +82,7 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
       printf("Tracks overflow %d in %d\n", idx, thisCell.theLayerPairId);
     if (thisCell.theDoubletId < 0)
       atomicAdd(&c.nKilledCells, 1);
-    if (thisCell.outerNeighbors().empty())
+    if (0==thisCell.theUsed)
       atomicAdd(&c.nEmptyCells, 1);
     if (thisCell.tracks().empty())
       atomicAdd(&c.nZeroTrackCells, 1);
@@ -188,15 +188,16 @@ __global__ void kernel_connect(AtomicPairCounter *apc1,
 
   if (cellIndex >= (*nCells))
     return;
-  auto const &thisCell = cells[cellIndex];
-  if (thisCell.theDoubletId < 0)
+  auto & thisCell = cells[cellIndex];
+  if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
     return;
   auto innerHitId = thisCell.get_inner_hit_id();
   auto numberOfPossibleNeighbors = isOuterHitOfCell[innerHitId].size();
   auto vi = isOuterHitOfCell[innerHitId].data();
   for (auto j = first; j < numberOfPossibleNeighbors; j += stride) {
     auto otherCell = __ldg(vi + j);
-    if (cells[otherCell].theDoubletId < 0)
+    if (cells[otherCell].theDoubletId < 0 ||
+        cells[otherCell].theUsed>1 )
       continue;
     if (thisCell.check_alignment(hh,
                                  cells[otherCell],
@@ -207,6 +208,8 @@ __global__ void kernel_connect(AtomicPairCounter *apc1,
                                  dcaCutInnerTriplet,
                                  dcaCutOuterTriplet)) {
       cells[otherCell].addOuterNeighbor(cellIndex, *cellNeighbors);
+      thisCell.theUsed |= 1;
+      cells[otherCell].theUsed |= 1;
     }
   }
 }
@@ -218,7 +221,8 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                                      TuplesOnGPU::Container *foundNtuplets,
                                      AtomicPairCounter *apc,
                                      GPUCACell::TupleMultiplicity *tupleMultiplicity,
-                                     unsigned int minHitsPerNtuplet) {
+                                     unsigned int minHitsPerNtuplet, 
+                                     int start) {
   // recursive: not obvious to widen
   auto const &hh = *hhp;
 
@@ -227,19 +231,25 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     return;
   auto &thisCell = cells[cellIndex];
 
+  if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
+    return;
+
 #ifdef CA_USE_LOCAL_COUNTERS
   __shared__ GPUCACell::TupleMultiplicity::CountersOnly local;
   if (0 == threadIdx.x)
     local.zero();
   __syncthreads();
 #endif
-
-  bool start0 =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
+  // this stuff needs optimization....
+  bool myStart[3];
+  myStart[0] =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
                  thisCell.theLayerPairId == 8;  // inner layer is 0 FIXME
-  bool start1 =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
-                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11;
-                 // inner layer is "1" FIXME
-  if (start0 || start1) {
+  myStart[1] =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
+                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11; // inner layer is "1" FIXME
+  myStart[2] =  thisCell.theLayerPairId == 2 || thisCell.theLayerPairId == 5 || thisCell.theLayerPairId == 10 ||
+                 thisCell.theLayerPairId == 7 || thisCell.theLayerPairId == 12; // inner layer is "1" FIXME
+  //
+  if (myStart[start]) {
     GPUCACell::TmpTuple stack;
     stack.reset();
     thisCell.find_ntuplets(hh,
@@ -254,7 +264,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
 #endif
                            stack,
                            minHitsPerNtuplet, 
-                           start0);
+                           0==start);
     assert(stack.size() == 0);
     // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
   }
@@ -265,6 +275,23 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     tupleMultiplicity->add(local);
 #endif
 }
+
+
+__global__ void kernel_mark_used(GPUCACell::Hits const *__restrict__ hhp,
+                                     GPUCACell *__restrict__ cells,
+                                     uint32_t const *nCells) {
+
+  // auto const &hh = *hhp;
+
+  auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
+  if (cellIndex >= (*nCells))
+    return;
+  auto &thisCell = cells[cellIndex];
+  if (!thisCell.tracks().empty())
+    thisCell.theUsed |= 2;
+
+}
+
 
 __global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
                                         GPUCACell::TupleMultiplicity *tupleMultiplicity) {
@@ -589,16 +616,25 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
       dcaCutOuterTriplet_);
   cudaCheck(cudaGetLastError());
 
-  kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
+
+  blockSize = 64;
+  numberOfBlocks = (maxNumberOfDoublets_ + blockSize - 1) / blockSize;
+  for (int startLayer=0; startLayer<2; ++startLayer) {
+    kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                      device_theCells_.get(),
                                                                      device_nCells_,
                                                                      device_theCellTracks_,
                                                                      gpu_.tuples_d,
                                                                      gpu_.apc_d,
                                                                      device_tupleMultiplicity_,
-                                                                     minHitsPerNtuplet_);
-  cudaCheck(cudaGetLastError());
+                                                                     minHitsPerNtuplet_,startLayer);
+    cudaCheck(cudaGetLastError());
 
+    kernel_mark_used<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
+                                                                   device_theCells_.get(),
+                                                                   device_nCells_);
+    cudaCheck(cudaGetLastError());
+  }
 #ifdef GPU_DEBUG
   cudaDeviceSynchronize();
   cudaCheck(cudaGetLastError());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -594,8 +594,11 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
 
   // std::cout << "N hits " << nhits << std::endl;
-  if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
+  // if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
 
+  //
+  // applying conbinatoric cleaning such as fishbone at this stage is too expensive
+  //
 
   auto nthTot = 64;
   auto stride = 4;
@@ -637,8 +640,6 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
         hh.view(), device_theCells_.get(), device_nCells_, device_isOuterHitOfCell_.get(), nhits, false);
     cudaCheck(cudaGetLastError());
   }
-
-
 
 
   blockSize = 64;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -754,7 +754,7 @@ void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::s
 
   // FIXME avoid magic numbers
   auto nActualPairs=gpuPixelDoublets::nPairs;
-  if (noForwardTriplets_) nActualPairs = 15;
+  if (!includeJumpingForwardDoublets_) nActualPairs = 15;
   if (minHitsPerNtuplet_>3) {
     nActualPairs = 13;
   }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -267,8 +267,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                 thisCell.theLayerPairId == 8;  // inner layer is 0
   myStart[1] =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11; // inner layer is "1"
-  myStart[2] =  thisCell.theLayerPairId == 13 || thisCell.theLayerPairId == 14 || // barrel jumps...
-                thisCell.theLayerPairId == 15 || thisCell.theLayerPairId == 16;    // fw jumps...
+  myStart[2] =  thisCell.theLayerPairId > 12;  // jumps
   //
   auto doit = start>=0 ? myStart[start] : myStart[0]||myStart[1]||myStart[2];
   if (doit) {
@@ -657,6 +656,7 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                      doIterations_ ? startLayer : -1);
     cudaCheck(cudaGetLastError());
 
+    if (doIterations_ || doStats_)
     kernel_mark_used<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                    device_theCells_.get(),
                                                                    device_nCells_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -245,10 +245,11 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
   // this stuff needs optimization....
   bool myStart[3];
   myStart[0] =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
-                 thisCell.theLayerPairId == 8 || thisCell.theLayerPairId == 13;  // inner layer is 0 FIXME
+                thisCell.theLayerPairId == 8;  // inner layer is 0
   myStart[1] =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
-                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11 || thisCell.theLayerPairId == 14; // inner layer is "1" FIXME
-  myStart[2] =  thisCell.theLayerPairId == 13 || thisCell.theLayerPairId == 14; // jumps...
+                thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11; // inner layer is "1"
+  myStart[2] =  thisCell.theLayerPairId == 13 || thisCell.theLayerPairId == 14 || // barrel jumps...
+                thisCell.theLayerPairId == 15 || thisCell.theLayerPairId == 16;    // fw jumps...
   //
   if (myStart[start]) {
     GPUCACell::TmpTuple stack;
@@ -622,7 +623,7 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
 
   blockSize = 64;
   numberOfBlocks = (maxNumberOfDoublets_ + blockSize - 1) / blockSize;
-  for (int startLayer=0; startLayer<2; ++startLayer) {
+  for (int startLayer=0; startLayer<3; ++startLayer) {
     kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                      device_theCells_.get(),
                                                                      device_nCells_,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -28,6 +28,7 @@ using TuplesOnGPU = pixelTuplesHeterogeneousProduct::TuplesOnGPU;
 using Quality = pixelTuplesHeterogeneousProduct::Quality;
 
 __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
+                                      CAConstants::TupleMultiplicity * tupleMultiplicity,
                                       AtomicPairCounter *apc,
                                       GPUCACell const *__restrict__ cells,
                                       uint32_t const *__restrict__ nCells,
@@ -45,6 +46,7 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
     atomicAdd(&c.nHits, nHits);
     atomicAdd(&c.nCells, *nCells);
     atomicAdd(&c.nTuples, apc->get().m);
+    atomicAdd(&c.nFitTracks,tupleMultiplicity->size());
   }
 
 #ifdef NTUPLE_DEBUG
@@ -735,6 +737,7 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   if (doStats_) {
     numberOfBlocks = (std::max(nhits, maxNumberOfDoublets_) + blockSize - 1) / blockSize;
     kernel_checkOverflows<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d,
+                                                                        device_tupleMultiplicity_,
                                                                         gpu_.apc_d,
                                                                         device_theCells_.get(),
                                                                         device_nCells_,
@@ -891,14 +894,15 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
 __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters const *counters) {
   auto const &c = *counters;
   printf(
-      "||Counters | nEvents | nHits | nCells | nTuples | nGoodTracks | nUsedHits | nDupHits | nKilledCells | "
+      "||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nGoodTracks | nUsedHits | nDupHits | nKilledCells | "
       "nEmptyCells | nZeroTrackCells ||\n");
-  printf("Counters Raw %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
+  printf("Counters Raw %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
          c.nEvents,
          c.nHits,
          c.nCells,
          c.nTuples,
          c.nGoodTracks,
+         c.nFitTracks,
          c.nUsedHits,
          c.nDupHits,
          c.nKilledCells,
@@ -909,6 +913,7 @@ __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters c
          c.nHits / double(c.nEvents),
          c.nCells / double(c.nEvents),
          c.nTuples / double(c.nEvents),
+         c.nFitTracks / double(c.nEvents),
          c.nGoodTracks / double(c.nEvents),
          c.nUsedHits / double(c.nEvents),
          c.nDupHits / double(c.nEvents),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -908,7 +908,7 @@ __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters c
          c.nKilledCells,
          c.nEmptyCells,
          c.nZeroTrackCells);
-  printf("Counters Norm %lld ||  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.3f|  %.3f||\n",
+  printf("Counters Norm %lld ||  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.1f|  %.3f|  %.3f||\n",
          c.nEvents,
          c.nHits / double(c.nEvents),
          c.nCells / double(c.nEvents),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -2,7 +2,7 @@
 // Author: Felice Pantaleo, CERN
 //
 
-#define NTUPLE_DEBUG
+// #define NTUPLE_DEBUG
 
 #include <cmath>
 #include <cstdint>
@@ -54,8 +54,10 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
            apc->get().m,
            apc->get().n,
            nHits);
-    assert(foundNtuplets->size(apc->get().m) == 0);
-    assert(foundNtuplets->size() == apc->get().n);
+    if (apc->get().m < CAConstants::maxNumberOfQuadruplets()) {
+      assert(foundNtuplets->size(apc->get().m) == 0);
+      assert(foundNtuplets->size() == apc->get().n);
+    }
   }
 
   if (idx < foundNtuplets->nbins()) {
@@ -243,11 +245,10 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
   // this stuff needs optimization....
   bool myStart[3];
   myStart[0] =  thisCell.theLayerPairId == 0 || thisCell.theLayerPairId == 3 ||
-                 thisCell.theLayerPairId == 8;  // inner layer is 0 FIXME
+                 thisCell.theLayerPairId == 8 || thisCell.theLayerPairId == 13;  // inner layer is 0 FIXME
   myStart[1] =  thisCell.theLayerPairId == 1 || thisCell.theLayerPairId == 4 || thisCell.theLayerPairId == 9 ||  
-                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11; // inner layer is "1" FIXME
-  myStart[2] =  thisCell.theLayerPairId == 2 || thisCell.theLayerPairId == 5 || thisCell.theLayerPairId == 10 ||
-                 thisCell.theLayerPairId == 7 || thisCell.theLayerPairId == 12; // inner layer is "1" FIXME
+                 thisCell.theLayerPairId == 6 || thisCell.theLayerPairId == 11 || thisCell.theLayerPairId == 14; // inner layer is "1" FIXME
+  myStart[2] =  thisCell.theLayerPairId == 13 || thisCell.theLayerPairId == 14; // jumps...
   //
   if (myStart[start]) {
     GPUCACell::TmpTuple stack;
@@ -303,6 +304,8 @@ __global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict
   auto nhits = foundNtuplets->size(it);
   if (nhits < 3)
     return;
+  if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
+  assert(nhits<8);
   tupleMultiplicity->fillDirect(nhits, it);
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -241,7 +241,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                                      CellTracksVector *cellTracks,
                                      TuplesOnGPU::Container *foundNtuplets,
                                      AtomicPairCounter *apc,
-                                     GPUCACell::TupleMultiplicity *tupleMultiplicity,
+                                     Quality * __restrict__ quality,
                                      unsigned int minHitsPerNtuplet, 
                                      int start) {
   // recursive: not obvious to widen
@@ -255,12 +255,6 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
   if (thisCell.theDoubletId < 0 || thisCell.theUsed>1)
     return;
 
-#ifdef CA_USE_LOCAL_COUNTERS
-  __shared__ GPUCACell::TupleMultiplicity::CountersOnly local;
-  if (0 == threadIdx.x)
-    local.zero();
-  __syncthreads();
-#endif
   // this stuff may need further optimization....
   bool myStart[3];
   myStart[0] =  thisCell.theLayerPairId <3; // inner layer is "0"
@@ -276,11 +270,7 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
                            *cellTracks,
                            *foundNtuplets,
                            *apc,
-#ifdef CA_USE_LOCAL_COUNTERS
-                           local,
-#else
-                           *tupleMultiplicity,
-#endif
+                           quality,
                            stack,
                            minHitsPerNtuplet, 
                            myStart[0]);
@@ -288,11 +278,6 @@ __global__ void kernel_find_ntuplets(GPUCACell::Hits const *__restrict__ hhp,
     // printf("in %d found quadruplets: %d\n", cellIndex, apc->get());
   }
 
-#ifdef CA_USE_LOCAL_COUNTERS
-  __syncthreads();
-  if (0 == threadIdx.x)
-    tupleMultiplicity->add(local);
-#endif
 }
 
 
@@ -311,9 +296,9 @@ __global__ void kernel_mark_used(GPUCACell::Hits const *__restrict__ hhp,
 
 }
 
-
-__global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
-                                        GPUCACell::TupleMultiplicity *tupleMultiplicity) {
+__global__ void kernel_countMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
+                                         Quality const * __restrict__ quality,
+                                         CAConstants::TupleMultiplicity *tupleMultiplicity) {
   auto it = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (it >= foundNtuplets->nbins())
@@ -322,10 +307,32 @@ __global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict
   auto nhits = foundNtuplets->size(it);
   if (nhits < 3)
     return;
+  if (quality[it] == pixelTuplesHeterogeneousProduct::dup) return;
+  if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
+  assert(nhits<8);
+  tupleMultiplicity->countDirect(nhits);
+}
+
+
+
+__global__ void kernel_fillMultiplicity(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
+                                        Quality const * __restrict__ quality,
+                                        CAConstants::TupleMultiplicity *tupleMultiplicity) {
+  auto it = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (it >= foundNtuplets->nbins())
+    return;
+
+  auto nhits = foundNtuplets->size(it);
+  if (nhits < 3)
+    return;
+  if (quality[it] == pixelTuplesHeterogeneousProduct::dup) return;
   if (nhits>5) printf("wrong mult %d %d\n",it,nhits);
   assert(nhits<8);
   tupleMultiplicity->fillDirect(nhits, it);
 }
+
+
 
 __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__ tuples,
                                       Rfit::helix_fit const *__restrict__ fit_results,
@@ -339,8 +346,10 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
     return;
   }
 
-  // mark as bad by default
-  quality[idx] = pixelTuplesHeterogeneousProduct::bad;
+  // if duplicate: not even fit
+  if (quality[idx] == pixelTuplesHeterogeneousProduct::dup) return;
+
+  assert(quality[idx] == pixelTuplesHeterogeneousProduct::bad);
 
   // mark doublets as bad
   if (tuples->size(idx) < 3) {
@@ -653,7 +662,7 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
                                                                      device_theCellTracks_,
                                                                      gpu_.tuples_d,
                                                                      gpu_.apc_d,
-                                                                     device_tupleMultiplicity_,
+                                                                     gpu_.quality_d,
                                                                      minHitsPerNtuplet_,
                                                                      doIterations_ ? startLayer : -1);
     cudaCheck(cudaGetLastError());
@@ -674,11 +683,11 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   numberOfBlocks = (TuplesOnGPU::Container::totbins() + blockSize - 1) / blockSize;
   cudautils::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.apc_d, gpu_.tuples_d);
 
-  cudautils::launchFinalize(device_tupleMultiplicity_, device_tmws_, cudaStream);
-
   blockSize = 128;
   numberOfBlocks = (CAConstants::maxTuples() + blockSize - 1) / blockSize;
-  kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, device_tupleMultiplicity_);
+  kernel_countMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, gpu_.quality_d, device_tupleMultiplicity_);
+  cudautils::launchFinalize(device_tupleMultiplicity_, device_tmws_, cudaStream);
+  kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(gpu_.tuples_d, gpu_.quality_d, device_tupleMultiplicity_);
   cudaCheck(cudaGetLastError());
 
   if (nhits > 1 && lateFishbone_) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.cu
@@ -2,6 +2,8 @@
 // Author: Felice Pantaleo, CERN
 //
 
+#define NTUPLE_DEBUG
+
 #include <cmath>
 #include <cstdint>
 
@@ -45,7 +47,7 @@ __global__ void kernel_checkOverflows(TuplesOnGPU::Container *foundNtuplets,
     atomicAdd(&c.nTuples, apc->get().m);
   }
 
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
   if (0 == idx) {
     printf("number of found cells %d, found tuples %d with total hits %d out of %d\n",
            *nCells,
@@ -120,12 +122,6 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *cells,
   assert(nCells);
 
   auto cellIndex = threadIdx.x + blockIdx.x * blockDim.x;
-
-#ifdef GPU_DEBUG
-  if (0==cellIndex)
-    printf("fastDuplicateRemover: %d cells\n",*nCells);
-#endif
-
 
   if (cellIndex >= (*nCells))
     return;
@@ -309,7 +305,7 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
     isNaN |= isnan(fit_results[idx].par(i));
   }
   if (isNaN) {
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
     printf("NaN in fit %d size %d chi2 %f + %f\n",
            idx,
            tuples->size(idx),
@@ -329,10 +325,12 @@ __global__ void kernel_classifyTracks(TuplesOnGPU::Container const *__restrict__
   float chi2Cut = cuts.chi2Scale *
                   (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
   if (fit_results[idx].chi2_line + fit_results[idx].chi2_circle >= chi2Cut) {
-#ifdef GPU_DEBUG
-    printf("Bad fit %d size %d chi2 %f + %f\n",
+#ifdef NTUPLE_DEBUG
+    printf("Bad fit %d size %d pt %f eta %f chi2 l %f + c %f\n",
            idx,
-           tuples->size(idx),
+           tuples->size(idx), 
+           fit_results[idx].par(2),
+           asinhf(fit_results[idx].par(3)), 
            fit_results[idx].chi2_line,
            fit_results[idx].chi2_circle);
 #endif
@@ -505,17 +503,35 @@ __global__ void kernel_tripletCleaner(TrackingRecHit2DSOAView const *__restrict_
   }  // loop over hits
 }
 
-__global__ void kernel_print_found_ntuplets(TuplesOnGPU::Container const *__restrict__ foundNtuplets,
-                                            uint32_t maxPrint) {
-  for (int i = 0; i < std::min(maxPrint, foundNtuplets->nbins()); ++i) {
-    if (foundNtuplets->size(i) < 4)
-      continue;
-    printf("\nquadruplet %d: %d %d %d %d\n",
-           i,
-           (*(*foundNtuplets).begin(i)),
-           (*(*foundNtuplets).begin(i) + 1),
-           (*(*foundNtuplets).begin(i) + 2),
-           (*(*foundNtuplets).begin(i) + 3));
+__global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__restrict__ hhp,
+                                      TuplesOnGPU::Container const *__restrict__ ptuples,
+                                      Rfit::helix_fit const *__restrict__ fit_results,
+                                      Quality *__restrict__ quality,
+                                      CAHitQuadrupletGeneratorKernels::HitToTuple const *__restrict__ phitToTuple,
+                                      uint32_t maxPrint, int iev) {
+  auto const & foundNtuplets = *ptuples;
+  int first = blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first; i < std::min(maxPrint, foundNtuplets.nbins()); i+=blockDim.x*gridDim.x) {
+    auto nh = foundNtuplets.size(i);
+    if (nh<3) continue;
+    printf("TK: %d %d %d %f %f %f %f %f %f %f %f %d %d %d %d %d\n",
+           10000*iev+i,
+           int(quality[i]),
+           nh,
+           fit_results[i].par(0),
+           fit_results[i].par(1),
+           fit_results[i].par(2),
+           fit_results[i].par(3),
+           fit_results[i].par(4),
+           asinhf(fit_results[i].par(3)),
+           fit_results[i].chi2_line,
+           fit_results[i].chi2_circle,
+           *foundNtuplets.begin(i),
+           *(foundNtuplets.begin(i) + 1),
+           *(foundNtuplets.begin(i) + 2),
+           nh>3 ? int(*(foundNtuplets.begin(i) + 3)):-1,
+           nh>4 ? int(*(foundNtuplets.begin(i) + 4)):-1
+          );
   }
 }
 
@@ -630,14 +646,12 @@ void CAHitQuadrupletGeneratorKernels::launchKernels(  // here goes algoparms....
   cudaCheck(cudaGetLastError());
 #endif
 
-
-  // kernel_print_found_ntuplets<<<1, 1, 0, cudaStream>>>(gpu_.tuples_d, 10);
 }
 
 void CAHitQuadrupletGeneratorKernels::buildDoublets(HitsOnCPU const &hh, cuda::stream_t<> &stream) {
   auto nhits = hh.nHits();
 
-#ifdef GPU_DEBUG
+#ifdef NTUPLE_DEBUG
   std::cout << "building Doublets out of " << nhits << " Hits" << std::endl;
 #endif
 
@@ -748,7 +762,15 @@ void CAHitQuadrupletGeneratorKernels::classifyTuples(HitsOnCPU const &hh,
   }
 #ifdef GPU_DEBUG
     cudaDeviceSynchronize();
+    cudaCheck(cudaGetLastError());
 #endif
+
+#ifdef    DUMP_GPU_TK_TUPLES
+  static std::atomic<int> iev(0);
+  ++iev;
+  kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(hh.view(), tuples.tuples_d, tuples.helix_fit_results_d, tuples.quality_d, device_hitToTuple_, 100,iev);
+#endif
+
 }
 
 __global__ void kernel_printCounters(CAHitQuadrupletGeneratorKernels::Counters const *counters) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -51,6 +51,7 @@ public:
   };
 
   CAHitQuadrupletGeneratorKernels(uint32_t minHitsPerNtuplet,
+                                  bool noForwardTriplets,
                                   bool earlyFishbone,
                                   bool lateFishbone,
                                   bool idealConditions,
@@ -58,6 +59,7 @@ public:
                                   bool doClusterCut,
                                   bool doZCut,
                                   bool doPhiCut,
+                                  bool doIterations,
                                   float ptmin,
                                   float CAThetaCutBarrel,
                                   float CAThetaCutForward,
@@ -66,6 +68,7 @@ public:
                                   float dcaCutOuterTriplet,
                                   QualityCuts const& cuts)
       : minHitsPerNtuplet_(minHitsPerNtuplet),
+        noForwardTriplets_(noForwardTriplets),
         earlyFishbone_(earlyFishbone),
         lateFishbone_(lateFishbone),
         idealConditions_(idealConditions),
@@ -73,6 +76,7 @@ public:
         doClusterCut_(doClusterCut),
         doZCut_(doZCut),
         doPhiCut_(doPhiCut),
+        doIterations_(doIterations),
         ptmin_(ptmin),
         CAThetaCutBarrel_(CAThetaCutBarrel),
         CAThetaCutForward_(CAThetaCutForward),
@@ -121,6 +125,7 @@ private:
 
   // params
   const uint32_t minHitsPerNtuplet_;
+  const bool noForwardTriplets_;
   const bool earlyFishbone_;
   const bool lateFishbone_;
   const bool idealConditions_;
@@ -128,6 +133,7 @@ private:
   const bool doClusterCut_;
   const bool doZCut_;
   const bool doPhiCut_;
+  const bool doIterations_;
   const float ptmin_;
   const float CAThetaCutBarrel_;
   const float CAThetaCutForward_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -18,6 +18,7 @@ public:
     unsigned long long nHits;
     unsigned long long nCells;
     unsigned long long nTuples;
+    unsigned long long nFitTracks;
     unsigned long long nGoodTracks;
     unsigned long long nUsedHits;
     unsigned long long nDupHits;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -51,7 +51,7 @@ public:
   };
 
   CAHitQuadrupletGeneratorKernels(uint32_t minHitsPerNtuplet,
-                                  bool noForwardTriplets,
+                                  bool includeJumpingForwardDoublets,
                                   bool earlyFishbone,
                                   bool lateFishbone,
                                   bool idealConditions,
@@ -68,7 +68,7 @@ public:
                                   float dcaCutOuterTriplet,
                                   QualityCuts const& cuts)
       : minHitsPerNtuplet_(minHitsPerNtuplet),
-        noForwardTriplets_(noForwardTriplets),
+        includeJumpingForwardDoublets_(includeJumpingForwardDoublets),
         earlyFishbone_(earlyFishbone),
         lateFishbone_(lateFishbone),
         idealConditions_(idealConditions),
@@ -125,7 +125,7 @@ private:
 
   // params
   const uint32_t minHitsPerNtuplet_;
-  const bool noForwardTriplets_;
+  const bool includeJumpingForwardDoublets_;
   const bool earlyFishbone_;
   const bool lateFishbone_;
   const bool idealConditions_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -7,7 +7,7 @@
 
 #include "GPUCACell.h"
 
-#define DUMP_GPU_TK_TUPLES
+// #define DUMP_GPU_TK_TUPLES
 
 
 class CAHitQuadrupletGeneratorKernels {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -7,6 +7,9 @@
 
 #include "GPUCACell.h"
 
+#define DUMP_GPU_TK_TUPLES
+
+
 class CAHitQuadrupletGeneratorKernels {
 public:
   // counters

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitQuadrupletGeneratorKernels.h
@@ -60,7 +60,6 @@ public:
                                   bool doClusterCut,
                                   bool doZCut,
                                   bool doPhiCut,
-                                  bool doIterations,
                                   float ptmin,
                                   float CAThetaCutBarrel,
                                   float CAThetaCutForward,
@@ -77,7 +76,6 @@ public:
         doClusterCut_(doClusterCut),
         doZCut_(doZCut),
         doPhiCut_(doPhiCut),
-        doIterations_(doIterations),
         ptmin_(ptmin),
         CAThetaCutBarrel_(CAThetaCutBarrel),
         CAThetaCutForward_(CAThetaCutForward),
@@ -134,7 +132,6 @@ private:
   const bool doClusterCut_;
   const bool doZCut_;
   const bool doPhiCut_;
-  const bool doIterations_;
   const float ptmin_;
   const float CAThetaCutBarrel_;
   const float CAThetaCutForward_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -141,7 +141,6 @@ public:
                    otherCell,
                    otherCell.get_inner_detIndex(hh) < last_bpix1_detIndex ? dcaCutInnerTriplet : dcaCutOuterTriplet,
                    hardCurvCut));  // FIXME tune cuts
-                                   // region_origin_radius_plus_tolerance,  hardCurvCut));
   }
 
   __device__ __forceinline__ static bool areAlignedRZ(

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -6,7 +6,7 @@
 //
 
 
-#define ALL_TRIPLETS
+// #define ONLY_TRIPLETS_IN_HOLE
 
 #include <cuda_runtime.h>
 
@@ -262,7 +262,7 @@ public:
     }
     if(last) {  // if long enough save...
       if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet - 1) {
-#ifndef ALL_TRIPLETS
+#ifdef ONLY_TRIPLETS_IN_HOLE
         // triplets accepted only pointing to the hole
         if (tmpNtuplet.size() >= 3 || 
             ( startAt0&&hole4(hh, cells[tmpNtuplet[0]]) ) ||

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -268,7 +268,7 @@ public:
     bool last=true;
     for (int j = 0; j < outerNeighbors().size(); ++j) {
       auto otherCell = outerNeighbors()[j];
-      if (cells[otherCell].theUsed>1) continue; // already in a track found in previous iteration
+      if (cells[otherCell].theDoubletId<0 || cells[otherCell].theUsed>1) continue; // already in a track found in previous iteration
         last = false;
         cells[otherCell].find_ntuplets(
             hh, cells, cellTracks, foundNtuplets, apc, tupleMultiplicity, tmpNtuplet, minHitsPerNtuplet,startAt0);

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -180,7 +180,7 @@ public:
     constexpr uint32_t max_ladder_bpx0 = 12;
     constexpr uint32_t first_ladder_bpx0 = 0;
     constexpr float module_length = 6.7f;
-    constexpr float module_tolerance = 0.2f;
+    constexpr float module_tolerance = 0.4f; // projection to cylinder is inaccurate on BPIX1
     int p = innerCell.get_inner_iphi(hh);
     if (p < 0)
       p += std::numeric_limits<unsigned short>::max();

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -5,6 +5,9 @@
 // Author: Felice Pantaleo, CERN
 //
 
+
+// #define ALL_TRIPLETS
+
 #include <cuda_runtime.h>
 
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h"
@@ -217,7 +220,7 @@ public:
     auto zi = innerCell.get_inner_z(hh);
     auto ro = get_outer_r(hh);
     auto zo = get_outer_z(hh);
-    auto z4 = zi + (r4 - ri) * (zo - zi) / (ro - ri);
+    auto z4 = zo + (r4 - ro) * (zo - zi) / (ro - ri);
     auto z_in_ladder = std::abs(z4-hh.averageGeometry().ladderZ[il]);
     auto z_in_module = z_in_ladder - module_length * int(z_in_ladder / module_length);
     auto gap = z_in_module < module_tolerance || z_in_module > (module_length - module_tolerance);

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -53,6 +53,7 @@ public:
     theLayerPairId = layerPairId;
     theUsed = 0;
 
+    // optimization that depends on access pattern
     theInnerZ = hh.zGlobal(innerHitId);
     theInnerR = hh.rGlobal(innerHitId);
 
@@ -78,13 +79,11 @@ public:
   __device__ __forceinline__ float get_outer_x(Hits const& hh) const { return hh.xGlobal(theOuterHitId); }
   __device__ __forceinline__ float get_inner_y(Hits const& hh) const { return hh.yGlobal(theInnerHitId); }
   __device__ __forceinline__ float get_outer_y(Hits const& hh) const { return hh.yGlobal(theOuterHitId); }
-  __device__ __forceinline__ float get_inner_z(Hits const& hh) const {
-    return theInnerZ;
-  }  // { return hh.zGlobal(theInnerHitId); } // { return theInnerZ; }
+  __device__ __forceinline__ float get_inner_z(Hits const& hh) const { return theInnerZ; }
+     // { return hh.zGlobal(theInnerHitId); } // { return theInnerZ; }
   __device__ __forceinline__ float get_outer_z(Hits const& hh) const { return hh.zGlobal(theOuterHitId); }
-  __device__ __forceinline__ float get_inner_r(Hits const& hh) const {
-    return theInnerR;
-  }  // { return hh.rGlobal(theInnerHitId); } // { return theInnerR; }
+  __device__ __forceinline__ float get_inner_r(Hits const& hh) const { return theInnerR; }
+     // { return hh.rGlobal(theInnerHitId); } // { return theInnerR; }
   __device__ __forceinline__ float get_outer_r(Hits const& hh) const { return hh.rGlobal(theOuterHitId); }
 
   __device__ __forceinline__ auto get_inner_iphi(Hits const& hh) const { return hh.iphi(theInnerHitId); }
@@ -175,6 +174,21 @@ public:
 
     return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
   }
+
+
+  __device__ __forceinline__ static bool dcaCutH(float x1,float y1, float x2,float y2, float x3,float y3,
+                                const float region_origin_radius_plus_tolerance,
+                                   const float maxCurv) {
+
+    CircleEq<float> eq(x1, y1, x2, y2, x3, y3);
+
+    if (eq.curvature() > maxCurv)
+      return false;
+
+    return std::abs(eq.dca0()) < region_origin_radius_plus_tolerance * std::abs(eq.curvature());
+  }
+
+
 
   __device__ inline bool hole0(Hits const& hh, GPUCACell const& innerCell) const {
     constexpr uint32_t max_ladder_bpx0 = 12;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -267,7 +267,7 @@ public:
     bool last=true;
     for (int j = 0; j < outerNeighbors().size(); ++j) {
       auto otherCell = outerNeighbors()[j];
-      if (cells[otherCell].theDoubletId<0 || cells[otherCell].theUsed>1) continue; // already in a track found in previous iteration
+      if (cells[otherCell].theDoubletId<0) continue; // killed by earlyFishbone
         last = false;
         cells[otherCell].find_ntuplets(
             hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet,startAt0);

--- a/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
@@ -10,7 +10,8 @@ class TrackingRecHit2DSOAView;
 class TrackingRecHit2DCUDA;
 
 namespace Rfit {
-  constexpr uint32_t maxNumberOfConcurrentFits() { return 12 * 1024; }
+  // in case of memory issue can be made smaller
+  constexpr uint32_t maxNumberOfConcurrentFits() { return CAConstants::maxNumberOfTuples(); }
   constexpr uint32_t stride() { return maxNumberOfConcurrentFits(); }
   using Matrix3x4d = Eigen::Matrix<double, 3, 4>;
   using Map3x4d = Eigen::Map<Matrix3x4d, 0, Eigen::Stride<3 * stride(), stride()> >;

--- a/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
@@ -10,7 +10,7 @@ class TrackingRecHit2DSOAView;
 class TrackingRecHit2DCUDA;
 
 namespace Rfit {
-  constexpr uint32_t maxNumberOfConcurrentFits() { return 6 * 1024; }
+  constexpr uint32_t maxNumberOfConcurrentFits() { return 12 * 1024; }
   constexpr uint32_t stride() { return maxNumberOfConcurrentFits(); }
   using Matrix3x4d = Eigen::Matrix<double, 3, 4>;
   using Map3x4d = Eigen::Map<Matrix3x4d, 0, Eigen::Stride<3 * stride(), stride()> >;

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -40,6 +40,7 @@ namespace gpuPixelDoublets {
     if (s < 2)
       return;
     // if alligned kill one of the two.
+    // in principle one could try to relax the cut (only in r-z?) for jumping-doublets 
     auto const& c0 = cells[vc[0]];
     auto xo = c0.get_outer_x(hh);
     auto yo = c0.get_outer_y(hh);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -50,6 +50,7 @@ namespace gpuPixelDoublets {
     auto sg = 0;
     for (uint32_t ic = 0; ic < s; ++ic) {
       auto& ci = cells[vc[ic]];
+      if (0==ci.theUsed) continue; // for triplets equivalent to next 
       if (checkTrack && ci.tracks().empty())
         continue;
       cc[sg] = vc[ic];

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -79,6 +79,7 @@ namespace gpuPixelDoublets {
                                CellNeighbors* cellNeighborsContainer,
                                CellTracksVector* cellTracks,
                                CellTracks* cellTracksContainer) {
+    assert(isOuterHitOfCell);
     int first = blockIdx.x * blockDim.x + threadIdx.x;
     for (int i = first; i < nHits; i += gridDim.x * blockDim.x)
       isOuterHitOfCell[i].reset();

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -13,7 +13,7 @@ namespace gpuPixelDoublets {
   static_assert(nPairs<=CAConstants::maxNumberOfLayerPairs());
 
 // start constants
-// google: DO NOT TOUCH FORMATTING HERE! 
+// clang-format off 
 
   CONSTANT_VAR const uint8_t layerPairs[2 * nPairs] = {
       0,1, 0,4, 0,7, // BPIX1 (3)
@@ -21,6 +21,7 @@ namespace gpuPixelDoublets {
       4,5, 7,8,      // FPIX1 (8)
       2,3, 2,4, 2,7, 5,6, 8,9,  // BPIX3 & FPIX2 (13)
       0,2, 1,3,      // Jumping Barrel (15)
+   // 0,5, 0,8,      // Jumping Forward (BPIX1,FPIX2)  OFF 
       4,6, 7,9       // Jumping Forward (17)
   };
 
@@ -34,13 +35,14 @@ namespace gpuPixelDoublets {
      phi0p05, phi0p05,
      phi0p06, phi0p06, phi0p06, phi0p05, phi0p05,
      phi0p05, phi0p05, phi0p06,phi0p06};
-//   phi0p07, phi0p07, phi0p06,phi0p06};
+//   phi0p07, phi0p07, phi0p06,phi0p06};  // relaxed cuts
 
   CONSTANT_VAR float const minz[nPairs] = {-20.,0.,-30., -22.,10.,-30., -70.,-70., -22.,15.,-30, -70.,-70., -20.,-22.,-70.,-70.};
   CONSTANT_VAR float const maxz[nPairs] = { 20.,30.,0.,   22.,30.,-10.,  70.,70.,   22.,30.,-15., 70., 70.,  20.,22.,  70.,70.};
   CONSTANT_VAR float const maxr[nPairs] = {20.,9.,9., 20.,7.,7., 5.,5., 20.,6.,6., 5., 5., 20.,20.,9.,9.}; 
 
 // end constants
+// clang-format on
 
   constexpr uint32_t MaxNumOfDoublets = CAConstants::maxNumberOfDoublets();  // not really relevant
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -101,13 +101,14 @@ namespace gpuPixelDoublets {
                                                                     CellTracksVector* cellTracks,
                                                                     TrackingRecHit2DSOAView const* __restrict__ hhp,
                                                                     GPUCACell::OuterHitOfCell* isOuterHitOfCell,
+                                                                    int nActualPairs,
                                                                     bool ideal_cond,
                                                                     bool doClusterCut,
                                                                     bool doZCut,
                                                                     bool doPhiCut) {
     auto const& __restrict__ hh = *hhp;
     doubletsFromHisto(layerPairs,
-                      nPairs,
+                      nActualPairs,
                       cells,
                       nCells,
                       cellNeighbors,

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -9,7 +9,7 @@ namespace gpuPixelDoublets {
 
   using namespace gpuPixelDoubletsAlgos;
 
-  constexpr int nPairs = 13+2+2;
+  constexpr int nPairs = 13+2+4;
   static_assert(nPairs<=CAConstants::maxNumberOfLayerPairs());
 
 // start constants
@@ -21,8 +21,8 @@ namespace gpuPixelDoublets {
       4,5, 7,8,      // FPIX1 (8)
       2,3, 2,4, 2,7, 5,6, 8,9,  // BPIX3 & FPIX2 (13)
       0,2, 1,3,      // Jumping Barrel (15)
-   // 0,5, 0,8,      // Jumping Forward (BPIX1,FPIX2)  OFF 
-      4,6, 7,9       // Jumping Forward (17)
+      0,5, 0,8,      // Jumping Forward (BPIX1,FPIX2)
+      4,6, 7,9       // Jumping Forward (19)
   };
 
   constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
@@ -34,12 +34,12 @@ namespace gpuPixelDoublets {
      phi0p05, phi0p06, phi0p06,
      phi0p05, phi0p05,
      phi0p06, phi0p06, phi0p06, phi0p05, phi0p05,
-     phi0p05, phi0p05, phi0p06,phi0p06};
-//   phi0p07, phi0p07, phi0p06,phi0p06};  // relaxed cuts
+     phi0p05, phi0p05, phi0p05,phi0p05, phi0p05,phi0p05};
+//   phi0p07, phi0p07, phi0p06,phi0p06, phi0p06,phi0p06};  // relaxed cuts
 
-  CONSTANT_VAR float const minz[nPairs] = {-20.,0.,-30., -22.,10.,-30., -70.,-70., -22.,15.,-30, -70.,-70., -20.,-22.,-70.,-70.};
-  CONSTANT_VAR float const maxz[nPairs] = { 20.,30.,0.,   22.,30.,-10.,  70.,70.,   22.,30.,-15., 70., 70.,  20.,22.,  70.,70.};
-  CONSTANT_VAR float const maxr[nPairs] = {20.,9.,9., 20.,7.,7., 5.,5., 20.,6.,6., 5., 5., 20.,20.,9.,9.}; 
+  CONSTANT_VAR float const minz[nPairs] = {-20.,0.,-30., -22.,10.,-30., -70.,-70., -22.,15.,-30, -70.,-70., -20.,-22., 0,-30., -70.,-70.};
+  CONSTANT_VAR float const maxz[nPairs] = { 20.,30.,0.,   22.,30.,-10.,  70.,70.,   22.,30.,-15., 70., 70.,  20.,22., 30.,0.,  70.,70.};
+  CONSTANT_VAR float const maxr[nPairs] = {20.,9.,9., 20.,7.,7., 5.,5., 20.,6.,6., 5., 5., 20.,20.,9.,9., 9.,9.}; 
 
 // end constants
 // clang-format on

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -9,7 +9,9 @@ namespace gpuPixelDoublets {
 
   using namespace gpuPixelDoubletsAlgos;
 
-  constexpr int nPairs = 13+2;
+  constexpr int nPairs = 13+2+2;
+  static_assert(nPairs<=CAConstants::maxNumberOfLayerPairs());
+
   CONSTANT_VAR const uint8_t layerPairs[2 * nPairs] = {
       0,
       1,
@@ -38,7 +40,8 @@ namespace gpuPixelDoublets {
       5,
       5,
       6,  // pos
-      0,2, 1,3
+      0,2, 1,3,
+      4,6, 7,9
   };
 
   constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
@@ -58,13 +61,13 @@ namespace gpuPixelDoublets {
                                              phi0p06,
                                              phi0p05,
                                              phi0p05,
-                                             phi0p07, phi0p07};
+                                             phi0p07, phi0p07, phi0p06,phi0p06};
 
-  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.};
+  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.,-70., -70.};
 
-  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.,20.,22};
+  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.,20.,22,70., 70};
 
-  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5., 20.,20.};
+  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5., 20.,20.,9.,9.};
 
   constexpr uint32_t MaxNumOfDoublets = CAConstants::maxNumberOfDoublets();  // not really relevant
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -61,7 +61,7 @@ namespace gpuPixelDoublets {
                                              phi0p06,
                                              phi0p05,
                                              phi0p05,
-                                             phi0p07, phi0p07, phi0p06,phi0p06};
+                                             phi0p05, phi0p05, phi0p06,phi0p06};
 
   CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.,-70., -70.};
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -9,7 +9,7 @@ namespace gpuPixelDoublets {
 
   using namespace gpuPixelDoubletsAlgos;
 
-  constexpr int nPairs = 13;
+  constexpr int nPairs = 13+2;
   CONSTANT_VAR const uint8_t layerPairs[2 * nPairs] = {
       0,
       1,
@@ -38,6 +38,7 @@ namespace gpuPixelDoublets {
       5,
       5,
       6,  // pos
+      0,2, 1,3
   };
 
   constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
@@ -56,13 +57,14 @@ namespace gpuPixelDoublets {
                                              phi0p06,
                                              phi0p06,
                                              phi0p05,
-                                             phi0p05};
+                                             phi0p05,
+                                             phi0p07, phi0p07};
 
-  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.};
+  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.};
 
-  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.};
+  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.,20.,22};
 
-  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5.};
+  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5., 20.,20.};
 
   constexpr uint32_t MaxNumOfDoublets = CAConstants::maxNumberOfDoublets();  // not really relevant
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -62,6 +62,7 @@ namespace gpuPixelDoublets {
                                              phi0p05,
                                              phi0p05,
                                              phi0p05, phi0p05, phi0p06,phi0p06};
+//                                             phi0p07, phi0p07, phi0p06,phi0p06};
 
   CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.,-70., -70.};
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -12,63 +12,35 @@ namespace gpuPixelDoublets {
   constexpr int nPairs = 13+2+2;
   static_assert(nPairs<=CAConstants::maxNumberOfLayerPairs());
 
+// start constants
+// google: DO NOT TOUCH FORMATTING HERE! 
+
   CONSTANT_VAR const uint8_t layerPairs[2 * nPairs] = {
-      0,
-      1,
-      1,
-      2,
-      2,
-      3,
-      // 0, 4,  1, 4,  2, 4,  4, 5,  5, 6,
-      0,
-      7,
-      1,
-      7,
-      2,
-      7,
-      7,
-      8,
-      8,
-      9,  // neg
-      0,
-      4,
-      1,
-      4,
-      2,
-      4,
-      4,
-      5,
-      5,
-      6,  // pos
-      0,2, 1,3,
-      4,6, 7,9
+      0,1, 0,4, 0,7, // BPIX1 (3)
+      1,2, 1,4, 1,7, // BPIX2 (5)
+      4,5, 7,8,      // FPIX1 (8)
+      2,3, 2,4, 2,7, 5,6, 8,9,  // BPIX3 & FPIX2 (13)
+      0,2, 1,3,      // Jumping Barrel (15)
+      4,6, 7,9       // Jumping Forward (17)
   };
 
   constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
   constexpr int16_t phi0p06 = 626;  // round(625.82270...) = phi2short(0.06);
   constexpr int16_t phi0p07 = 730;  // round(730.12648...) = phi2short(0.07);
 
-  CONSTANT_VAR const int16_t phicuts[nPairs]{phi0p05,
-                                             phi0p05,
-                                             phi0p06,
-                                             phi0p07,
-                                             phi0p06,
-                                             phi0p06,
-                                             phi0p05,
-                                             phi0p05,
-                                             phi0p07,
-                                             phi0p06,
-                                             phi0p06,
-                                             phi0p05,
-                                             phi0p05,
-                                             phi0p05, phi0p05, phi0p06,phi0p06};
-//                                             phi0p07, phi0p07, phi0p06,phi0p06};
+  CONSTANT_VAR const int16_t phicuts[nPairs]{
+     phi0p05, phi0p07, phi0p07, 
+     phi0p05, phi0p06, phi0p06,
+     phi0p05, phi0p05,
+     phi0p06, phi0p06, phi0p06, phi0p05, phi0p05,
+     phi0p05, phi0p05, phi0p06,phi0p06};
+//   phi0p07, phi0p07, phi0p06,phi0p06};
 
-  CONSTANT_VAR float const minz[nPairs] = {-20., -22., -22., -30., -30., -30., -70., -70., 0., 10., 15., -70., -70.,-20.,-22.,-70., -70.};
+  CONSTANT_VAR float const minz[nPairs] = {-20.,0.,-30., -22.,10.,-30., -70.,-70., -22.,15.,-30, -70.,-70., -20.,-22.,-70.,-70.};
+  CONSTANT_VAR float const maxz[nPairs] = { 20.,30.,0.,   22.,30.,-10.,  70.,70.,   22.,30.,-15., 70., 70.,  20.,22.,  70.,70.};
+  CONSTANT_VAR float const maxr[nPairs] = {20.,9.,9., 20.,7.,7., 5.,5., 20.,6.,6., 5., 5., 20.,20.,9.,9.}; 
 
-  CONSTANT_VAR float const maxz[nPairs] = {20., 22., 22., 0., -10., -15., 70., 70., 30., 30., 30., 70., 70.,20.,22,70., 70};
-
-  CONSTANT_VAR float const maxr[nPairs] = {20., 20., 20., 9., 7., 6., 5., 5., 9., 7., 6., 5., 5., 20.,20.,9.,9.};
+// end constants
 
   constexpr uint32_t MaxNumOfDoublets = CAConstants::maxNumberOfDoublets();  // not really relevant
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -133,11 +133,12 @@ namespace gpuPixelDoubletsAlgos {
       constexpr float minRadius =
           hardPtCut * 87.78f;  // cm (1 GeV track has 1 GeV/c / (e * 3.8T) ~ 87 cm radius in a 3.8T field)
       constexpr float minRadius2T4 = 4.f * minRadius * minRadius;
-      auto ptcut = [&](int j) {
+      auto ptcut = [&](int j, int16_t mop) {
         auto r2t4 = minRadius2T4;
         auto ri = mer;
         auto ro = hh.rGlobal(j);
-        auto dphi = short2phi(min(abs(int16_t(mep - hh.iphi(j))), abs(int16_t(hh.iphi(j) - mep))));
+        // auto mop = hh.iphi(j);
+        auto dphi = short2phi(std::min(std::abs(int16_t(mep - mop)), std::abs(int16_t(mop - mep))));
         return dphi * dphi * (r2t4 - ri * ro) > (ro - ri) * (ro - ri);
       };
       auto z0cutoff = [&](int j) {
@@ -181,13 +182,13 @@ namespace gpuPixelDoubletsAlgos {
           auto oi = __ldg(p);
           assert(oi >= offsets[outer]);
           assert(oi < offsets[outer + 1]);
-
-          if (std::min(std::abs(int16_t(hh.iphi(oi) - mep)), std::abs(int16_t(mep - hh.iphi(oi)))) > iphicut)
+          auto mop = hh.iphi(oi);
+          if (std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop))) > iphicut)
             continue;
           if (doPhiCut) {
             if (doClusterCut && zsizeCut(oi))
               continue;
-            if (z0cutoff(oi) || ptcut(oi))
+            if (z0cutoff(oi) || ptcut(oi,mop))
               continue;
           }
           auto ind = atomicAdd(nCells, 1);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -62,7 +62,7 @@ namespace gpuPixelDoubletsAlgos {
     // nPairsMax to be optimized later (originally was 64).
     // If it should be much bigger, consider using a block-wide parallel prefix scan,
     // e.g. see  https://nvlabs.github.io/cub/classcub_1_1_warp_scan.html
-    const int nPairsMax = 16;
+    const int nPairsMax = CAConstants::maxNumberOfLayerPairs();
     assert(nPairs <= nPairsMax);
     __shared__ uint32_t innerLayerCumulativeSize[nPairsMax];
     __shared__ uint32_t ntot;

--- a/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/pixelTuplesHeterogeneousProduct.h
@@ -13,7 +13,7 @@ class TrackingRecHit2DSOAView;
 
 namespace pixelTuplesHeterogeneousProduct {
 
-  enum Quality : uint8_t { bad, dup, loose, strict, tight, highPurity };
+  enum Quality : uint8_t { bad=0, dup, loose, strict, tight, highPurity };
 
   using CPUProduct = int;  // dummy
 


### PR DESCRIPTION
To enable pixel triplets:
```
process.pixelTracksHitQuadruplets.minHitsPerNtuplet = 3
process.pixelTracksHitQuadruplets.includeJumpingForwardDoublets = True
```

The code should be cleaned up to avoid "magic numbers".

This PR is a rebase of the (updated) #362 on top of the current master.
See also the discussion and comments in #362 and #377.