### PR TITLE
Replace use of API wrapper stream and event with plain CUDA, part 1

### DIFF
--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -3,7 +3,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class BeamSpotCUDA {
 public:
@@ -21,7 +21,7 @@ public:
   };
 
   BeamSpotCUDA() = default;
-  BeamSpotCUDA(Data const* data_h, cuda::stream_t<>& stream);
+  BeamSpotCUDA(Data const* data_h, cudaStream_t stream);
 
   Data const* data() const { return data_d_.get(); }
 

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -2,7 +2,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
-BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cuda::stream_t<>& stream) {
+BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cudaStream_t stream) {
   data_d_ = cudautils::make_device_unique<Data>(stream);
-  cuda::memory::async::copy(data_d_.get(), data_h, sizeof(Data), stream.id());
+  cuda::memory::async::copy(data_d_.get(), data_h, sizeof(Data), stream);
 }

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -43,8 +43,12 @@ public:
   cudaStream_t stream() const { return stream_->id(); }
   cudaStream_t stream() { return stream_->id(); }
 
-  const cuda::event_t* event() const { return event_.get(); }
-  cuda::event_t* event() { return event_.get(); }
+  // cudaEvent_t is a pointer to a thread-safe object, for which a
+  // mutable access is needed even if the CUDAScopedContext itself
+  // would be const. Therefore it is ok to return a non-const
+  // pointer from a const method here.
+  cudaEvent_t event() const { return event_ ? event_->id() : nullptr; }
+  cudaEvent_t event() { return event_ ? event_->id() : nullptr; }
 
 protected:
   explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream)

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -36,8 +36,12 @@ public:
 
   int device() const { return device_; }
 
-  const cuda::stream_t<>& stream() const { return *stream_; }
-  cuda::stream_t<>& stream() { return *stream_; }
+  // cudaStream_t is a pointer to a thread-safe object, for which a
+  // mutable access is needed even if the CUDAScopedContext itself
+  // would be const. Therefore it is ok to return a non-const
+  // pointer from a const method here.
+  cudaStream_t stream() const { return stream_->id(); }
+  cudaStream_t stream() { return stream_->id(); }
 
   const cuda::event_t* event() const { return event_.get(); }
   cuda::event_t* event() { return event_.get(); }

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -41,14 +41,12 @@ public:
   // would be const. Therefore it is ok to return a non-const
   // pointer from a const method here.
   cudaStream_t stream() const { return stream_->id(); }
-  cudaStream_t stream() { return stream_->id(); }
 
   // cudaEvent_t is a pointer to a thread-safe object, for which a
   // mutable access is needed even if the CUDAScopedContext itself
   // would be const. Therefore it is ok to return a non-const
   // pointer from a const method here.
   cudaEvent_t event() const { return event_ ? event_->id() : nullptr; }
-  cudaEvent_t event() { return event_ ? event_->id() : nullptr; }
 
 protected:
   explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream)

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -35,10 +35,10 @@ public:
   auto *operator-> () { return get(); }
 
   // in reality valid only for GPU version...
-  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const {
+  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const {
     assert(dm_ptr);
     auto ret = cudautils::make_host_unique<T>(stream);
-    cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream));
     return ret;
   }
 
@@ -56,27 +56,27 @@ namespace cudaCompat {
     using unique_ptr = cudautils::device::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &stream) {
+    static auto make_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream) {
+    static auto make_host_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream) {
+    static auto make_device_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_device_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
   };
@@ -86,22 +86,22 @@ namespace cudaCompat {
     using unique_ptr = cudautils::host::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &stream) {
+    static auto make_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream) {
+    static auto make_host_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream) {
+    static auto make_device_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_device_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
   };
@@ -111,27 +111,27 @@ namespace cudaCompat {
     using unique_ptr = std::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &) {
+    static auto make_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &) {
+    static auto make_unique(size_t size, cudaStream_t) {
       return std::make_unique<T>(size);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &) {
+    static auto make_host_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &) {
+    static auto make_device_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &) {
+    static auto make_device_unique(size_t size, cudaStream_t) {
       return std::make_unique<T>(size);
     }
   };
@@ -151,28 +151,28 @@ public:
   HeterogeneousSoAImpl &operator=(HeterogeneousSoAImpl &&) = default;
 
   explicit HeterogeneousSoAImpl(unique_ptr<T> &&p) : m_ptr(std::move(p)) {}
-  explicit HeterogeneousSoAImpl(cuda::stream_t<> &stream);
+  explicit HeterogeneousSoAImpl(cudaStream_t stream);
 
   T const *get() const { return m_ptr.get(); }
 
   T *get() { return m_ptr.get(); }
 
-  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const;
+  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const;
 
 private:
   unique_ptr<T> m_ptr;  //!
 };
 
 template <typename T, typename Traits>
-HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
+HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cudaStream_t stream) {
   m_ptr = Traits::template make_unique<T>(stream);
 }
 
 // in reality valid only for GPU version...
 template <typename T, typename Traits>
-cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cuda::stream_t<> &stream) const {
+cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<T>(stream);
-  cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+  cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream));
   return ret;
 }
 

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -1,4 +1,5 @@
 #include "CUDADataFormats/Common/interface/CUDAProductBase.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 
 bool CUDAProductBase::isAvailable() const {
   // In absence of event, the product was available already at the end
@@ -6,5 +7,5 @@ bool CUDAProductBase::isAvailable() const {
   if (not event_) {
     return true;
   }
-  return event_->has_occurred();
+  return cudautils::eventIsOccurred(event_->id());
 }

--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -43,7 +43,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
     SECTION("Construct from CUDAScopedContext") {
       REQUIRE(data.isValid());
       REQUIRE(data.device() == defaultDevice);
-      REQUIRE(data.stream().id() == ctx.stream().id());
+      REQUIRE(data.stream() == ctx.stream());
       REQUIRE(data.event() != nullptr);
     }
 

--- a/CUDADataFormats/SiPixelCluster/BuildFile.xml
+++ b/CUDADataFormats/SiPixelCluster/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="CUDADataFormats/Common"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <use name="rootcore"/>
 
 <export>

--- a/CUDADataFormats/SiPixelCluster/interface/SiPixelClustersCUDA.h
+++ b/CUDADataFormats/SiPixelCluster/interface/SiPixelClustersCUDA.h
@@ -3,15 +3,14 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
-
-#include <cuda/api_wrappers.h>
-
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
+
+#include <cuda_runtime.h>
 
 class SiPixelClustersCUDA {
 public:
   SiPixelClustersCUDA() = default;
-  explicit SiPixelClustersCUDA(size_t maxClusters, cuda::stream_t<> &stream);
+  explicit SiPixelClustersCUDA(size_t maxClusters, cudaStream_t stream);
   ~SiPixelClustersCUDA() = default;
 
   SiPixelClustersCUDA(const SiPixelClustersCUDA &) = delete;

--- a/CUDADataFormats/SiPixelCluster/src/SiPixelClustersCUDA.cc
+++ b/CUDADataFormats/SiPixelCluster/src/SiPixelClustersCUDA.cc
@@ -4,7 +4,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 
-SiPixelClustersCUDA::SiPixelClustersCUDA(size_t maxClusters, cuda::stream_t<>& stream) {
+SiPixelClustersCUDA::SiPixelClustersCUDA(size_t maxClusters, cudaStream_t stream) {
   moduleStart_d = cudautils::make_device_unique<uint32_t[]>(maxClusters + 1, stream);
   clusInModule_d = cudautils::make_device_unique<uint32_t[]>(maxClusters, stream);
   moduleId_d = cudautils::make_device_unique<uint32_t[]>(maxClusters, stream);

--- a/CUDADataFormats/SiPixelDigi/BuildFile.xml
+++ b/CUDADataFormats/SiPixelDigi/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiPixelRawData"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <use name="rootcore"/>
 
 <export>

--- a/CUDADataFormats/SiPixelDigi/interface/SiPixelDigiErrorsCUDA.h
+++ b/CUDADataFormats/SiPixelDigi/interface/SiPixelDigiErrorsCUDA.h
@@ -6,12 +6,12 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class SiPixelDigiErrorsCUDA {
 public:
   SiPixelDigiErrorsCUDA() = default;
-  explicit SiPixelDigiErrorsCUDA(size_t maxFedWords, PixelFormatterErrors errors, cuda::stream_t<>& stream);
+  explicit SiPixelDigiErrorsCUDA(size_t maxFedWords, PixelFormatterErrors errors, cudaStream_t stream);
   ~SiPixelDigiErrorsCUDA() = default;
 
   SiPixelDigiErrorsCUDA(const SiPixelDigiErrorsCUDA&) = delete;
@@ -27,9 +27,9 @@ public:
 
   using HostDataError =
       std::pair<GPU::SimpleVector<PixelErrorCompact>, cudautils::host::unique_ptr<PixelErrorCompact[]>>;
-  HostDataError dataErrorToHostAsync(cuda::stream_t<>& stream) const;
+  HostDataError dataErrorToHostAsync(cudaStream_t stream) const;
 
-  void copyErrorToHostAsync(cuda::stream_t<>& stream);
+  void copyErrorToHostAsync(cudaStream_t stream);
 
 private:
   cudautils::device::unique_ptr<PixelErrorCompact[]> data_d;

--- a/CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDA.h
+++ b/CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDA.h
@@ -3,14 +3,14 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
-
-#include <cuda/api_wrappers.h>
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
+
+#include <cuda_runtime.h>
 
 class SiPixelDigisCUDA {
 public:
   SiPixelDigisCUDA() = default;
-  explicit SiPixelDigisCUDA(size_t maxFedWords, cuda::stream_t<> &stream);
+  explicit SiPixelDigisCUDA(size_t maxFedWords, cudaStream_t stream);
   ~SiPixelDigisCUDA() = default;
 
   SiPixelDigisCUDA(const SiPixelDigisCUDA &) = delete;
@@ -50,10 +50,10 @@ public:
   uint32_t const *c_pdigi() const { return pdigi_d.get(); }
   uint32_t const *c_rawIdArr() const { return rawIdArr_d.get(); }
 
-  cudautils::host::unique_ptr<uint16_t[]> adcToHostAsync(cuda::stream_t<> &stream) const;
-  cudautils::host::unique_ptr<int32_t[]> clusToHostAsync(cuda::stream_t<> &stream) const;
-  cudautils::host::unique_ptr<uint32_t[]> pdigiToHostAsync(cuda::stream_t<> &stream) const;
-  cudautils::host::unique_ptr<uint32_t[]> rawIdArrToHostAsync(cuda::stream_t<> &stream) const;
+  cudautils::host::unique_ptr<uint16_t[]> adcToHostAsync(cudaStream_t stream) const;
+  cudautils::host::unique_ptr<int32_t[]> clusToHostAsync(cudaStream_t stream) const;
+  cudautils::host::unique_ptr<uint32_t[]> pdigiToHostAsync(cudaStream_t stream) const;
+  cudautils::host::unique_ptr<uint32_t[]> rawIdArrToHostAsync(cudaStream_t stream) const;
 
   class DeviceConstView {
   public:

--- a/CUDADataFormats/SiPixelDigi/src/SiPixelDigiErrorsCUDA.cc
+++ b/CUDADataFormats/SiPixelDigi/src/SiPixelDigiErrorsCUDA.cc
@@ -7,7 +7,7 @@
 
 #include <cassert>
 
-SiPixelDigiErrorsCUDA::SiPixelDigiErrorsCUDA(size_t maxFedWords, PixelFormatterErrors errors, cuda::stream_t<>& stream)
+SiPixelDigiErrorsCUDA::SiPixelDigiErrorsCUDA(size_t maxFedWords, PixelFormatterErrors errors, cudaStream_t stream)
     : formatterErrors_h(std::move(errors)) {
   error_d = cudautils::make_device_unique<GPU::SimpleVector<PixelErrorCompact>>(stream);
   data_d = cudautils::make_device_unique<PixelErrorCompact[]>(maxFedWords, stream);
@@ -22,11 +22,11 @@ SiPixelDigiErrorsCUDA::SiPixelDigiErrorsCUDA(size_t maxFedWords, PixelFormatterE
   cudautils::copyAsync(error_d, error_h, stream);
 }
 
-void SiPixelDigiErrorsCUDA::copyErrorToHostAsync(cuda::stream_t<>& stream) {
+void SiPixelDigiErrorsCUDA::copyErrorToHostAsync(cudaStream_t stream) {
   cudautils::copyAsync(error_h, error_d, stream);
 }
 
-SiPixelDigiErrorsCUDA::HostDataError SiPixelDigiErrorsCUDA::dataErrorToHostAsync(cuda::stream_t<>& stream) const {
+SiPixelDigiErrorsCUDA::HostDataError SiPixelDigiErrorsCUDA::dataErrorToHostAsync(cudaStream_t stream) const {
   // On one hand size() could be sufficient. On the other hand, if
   // someone copies the SimpleVector<>, (s)he might expect the data
   // buffer to actually have space for capacity() elements.

--- a/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
+++ b/CUDADataFormats/SiPixelDigi/src/SiPixelDigisCUDA.cc
@@ -4,7 +4,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 
-SiPixelDigisCUDA::SiPixelDigisCUDA(size_t maxFedWords, cuda::stream_t<>& stream) {
+SiPixelDigisCUDA::SiPixelDigisCUDA(size_t maxFedWords, cudaStream_t stream) {
   xx_d = cudautils::make_device_unique<uint16_t[]>(maxFedWords, stream);
   yy_d = cudautils::make_device_unique<uint16_t[]>(maxFedWords, stream);
   adc_d = cudautils::make_device_unique<uint16_t[]>(maxFedWords, stream);
@@ -25,25 +25,25 @@ SiPixelDigisCUDA::SiPixelDigisCUDA(size_t maxFedWords, cuda::stream_t<>& stream)
   cudautils::copyAsync(view_d, view, stream);
 }
 
-cudautils::host::unique_ptr<uint16_t[]> SiPixelDigisCUDA::adcToHostAsync(cuda::stream_t<>& stream) const {
+cudautils::host::unique_ptr<uint16_t[]> SiPixelDigisCUDA::adcToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<uint16_t[]>(nDigis(), stream);
   cudautils::copyAsync(ret, adc_d, nDigis(), stream);
   return ret;
 }
 
-cudautils::host::unique_ptr<int32_t[]> SiPixelDigisCUDA::clusToHostAsync(cuda::stream_t<>& stream) const {
+cudautils::host::unique_ptr<int32_t[]> SiPixelDigisCUDA::clusToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<int32_t[]>(nDigis(), stream);
   cudautils::copyAsync(ret, clus_d, nDigis(), stream);
   return ret;
 }
 
-cudautils::host::unique_ptr<uint32_t[]> SiPixelDigisCUDA::pdigiToHostAsync(cuda::stream_t<>& stream) const {
+cudautils::host::unique_ptr<uint32_t[]> SiPixelDigisCUDA::pdigiToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<uint32_t[]>(nDigis(), stream);
   cudautils::copyAsync(ret, pdigi_d, nDigis(), stream);
   return ret;
 }
 
-cudautils::host::unique_ptr<uint32_t[]> SiPixelDigisCUDA::rawIdArrToHostAsync(cuda::stream_t<>& stream) const {
+cudautils::host::unique_ptr<uint32_t[]> SiPixelDigisCUDA::rawIdArrToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<uint32_t[]>(nDigis(), stream);
   cudautils::copyAsync(ret, rawIdArr_d, nDigis(), stream);
   return ret;

--- a/CUDADataFormats/Track/BuildFile.xml
+++ b/CUDADataFormats/Track/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <use name="rootcore"/>
 <use name="DataFormats/Common"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>

--- a/CUDADataFormats/TrackingRecHit/BuildFile.xml
+++ b/CUDADataFormats/TrackingRecHit/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <use name="rootcore"/>
 <use name="CUDADataFormats/Common"/>
 <use name="DataFormats/Common"/>

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
@@ -17,7 +17,7 @@ public:
   explicit TrackingRecHit2DHeterogeneous(uint32_t nHits,
                                          pixelCPEforGPU::ParamsOnGPU const* cpeParams,
                                          uint32_t const* hitsModuleStart,
-                                         cuda::stream_t<>& stream);
+                                         cudaStream_t stream);
 
   ~TrackingRecHit2DHeterogeneous() = default;
 
@@ -37,9 +37,9 @@ public:
   auto iphi() { return m_iphi; }
 
   // only the local coord and detector index
-  cudautils::host::unique_ptr<float[]> localCoordToHostAsync(cuda::stream_t<>& stream) const;
-  cudautils::host::unique_ptr<uint16_t[]> detIndexToHostAsync(cuda::stream_t<>& stream) const;
-  cudautils::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cuda::stream_t<>& stream) const;
+  cudautils::host::unique_ptr<float[]> localCoordToHostAsync(cudaStream_t stream) const;
+  cudautils::host::unique_ptr<uint16_t[]> detIndexToHostAsync(cudaStream_t stream) const;
+  cudautils::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
 
 private:
   static constexpr uint32_t n16 = 4;
@@ -71,7 +71,7 @@ template <typename Traits>
 TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nHits,
                                                                      pixelCPEforGPU::ParamsOnGPU const* cpeParams,
                                                                      uint32_t const* hitsModuleStart,
-                                                                     cuda::stream_t<>& stream)
+                                                                     cudaStream_t stream)
     : m_nHits(nHits), m_hitsModuleStart(hitsModuleStart) {
   auto view = Traits::template make_host_unique<TrackingRecHit2DSOAView>(stream);
 

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
@@ -5,16 +5,15 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 
 template <>
-cudautils::host::unique_ptr<float[]> TrackingRecHit2DCUDA::localCoordToHostAsync(cuda::stream_t<> &stream) const {
+cudautils::host::unique_ptr<float[]> TrackingRecHit2DCUDA::localCoordToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<float[]>(4 * nHits(), stream);
   cudautils::copyAsync(ret, m_store32, 4 * nHits(), stream);
   return ret;
 }
 
 template <>
-cudautils::host::unique_ptr<uint32_t[]> TrackingRecHit2DCUDA::hitsModuleStartToHostAsync(
-    cuda::stream_t<> &stream) const {
+cudautils::host::unique_ptr<uint32_t[]> TrackingRecHit2DCUDA::hitsModuleStartToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<uint32_t[]>(2001, stream);
-  cudaMemcpyAsync(ret.get(), m_hitsModuleStart, 4 * 2001, cudaMemcpyDefault, stream.id());
+  cudaMemcpyAsync(ret.get(), m_hitsModuleStart, 4 * 2001, cudaMemcpyDefault);
   return ret;
 }

--- a/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
+++ b/CUDADataFormats/TrackingRecHit/src/TrackingRecHit2DCUDA.cc
@@ -14,6 +14,6 @@ cudautils::host::unique_ptr<float[]> TrackingRecHit2DCUDA::localCoordToHostAsync
 template <>
 cudautils::host::unique_ptr<uint32_t[]> TrackingRecHit2DCUDA::hitsModuleStartToHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<uint32_t[]>(2001, stream);
-  cudaMemcpyAsync(ret.get(), m_hitsModuleStart, 4 * 2001, cudaMemcpyDefault);
+  cudaMemcpyAsync(ret.get(), m_hitsModuleStart, 4 * 2001, cudaMemcpyDefault, stream);
   return ret;
 }

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -15,7 +15,7 @@ int main() {
   cudaStream_t stream;
   cudaCheck(cudaStreamCreate(&stream));
 
-  // innert scope to deallocate memory before destroyn the stream
+  // inner scope to deallocate memory before destroying the stream
   {
     auto nHits = 200;
     TrackingRecHit2DCUDA tkhit(nHits, nullptr, nullptr, stream);

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -1,6 +1,7 @@
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 namespace testTrackingRecHit2D {
 
@@ -11,13 +12,18 @@ namespace testTrackingRecHit2D {
 int main() {
   exitSansCUDADevices();
 
-  auto current_device = cuda::device::current::get();
-  auto stream = current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream);
+  cudaStream_t stream;
+  cudaCheck(cudaStreamCreate(&stream));
 
-  auto nHits = 200;
-  TrackingRecHit2DCUDA tkhit(nHits, nullptr, nullptr, stream);
+  // innert scope to deallocate memory before destroyn the stream
+  {
+    auto nHits = 200;
+    TrackingRecHit2DCUDA tkhit(nHits, nullptr, nullptr, stream);
 
-  testTrackingRecHit2D::runKernels(tkhit.view());
+    testTrackingRecHit2D::runKernels(tkhit.view());
+  }
+
+  cudaCheck(cudaStreamDestroy(stream));
 
   return 0;
 }

--- a/CUDADataFormats/Vertex/BuildFile.xml
+++ b/CUDADataFormats/Vertex/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <use name="rootcore"/>
 <use name="DataFormats/Common"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>

--- a/CalibTracker/SiPixelESProducers/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="MagneticField/VolumeBasedEngine"/>
 <use   name="HeterogeneousCore/CUDACore"/>
 <use   name="boost"/>
-<use   name="cuda-api-wrappers"/>
+<use   name="cuda"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTGPU.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTGPU.h
@@ -16,7 +16,7 @@ public:
   explicit SiPixelGainCalibrationForHLTGPU(const SiPixelGainCalibrationForHLT &gains, const TrackerGeometry &geom);
   ~SiPixelGainCalibrationForHLTGPU();
 
-  const SiPixelGainForHLTonGPU *getGPUProductAsync(cuda::stream_t<> &cudaStream) const;
+  const SiPixelGainForHLTonGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
   const SiPixelGainForHLTonGPU *getCPUProduct() const { return gainForHLTonHost_; }
   const SiPixelGainCalibrationForHLT *getOriginalProduct() { return gains_; }
 

--- a/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="CalibTracker/SiPixelESProducers"/>
 <use   name="HeterogeneousCore/CUDACore"/>
-<use   name="cuda-api-wrappers"/>
+<use   name="cuda"/>
 <library   file="*.cc" name="CalibTrackerSiPixelESProducersPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/SiPixelRawToDigi/plugins/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="CUDADataFormats/SiPixelDigi"/>
 <use name="EventFilter/SiPixelRawToDigi"/>
 <use name="HeterogeneousCore/CUDACore"/>
-<use name="cuda-api-wrappers"/>
+<use name="cuda"/>
 <library file="*.cc" name="EventFilterSiPixelRawToDigiPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
@@ -23,11 +23,11 @@ public:
   }
   ~CUDAESProduct() = default;
 
-  // transferAsync should be a function of (T&, cuda::stream_t<>&)
+  // transferAsync should be a function of (T&, cudaStream_t)
   // which enqueues asynchronous transfers (possibly kernels as well)
   // to the CUDA stream
   template <typename F>
-  const T& dataForCurrentDeviceAsync(cuda::stream_t<>& cudaStream, F transferAsync) const {
+  const T& dataForCurrentDeviceAsync(cudaStream_t cudaStream, F transferAsync) const {
     auto device = cuda::device::current::get().id();
 
     auto& data = gpuDataPerDevice_[device];
@@ -54,12 +54,12 @@ public:
           auto should_be_false = data.m_filled.exchange(true);
           assert(!should_be_false);
           data.m_fillingStream = nullptr;
-        } else if (data.m_fillingStream != cudaStream.id()) {
+        } else if (data.m_fillingStream != cudaStream) {
           // Filling is still going on. For other CUDA stream, add
           // wait on the CUDA stream and return the value. Subsequent
           // work queued on the stream will wait for the event to
           // occur (i.e. transfer to finish).
-          auto ret = cudaStreamWaitEvent(cudaStream.id(), data.m_event->id(), 0);
+          auto ret = cudaStreamWaitEvent(cudaStream, data.m_event->id(), 0);
           cuda::throw_if_error(ret, "Failed to make a stream to wait for an event");
         }
         // else: filling is still going on. But for the same CUDA
@@ -72,7 +72,7 @@ public:
         // this thread is the first to try that.
         transferAsync(data.m_data, cudaStream);
         assert(data.m_fillingStream == nullptr);
-        data.m_fillingStream = cudaStream.id();
+        data.m_fillingStream = cudaStream;
         // Now the filling has been enqueued to the cudaStream, so we
         // can return the GPU data immediately, since all subsequent
         // work must be either enqueued to the cudaStream, or the cudaStream

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -23,8 +23,12 @@ namespace impl {
   public:
     int device() const { return currentDevice_; }
 
-    cuda::stream_t<>& stream() { return *stream_; }
-    const cuda::stream_t<>& stream() const { return *stream_; }
+    // cudaStream_t is a pointer to a thread-safe object, for which a
+    // mutable access is needed even if the CUDAScopedContext itself
+    // would be const. Therefore it is ok to return a non-const
+    // pointer from a const method here.
+    cudaStream_t stream() { return stream_->id(); }
+    cudaStream_t stream() const { return stream_->id(); }
     const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
 
   protected:
@@ -59,10 +63,7 @@ namespace impl {
     template <typename... Args>
     CUDAScopedContextGetterBase(Args&&... args) : CUDAScopedContextBase(std::forward<Args>(args)...) {}
 
-    void synchronizeStreams(int dataDevice,
-                            const cuda::stream_t<>& dataStream,
-                            bool available,
-                            const cuda::event_t* dataEvent);
+    void synchronizeStreams(int dataDevice, cudaStream_t dataStream, bool available, const cuda::event_t* dataEvent);
   };
 
   class CUDAScopedContextHolderHelper {
@@ -77,7 +78,7 @@ namespace impl {
       waitingTaskHolder_ = std::move(waitingTaskHolder);
     }
 
-    void enqueueCallback(int device, cuda::stream_t<>& stream);
+    void enqueueCallback(int device, cudaStream_t stream);
 
   private:
     edm::WaitingTaskWithArenaHolder waitingTaskHolder_;

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -63,7 +63,7 @@ namespace impl {
     template <typename... Args>
     CUDAScopedContextGetterBase(Args&&... args) : CUDAScopedContextBase(std::forward<Args>(args)...) {}
 
-    void synchronizeStreams(int dataDevice, cudaStream_t dataStream, bool available, const cuda::event_t* dataEvent);
+    void synchronizeStreams(int dataDevice, cudaStream_t dataStream, bool available, cudaEvent_t dataEvent);
   };
 
   class CUDAScopedContextHolderHelper {

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -27,7 +27,6 @@ namespace impl {
     // mutable access is needed even if the CUDAScopedContext itself
     // would be const. Therefore it is ok to return a non-const
     // pointer from a const method here.
-    cudaStream_t stream() { return stream_->id(); }
     cudaStream_t stream() const { return stream_->id(); }
     const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
 

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -60,7 +60,7 @@ namespace impl {
   void CUDAScopedContextGetterBase::synchronizeStreams(int dataDevice,
                                                        cudaStream_t dataStream,
                                                        bool available,
-                                                       const cuda::event_t* dataEvent) {
+                                                       cudaEvent_t dataEvent) {
     if (dataDevice != device()) {
       // Eventually replace with prefetch to current device (assuming unified memory works)
       // If we won't go to unified memory, need to figure out something else...
@@ -75,7 +75,7 @@ namespace impl {
         // wait for an event, so all subsequent work in the stream
         // will run only after the event has "occurred" (i.e. data
         // product became available).
-        auto ret = cudaStreamWaitEvent(stream(), dataEvent->id(), 0);
+        auto ret = cudaStreamWaitEvent(stream(), dataEvent, 0);
         cuda::throw_if_error(ret, "Failed to make a stream to wait for an event");
       }
     }

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -5,8 +5,37 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 #include "chooseCUDADevice.h"
+
+namespace {
+  struct CallbackData {
+    edm::WaitingTaskWithArenaHolder holder;
+    int device;
+  };
+
+  void CUDART_CB cudaScopedContextCallback(cudaStream_t streamId, cudaError_t status, void* data) {
+    std::unique_ptr<CallbackData> guard{reinterpret_cast<CallbackData*>(data)};
+    edm::WaitingTaskWithArenaHolder& waitingTaskHolder = guard->holder;
+    int device = guard->device;
+    if (status == cudaSuccess) {
+      LogTrace("CUDAScopedContext") << " GPU kernel finished (in callback) device " << device << " CUDA stream "
+                                    << streamId;
+      waitingTaskHolder.doneWaiting(nullptr);
+    } else {
+      // wrap the exception in a try-catch block to let GDB "catch throw" break on it
+      try {
+        auto error = cudaGetErrorName(status);
+        auto message = cudaGetErrorString(status);
+        throw cms::Exception("CUDAError") << "Callback of CUDA stream " << streamId << " in device " << device
+                                          << " error " << error << ": " << message;
+      } catch (cms::Exception&) {
+        waitingTaskHolder.doneWaiting(std::current_exception());
+      }
+    }
+  }
+}  // namespace
 
 namespace impl {
   CUDAScopedContextBase::CUDAScopedContextBase(edm::StreamID streamID)
@@ -29,7 +58,7 @@ namespace impl {
   ////////////////////
 
   void CUDAScopedContextGetterBase::synchronizeStreams(int dataDevice,
-                                                       const cuda::stream_t<>& dataStream,
+                                                       cudaStream_t dataStream,
                                                        bool available,
                                                        const cuda::event_t* dataEvent) {
     if (dataDevice != device()) {
@@ -38,7 +67,7 @@ namespace impl {
       throw cms::Exception("LogicError") << "Handling data from multiple devices is not yet supported";
     }
 
-    if (dataStream.id() != stream().id()) {
+    if (dataStream != stream()) {
       // Different streams, need to synchronize
       if (not available) {
         // Event not yet occurred, so need to add synchronization
@@ -46,31 +75,15 @@ namespace impl {
         // wait for an event, so all subsequent work in the stream
         // will run only after the event has "occurred" (i.e. data
         // product became available).
-        auto ret = cudaStreamWaitEvent(stream().id(), dataEvent->id(), 0);
+        auto ret = cudaStreamWaitEvent(stream(), dataEvent->id(), 0);
         cuda::throw_if_error(ret, "Failed to make a stream to wait for an event");
       }
     }
   }
 
-  void CUDAScopedContextHolderHelper::enqueueCallback(int device, cuda::stream_t<>& stream) {
-    stream.enqueue.callback(
-        [device, waitingTaskHolder = waitingTaskHolder_](cuda::stream::id_t streamId, cuda::status_t status) mutable {
-          if (cuda::is_success(status)) {
-            LogTrace("CUDAScopedContext")
-                << " GPU kernel finished (in callback) device " << device << " CUDA stream " << streamId;
-            waitingTaskHolder.doneWaiting(nullptr);
-          } else {
-            // wrap the exception in a try-catch block to let GDB "catch throw" break on it
-            try {
-              auto error = cudaGetErrorName(status);
-              auto message = cudaGetErrorString(status);
-              throw cms::Exception("CUDAError") << "Callback of CUDA stream " << streamId << " in device " << device
-                                                << " error " << error << ": " << message;
-            } catch (cms::Exception&) {
-              waitingTaskHolder.doneWaiting(std::current_exception());
-            }
-          }
-        });
+  void CUDAScopedContextHolderHelper::enqueueCallback(int device, cudaStream_t stream) {
+    cudaCheck(
+        cudaStreamAddCallback(stream, cudaScopedContextCallback, new CallbackData{waitingTaskHolder_, device}, 0));
   }
 }  // namespace impl
 
@@ -93,14 +106,24 @@ void CUDAScopedContextAcquire::throwNoState() {
 
 CUDAScopedContextProduce::~CUDAScopedContextProduce() {
   if (event_) {
-    event_->record(stream().id());
+    event_->record(stream());
   }
 }
 
 void CUDAScopedContextProduce::createEventIfStreamBusy() {
-  if (event_ or stream().is_clear()) {
+  if (event_) {
     return;
   }
+  auto ret = cudaStreamQuery(stream());
+  if (ret == cudaSuccess) {
+    return;
+  }
+  if (ret != cudaErrorNotReady) {
+    // cudaErrorNotReady indicates that the stream is busy, and thus
+    // is not an error
+    cudaCheck(ret);
+  }
+
   event_ = cudautils::getCUDAEventCache().getCUDAEvent();
 }
 

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -31,7 +31,7 @@ namespace {
   std::unique_ptr<CUDAProduct<int*>> produce(int device, int* d, int* h) {
     auto ctx = cudatest::TestCUDAScopedContext::make(device, true);
 
-    cuda::memory::async::copy(d, h, sizeof(int), ctx.stream().id());
+    cuda::memory::async::copy(d, h, sizeof(int), ctx.stream());
     testCUDAScopedContextKernels_single(d, ctx.stream());
     return ctx.wrap(d);
   }
@@ -50,7 +50,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       std::unique_ptr<CUDAProduct<int>> dataPtr = ctx.wrap(10);
       REQUIRE(dataPtr.get() != nullptr);
       REQUIRE(dataPtr->device() == ctx.device());
-      REQUIRE(dataPtr->stream().id() == ctx.stream().id());
+      REQUIRE(dataPtr->stream() == ctx.stream());
     }
 
     SECTION("Construct from from CUDAProduct<T>") {
@@ -59,12 +59,12 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
 
       CUDAScopedContextProduce ctx2{data};
       REQUIRE(cuda::device::current::get().id() == data.device());
-      REQUIRE(ctx2.stream().id() == data.stream().id());
+      REQUIRE(ctx2.stream() == data.stream());
 
       // Second use of a product should lead to new stream
       CUDAScopedContextProduce ctx3{data};
       REQUIRE(cuda::device::current::get().id() == data.device());
-      REQUIRE(ctx3.stream().id() != data.stream().id());
+      REQUIRE(ctx3.stream() != data.stream());
     }
 
     SECTION("Storing state in CUDAContextState") {
@@ -80,7 +80,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       {  // produce
         CUDAScopedContextProduce ctx2{ctxstate};
         REQUIRE(cuda::device::current::get().id() == ctx.device());
-        REQUIRE(ctx2.stream().id() == ctx.stream().id());
+        REQUIRE(ctx2.stream() == ctx.stream());
       }
     }
 
@@ -98,7 +98,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       auto d_a2 = cuda::memory::device::make_unique<int>(current_device);
       auto wprod2 = produce(defaultDevice, d_a2.get(), &h_a2);
 
-      REQUIRE(wprod1->stream().id() != wprod2->stream().id());
+      REQUIRE(wprod1->stream() != wprod2->stream());
 
       // Mimick a third producer "joining" the two streams
       CUDAScopedContextProduce ctx2{*wprod1};
@@ -108,16 +108,16 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
 
       auto d_a3 = cuda::memory::device::make_unique<int>(current_device);
       testCUDAScopedContextKernels_join(prod1, prod2, d_a3.get(), ctx2.stream());
-      ctx2.stream().synchronize();
+      cudaCheck(cudaStreamSynchronize(ctx2.stream()));
       REQUIRE(wprod2->isAvailable());
       REQUIRE(wprod2->event()->has_occurred());
 
       h_a1 = 0;
       h_a2 = 0;
       int h_a3 = 0;
-      cuda::memory::async::copy(&h_a1, d_a1.get(), sizeof(int), ctx.stream().id());
-      cuda::memory::async::copy(&h_a2, d_a2.get(), sizeof(int), ctx.stream().id());
-      cuda::memory::async::copy(&h_a3, d_a3.get(), sizeof(int), ctx.stream().id());
+      cuda::memory::async::copy(&h_a1, d_a1.get(), sizeof(int), ctx.stream());
+      cuda::memory::async::copy(&h_a2, d_a2.get(), sizeof(int), ctx.stream());
+      cuda::memory::async::copy(&h_a3, d_a3.get(), sizeof(int), ctx.stream());
 
       REQUIRE(h_a1 == 2);
       REQUIRE(h_a2 == 4);

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
 
 #include "test_CUDAScopedContextKernels.h"
@@ -110,7 +111,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
       testCUDAScopedContextKernels_join(prod1, prod2, d_a3.get(), ctx2.stream());
       cudaCheck(cudaStreamSynchronize(ctx2.stream()));
       REQUIRE(wprod2->isAvailable());
-      REQUIRE(wprod2->event()->has_occurred());
+      REQUIRE(cudautils::eventIsOccurred(wprod2->event()));
 
       h_a1 = 0;
       h_a2 = 0;

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContextKernels.cu
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContextKernels.cu
@@ -1,16 +1,13 @@
 #include "test_CUDAScopedContextKernels.h"
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-
 namespace {
   __global__ void single_mul(int *d) { d[0] = d[0] * 2; }
 
   __global__ void join_add(const int *d1, const int *d2, int *d3) { d3[0] = d1[0] + d2[0]; }
 }  // namespace
 
-void testCUDAScopedContextKernels_single(int *d, cuda::stream_t<> &stream) { single_mul<<<1, 1, 0, stream.id()>>>(d); }
+void testCUDAScopedContextKernels_single(int *d, cudaStream_t stream) { single_mul<<<1, 1, 0, stream>>>(d); }
 
-void testCUDAScopedContextKernels_join(const int *d1, const int *d2, int *d3, cuda::stream_t<> &stream) {
-  join_add<<<1, 1, 0, stream.id()>>>(d1, d2, d3);
+void testCUDAScopedContextKernels_join(const int *d1, const int *d2, int *d3, cudaStream_t stream) {
+  join_add<<<1, 1, 0, stream>>>(d1, d2, d3);
 }

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContextKernels.h
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContextKernels.h
@@ -1,9 +1,9 @@
 #ifndef HeterogeneousCore_CUDACore_test_CUDAScopedContextKernels_h
 #define HeterogeneousCore_CUDACore_test_CUDAScopedContextKernels_h
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
-void testCUDAScopedContextKernels_single(int *d, cuda::stream_t<> &stream);
-void testCUDAScopedContextKernels_join(const int *d1, const int *d2, int *d3, cuda::stream_t<> &stream);
+void testCUDAScopedContextKernels_single(int *d, cudaStream_t stream);
+void testCUDAScopedContextKernels_join(const int *d1, const int *d2, int *d3, cudaStream_t stream);
 
 #endif

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
@@ -40,7 +40,7 @@ TestCUDAAnalyzerGPU::TestCUDAAnalyzerGPU(const edm::ParameterSet& iConfig)
   edm::Service<CUDAService> cs;
   if (cs->enabled()) {
     auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(*streamPtr);
+    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(streamPtr->id());
   }
 }
 
@@ -70,7 +70,7 @@ void TestCUDAAnalyzerGPU::endJob() {
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << " TestCUDAAnalyzerGPU::endJob begin";
 
   auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-  auto value = gpuAlgo_->value(*streamPtr);
+  auto value = gpuAlgo_->value(streamPtr->id());
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << "  accumulated value " << value;
   assert(minValue_ <= value && value <= maxValue_);
 

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPUKernel.h
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPUKernel.h
@@ -3,18 +3,18 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class TestCUDAAnalyzerGPUKernel {
 public:
   static constexpr int NUM_VALUES = 4000;
 
-  TestCUDAAnalyzerGPUKernel(cuda::stream_t<>& stream);
+  TestCUDAAnalyzerGPUKernel(cudaStream_t stream);
   ~TestCUDAAnalyzerGPUKernel() = default;
 
   // returns (owning) pointer to device memory
-  void analyzeAsync(const float* d_input, cuda::stream_t<>& stream) const;
-  float value(cuda::stream_t<>& stream) const;
+  void analyzeAsync(const float* d_input, cudaStream_t stream) const;
+  float value(cudaStream_t stream) const;
 
 private:
   mutable cudautils::device::unique_ptr<float[]> sum_;  // all writes are atomic in CUDA

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEW.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEW.cc
@@ -67,7 +67,7 @@ void TestCUDAProducerGPUEW::acquire(const edm::Event& iEvent,
   // Mimick the need to transfer some of the GPU data back to CPU to
   // be used for something within this module, or to be put in the
   // event.
-  cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream().id());
+  cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream());
 
   edm::LogVerbatim("TestCUDAProducerGPUEW") << label_ << " TestCUDAProducerGPUEW::acquire end event "
                                             << iEvent.id().event() << " stream " << iEvent.streamID();

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEWTask.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEWTask.cc
@@ -75,7 +75,7 @@ void TestCUDAProducerGPUEWTask::acquire(const edm::Event& iEvent,
   // Mimick the need to transfer some of the GPU data back to CPU to
   // be used for something within this module, or to be put in the
   // event.
-  cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream().id());
+  cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream());
 
   // Push a task to run addSimpleWork() after the asynchronous work
   // (and acquire()) has finished instead of produce()
@@ -94,7 +94,7 @@ void TestCUDAProducerGPUEWTask::addSimpleWork(edm::EventNumber_t eventID,
     edm::LogVerbatim("TestCUDAProducerGPUEWTask")
         << label_ << " TestCUDAProducerGPUEWTask::addSimpleWork begin event " << eventID << " stream " << streamID
         << " 10th element " << *hostData_ << " not satisfied, queueing more work";
-    cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream().id());
+    cuda::memory::async::copy(hostData_.get(), devicePtr_.get() + 10, sizeof(float), ctx.stream());
 
     ctx.pushNextTask([eventID, streamID, this](CUDAScopedContextTask ctx) { addSimpleWork(eventID, streamID, ctx); });
     gpuAlgo_.runSimpleAlgo(devicePtr_.get(), ctx.stream());

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.h
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.h
@@ -3,7 +3,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 /**
  * This class models the actual CUDA implementation of an algorithm.
@@ -22,14 +22,14 @@ public:
   ~TestCUDAProducerGPUKernel() = default;
 
   // returns (owning) pointer to device memory
-  cudautils::device::unique_ptr<float[]> runAlgo(const std::string& label, cuda::stream_t<>& stream) const {
+  cudautils::device::unique_ptr<float[]> runAlgo(const std::string& label, cudaStream_t stream) const {
     return runAlgo(label, nullptr, stream);
   }
   cudautils::device::unique_ptr<float[]> runAlgo(const std::string& label,
                                                  const float* d_input,
-                                                 cuda::stream_t<>& stream) const;
+                                                 cudaStream_t stream) const;
 
-  void runSimpleAlgo(float* d_data, cuda::stream_t<>& stream) const;
+  void runSimpleAlgo(float* d_data, cudaStream_t stream) const;
 };
 
 #endif

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUtoCPU.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUtoCPU.cc
@@ -59,7 +59,7 @@ void TestCUDAProducerGPUtoCPU::acquire(const edm::Event& iEvent,
   buffer_ = cudautils::make_host_unique<float[]>(TestCUDAProducerGPUKernel::NUM_VALUES, ctx.stream());
   // Enqueue async copy, continue in produce once finished
   cuda::memory::async::copy(
-      buffer_.get(), device.get(), TestCUDAProducerGPUKernel::NUM_VALUES * sizeof(float), ctx.stream().id());
+      buffer_.get(), device.get(), TestCUDAProducerGPUKernel::NUM_VALUES * sizeof(float), ctx.stream());
 
   edm::LogVerbatim("TestCUDAProducerGPUtoCPU") << label_ << " TestCUDAProducerGPUtoCPU::acquire end event "
                                                << iEvent.id().event() << " stream " << iEvent.streamID();

--- a/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
+++ b/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
@@ -6,6 +6,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDATest/interface/CUDAThing.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 #include <iostream>
 
@@ -73,11 +74,11 @@ process.moduleToTest(process.toTest)
     REQUIRE(data != nullptr);
 
     float firstElements[10];
-    cuda::memory::async::copy(firstElements, data, sizeof(float) * 10, prod->stream().id());
+    cuda::memory::async::copy(firstElements, data, sizeof(float) * 10, prod->stream());
 
     std::cout << "Synchronizing with CUDA stream" << std::endl;
     auto stream = prod->stream();
-    stream.synchronize();
+    cudaCheck(cudaStreamSynchronize(stream));
     std::cout << "Synchronized" << std::endl;
     REQUIRE(firstElements[0] == 0.f);
     REQUIRE(firstElements[1] == 1.f);

--- a/HeterogeneousCore/CUDAUtilities/interface/allocate_device.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/allocate_device.h
@@ -1,11 +1,11 @@
 #ifndef HeterogeneousCore_CUDAUtilities_allocate_device_h
 #define HeterogeneousCore_CUDAUtilities_allocate_device_h
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 namespace cudautils {
   // Allocate device memory
-  void *allocate_device(int dev, size_t nbytes, cuda::stream_t<> &stream);
+  void *allocate_device(int dev, size_t nbytes, cudaStream_t stream);
 
   // Free device memory (to be called from unique_ptr)
   void free_device(int device, void *ptr);

--- a/HeterogeneousCore/CUDAUtilities/interface/allocate_host.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/allocate_host.h
@@ -1,11 +1,11 @@
 #ifndef HeterogeneousCore_CUDAUtilities_allocate_host_h
 #define HeterogeneousCore_CUDAUtilities_allocate_host_h
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 namespace cudautils {
   // Allocate pinned host memory (to be called from unique_ptr)
-  void *allocate_host(size_t nbytes, cuda::stream_t<> &stream);
+  void *allocate_host(size_t nbytes, cudaStream_t stream);
 
   // Free pinned host memory (to be called from unique_ptr)
   void free_host(void *ptr);

--- a/HeterogeneousCore/CUDAUtilities/interface/copyAsync.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/copyAsync.h
@@ -13,19 +13,19 @@ namespace cudautils {
   template <typename T>
   inline void copyAsync(cudautils::device::unique_ptr<T>& dst,
                         const cudautils::host::unique_ptr<T>& src,
-                        cuda::stream_t<>& stream) {
+                        cudaStream_t stream) {
     // Shouldn't compile for array types because of sizeof(T), but
     // let's add an assert with a more helpful message
     static_assert(std::is_array<T>::value == false, "For array types, use the other overload with the size parameter");
-    cuda::memory::async::copy(dst.get(), src.get(), sizeof(T), stream.id());
+    cuda::memory::async::copy(dst.get(), src.get(), sizeof(T), stream);
   }
 
   template <typename T>
   inline void copyAsync(cudautils::host::unique_ptr<T>& dst,
                         const cudautils::device::unique_ptr<T>& src,
-                        cuda::stream_t<>& stream) {
+                        cudaStream_t stream) {
     static_assert(std::is_array<T>::value == false, "For array types, use the other overload with the size parameter");
-    cuda::memory::async::copy(dst.get(), src.get(), sizeof(T), stream.id());
+    cuda::memory::async::copy(dst.get(), src.get(), sizeof(T), stream);
   }
 
   // Multiple elements
@@ -33,16 +33,16 @@ namespace cudautils {
   inline void copyAsync(cudautils::device::unique_ptr<T[]>& dst,
                         const cudautils::host::unique_ptr<T[]>& src,
                         size_t nelements,
-                        cuda::stream_t<>& stream) {
-    cuda::memory::async::copy(dst.get(), src.get(), nelements * sizeof(T), stream.id());
+                        cudaStream_t stream) {
+    cuda::memory::async::copy(dst.get(), src.get(), nelements * sizeof(T), stream);
   }
 
   template <typename T>
   inline void copyAsync(cudautils::host::unique_ptr<T[]>& dst,
                         const cudautils::device::unique_ptr<T[]>& src,
                         size_t nelements,
-                        cuda::stream_t<>& stream) {
-    cuda::memory::async::copy(dst.get(), src.get(), nelements * sizeof(T), stream.id());
+                        cudaStream_t stream) {
+    cuda::memory::async::copy(dst.get(), src.get(), nelements * sizeof(T), stream);
   }
 }  // namespace cudautils
 

--- a/HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <functional>
 
+#include <cuda/api_wrappers.h>
+
 #include "FWCore/Utilities/interface/Likely.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/allocate_device.h"
 
@@ -47,7 +49,7 @@ namespace cudautils {
   }    // namespace device
 
   template <typename T>
-  typename device::impl::make_device_unique_selector<T>::non_array make_device_unique(cuda::stream_t<> &stream) {
+  typename device::impl::make_device_unique_selector<T>::non_array make_device_unique(cudaStream_t stream) {
     static_assert(std::is_trivially_constructible<T>::value,
                   "Allocating with non-trivial constructor on the device memory is not supported");
     int dev = cuda::device::current::get().id();
@@ -58,7 +60,7 @@ namespace cudautils {
 
   template <typename T>
   typename device::impl::make_device_unique_selector<T>::unbounded_array make_device_unique(size_t n,
-                                                                                            cuda::stream_t<> &stream) {
+                                                                                            cudaStream_t stream) {
     using element_type = typename std::remove_extent<T>::type;
     static_assert(std::is_trivially_constructible<element_type>::value,
                   "Allocating with non-trivial constructor on the device memory is not supported");
@@ -74,7 +76,7 @@ namespace cudautils {
   // No check for the trivial constructor, make it clear in the interface
   template <typename T>
   typename device::impl::make_device_unique_selector<T>::non_array make_device_unique_uninitialized(
-      cuda::stream_t<> &stream) {
+      cudaStream_t stream) {
     int dev = cuda::device::current::get().id();
     void *mem = cudautils::allocate_device(dev, sizeof(T), stream);
     return typename device::impl::make_device_unique_selector<T>::non_array{reinterpret_cast<T *>(mem),
@@ -83,7 +85,7 @@ namespace cudautils {
 
   template <typename T>
   typename device::impl::make_device_unique_selector<T>::unbounded_array make_device_unique_uninitialized(
-      size_t n, cuda::stream_t<> &stream) {
+      size_t n, cudaStream_t stream) {
     using element_type = typename std::remove_extent<T>::type;
     int dev = cuda::device::current::get().id();
     void *mem = cudautils::allocate_device(dev, n * sizeof(element_type), stream);

--- a/HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h
@@ -1,0 +1,22 @@
+#ifndef HeterogeneousCore_CUDAUtilities_eventIsOccurred_h
+#define HeterogeneousCore_CUDAUtilities_eventIsOccurred_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  inline bool eventIsOccurred(cudaEvent_t event) {
+    const auto ret = cudaEventQuery(event);
+    if (ret == cudaSuccess) {
+      return true;
+    } else if (ret == cudaErrorNotReady) {
+      return false;
+    }
+    // leave error case handling to cudaCheck
+    cudaCheck(ret);
+    return false;  // to keep compiler happy
+  }
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h
@@ -37,7 +37,7 @@ namespace cudautils {
 
   // Allocate pinned host memory
   template <typename T>
-  typename host::impl::make_host_unique_selector<T>::non_array make_host_unique(cuda::stream_t<> &stream) {
+  typename host::impl::make_host_unique_selector<T>::non_array make_host_unique(cudaStream_t stream) {
     static_assert(std::is_trivially_constructible<T>::value,
                   "Allocating with non-trivial constructor on the pinned host memory is not supported");
     void *mem = allocate_host(sizeof(T), stream);
@@ -45,8 +45,7 @@ namespace cudautils {
   }
 
   template <typename T>
-  typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique(size_t n,
-                                                                                      cuda::stream_t<> &stream) {
+  typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique(size_t n, cudaStream_t stream) {
     using element_type = typename std::remove_extent<T>::type;
     static_assert(std::is_trivially_constructible<element_type>::value,
                   "Allocating with non-trivial constructor on the pinned host memory is not supported");
@@ -59,14 +58,14 @@ namespace cudautils {
 
   // No check for the trivial constructor, make it clear in the interface
   template <typename T>
-  typename host::impl::make_host_unique_selector<T>::non_array make_host_unique_uninitialized(cuda::stream_t<> &stream) {
+  typename host::impl::make_host_unique_selector<T>::non_array make_host_unique_uninitialized(cudaStream_t stream) {
     void *mem = allocate_host(sizeof(T), stream);
     return typename host::impl::make_host_unique_selector<T>::non_array{reinterpret_cast<T *>(mem)};
   }
 
   template <typename T>
   typename host::impl::make_host_unique_selector<T>::unbounded_array make_host_unique_uninitialized(
-      size_t n, cuda::stream_t<> &stream) {
+      size_t n, cudaStream_t stream) {
     using element_type = typename std::remove_extent<T>::type;
     void *mem = allocate_host(n * sizeof(element_type), stream);
     return typename host::impl::make_host_unique_selector<T>::unbounded_array{reinterpret_cast<element_type *>(mem)};

--- a/HeterogeneousCore/CUDAUtilities/interface/memsetAsync.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/memsetAsync.h
@@ -9,11 +9,11 @@
 
 namespace cudautils {
   template <typename T>
-  inline void memsetAsync(cudautils::device::unique_ptr<T>& ptr, T value, cuda::stream_t<>& stream) {
+  inline void memsetAsync(cudautils::device::unique_ptr<T>& ptr, T value, cudaStream_t stream) {
     // Shouldn't compile for array types because of sizeof(T), but
     // let's add an assert with a more helpful message
     static_assert(std::is_array<T>::value == false, "For array types, use the other overload with the size parameter");
-    cuda::memory::device::async::set(ptr.get(), value, sizeof(T), stream.id());
+    cuda::memory::device::async::set(ptr.get(), value, sizeof(T), stream);
   }
 
   /**
@@ -23,11 +23,8 @@ namespace cudautils {
    * `sizeof(T) > 1` and `value != 0`.
    */
   template <typename T>
-  inline void memsetAsync(cudautils::device::unique_ptr<T[]>& ptr,
-                          int value,
-                          size_t nelements,
-                          cuda::stream_t<>& stream) {
-    cuda::memory::device::async::set(ptr.get(), value, nelements * sizeof(T), stream.id());
+  inline void memsetAsync(cudautils::device::unique_ptr<T[]>& ptr, int value, size_t nelements, cudaStream_t stream) {
+    cuda::memory::device::async::set(ptr.get(), value, nelements * sizeof(T), stream);
   }
 }  // namespace cudautils
 

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
@@ -4,6 +4,8 @@
 
 #include "getCachingDeviceAllocator.h"
 
+#include <cuda/api_wrappers.h>
+
 #include <limits>
 
 namespace {
@@ -12,15 +14,14 @@ namespace {
 }
 
 namespace cudautils {
-  void *allocate_device(int dev, size_t nbytes, cuda::stream_t<> &stream) {
+  void *allocate_device(int dev, size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
     if constexpr (cudautils::allocator::useCaching) {
       if (UNLIKELY(nbytes > maxAllocationSize)) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cuda::throw_if_error(
-          cudautils::allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream.id()));
+      cuda::throw_if_error(cudautils::allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
     } else {
       cuda::device::current::scoped_override_t<> setDeviceForThisScope(dev);
       cuda::throw_if_error(cudaMalloc(&ptr, nbytes));

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
@@ -4,6 +4,8 @@
 
 #include "getCachingHostAllocator.h"
 
+#include <cuda/api_wrappers.h>
+
 #include <limits>
 
 namespace {
@@ -12,14 +14,14 @@ namespace {
 }
 
 namespace cudautils {
-  void *allocate_host(size_t nbytes, cuda::stream_t<> &stream) {
+  void *allocate_host(size_t nbytes, cudaStream_t stream) {
     void *ptr = nullptr;
     if constexpr (cudautils::allocator::useCaching) {
       if (UNLIKELY(nbytes > maxAllocationSize)) {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cuda::throw_if_error(cudautils::allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream.id()));
+      cuda::throw_if_error(cudautils::allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream));
     } else {
       cuda::throw_if_error(cudaMallocHost(&ptr, nbytes));
     }

--- a/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
@@ -5,6 +5,8 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "CachingDeviceAllocator.h"
 
+#include <cuda/api_wrappers.h>
+
 #include <iomanip>
 
 namespace cudautils {

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -1,13 +1,14 @@
 #include "catch.hpp"
 
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
 
 TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   exitSansCUDADevices();
 
-  auto current_device = cuda::device::current::get();
-  auto stream = current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream);
+  cudaStream_t stream;
+  cudaCheck(cudaStreamCreate(&stream));
 
   SECTION("Single element") {
     auto ptr = cudautils::make_host_unique<int>(stream);
@@ -33,4 +34,6 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
     ptr.reset();
     REQUIRE_THROWS(ptr = cudautils::make_host_unique<char[]>(maxSize + 1, stream));
   }
+
+  cudaCheck(cudaStreamDestroy(stream));
 }

--- a/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
@@ -14,7 +14,6 @@
 <use   name="cuda"/>
 <use   name="CUDADataFormats/EcalRecHitSoA"/>
 <use   name="HeterogeneousCore/CUDAUtilities"/>
-<use   name="cuda-api-wrappers"/>
 <use   name="HeterogeneousCore/CUDACore"/>
 
 <export>

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalGainRatiosGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalGainRatiosGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalGainRatiosGPU {
 public:
@@ -26,7 +26,7 @@ public:
   ~EcalGainRatiosGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalGainRatiosGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPedestalsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPedestalsGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalPedestalsGPU {
 public:
@@ -27,7 +27,7 @@ public:
   ~EcalPedestalsGPU() = default;
 
   // get device pointers
-  Product const &getProduct(cuda::stream_t<> &) const;
+  Product const &getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalPedestalsGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseCovariancesGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseCovariancesGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalPulseCovariancesGPU {
 public:
@@ -25,7 +25,7 @@ public:
   ~EcalPulseCovariancesGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalPulseCovariancesGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseShapesGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseShapesGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalPulseShapesGPU {
 public:
@@ -25,7 +25,7 @@ public:
   ~EcalPulseShapesGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalPulseShapesGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSamplesCorrelationGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSamplesCorrelationGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalSamplesCorrelationGPU {
 public:
@@ -26,7 +26,7 @@ public:
   ~EcalSamplesCorrelationGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalSamplesCorrelationGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeBiasCorrectionsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeBiasCorrectionsGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalTimeBiasCorrectionsGPU {
 public:
@@ -28,7 +28,7 @@ public:
   ~EcalTimeBiasCorrectionsGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   //
   static std::string name() { return std::string{"ecalTimeBiasCorrectionsGPU"}; }

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeCalibConstantsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeCalibConstantsGPU.h
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAESProduct.h"
 #endif
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 class EcalTimeCalibConstantsGPU {
 public:
@@ -25,7 +25,7 @@ public:
   ~EcalTimeCalibConstantsGPU() = default;
 
   // get device pointers
-  Product const& getProduct(cuda::stream_t<>&) const;
+  Product const& getProduct(cudaStream_t) const;
 
   // TODO: do this centrally
   // get offset for hashes. equals number of barrel items

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo_gpu_new.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo_gpu_new.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#include <cuda.h>
+#include <cuda_runtime.h>
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/DeclsForKernels.h"
 
@@ -16,7 +16,7 @@ namespace ecal {
                     EventDataForScratchGPU&,
                     ConditionsProducts const&,
                     ConfigurationParameters const&,
-                    cuda::stream_t<>&);
+                    cudaStream_t);
 
   }
 }  // namespace ecal

--- a/RecoLocalCalo/EcalRecAlgos/src/AmplitudeComputationKernelsV1.cu
+++ b/RecoLocalCalo/EcalRecAlgos/src/AmplitudeComputationKernelsV1.cu
@@ -331,22 +331,22 @@ namespace ecal {
                                   EventDataForScratchGPU& scratch,
                                   ConditionsProducts const& conditions,
                                   ConfigurationParameters const& configParameters,
-                                  cuda::stream_t<>& cudaStream) {
+                                  cudaStream_t cudaStream) {
         unsigned int totalChannels = eventInputCPU.ebDigis.size() + eventInputCPU.eeDigis.size();
         //    unsigned int threads_min = conf.threads.x;
         // TODO: configure from python
         unsigned int threads_min = configParameters.kernelMinimizeThreads[0];
         unsigned int blocks_min = threads_min > totalChannels ? 1 : (totalChannels + threads_min - 1) / threads_min;
-        kernel_minimize<<<blocks_min, threads_min, 0, cudaStream.id()>>>(scratch.noisecov,
-                                                                         scratch.pulse_covariances,
-                                                                         scratch.activeBXs,
-                                                                         scratch.samples,
-                                                                         (SampleVector*)eventOutputGPU.amplitudesAll,
-                                                                         scratch.pulse_matrix,
-                                                                         eventOutputGPU.chi2,
-                                                                         scratch.acState,
-                                                                         totalChannels,
-                                                                         50);
+        kernel_minimize<<<blocks_min, threads_min, 0, cudaStream>>>(scratch.noisecov,
+                                                                    scratch.pulse_covariances,
+                                                                    scratch.activeBXs,
+                                                                    scratch.samples,
+                                                                    (SampleVector*)eventOutputGPU.amplitudesAll,
+                                                                    scratch.pulse_matrix,
+                                                                    eventOutputGPU.chi2,
+                                                                    scratch.acState,
+                                                                    totalChannels,
+                                                                    50);
         cudaCheck(cudaGetLastError());
 
         //
@@ -357,7 +357,7 @@ namespace ecal {
         unsigned int blocksPermute =
             threadsPermute > 10 * totalChannels ? 1 : (10 * totalChannels + threadsPermute - 1) / threadsPermute;
         int bytesPermute = threadsPermute * sizeof(SampleVector::Scalar);
-        kernel_permute_results<<<blocksPermute, threadsPermute, bytesPermute, cudaStream.id()>>>(
+        kernel_permute_results<<<blocksPermute, threadsPermute, bytesPermute, cudaStream>>>(
             (SampleVector*)eventOutputGPU.amplitudesAll,
             scratch.activeBXs,
             eventOutputGPU.amplitude,

--- a/RecoLocalCalo/EcalRecAlgos/src/AmplitudeComputationKernelsV1.h
+++ b/RecoLocalCalo/EcalRecAlgos/src/AmplitudeComputationKernelsV1.h
@@ -20,7 +20,7 @@ namespace ecal {
                                   EventDataForScratchGPU& scratch,
                                   ConditionsProducts const& conditions,
                                   ConfigurationParameters const& configParameters,
-                                  cuda::stream_t<>& cudaStream);
+                                  cudaStream_t cudaStream);
 
     }
 

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalGainRatiosGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalGainRatiosGPU.cc
@@ -27,9 +27,9 @@ EcalGainRatiosGPU::Product::~Product() {
   cudaCheck(cudaFree(gain6Over1));
 }
 
-EcalGainRatiosGPU::Product const& EcalGainRatiosGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalGainRatiosGPU::Product const& EcalGainRatiosGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalGainRatiosGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalGainRatiosGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(cudaMalloc((void**)&product.gain12Over6, this->gain12Over6_.size() * sizeof(float)));
         cudaCheck(cudaMalloc((void**)&product.gain6Over1, this->gain6Over1_.size() * sizeof(float)));
@@ -38,12 +38,12 @@ EcalGainRatiosGPU::Product const& EcalGainRatiosGPU::getProduct(cuda::stream_t<>
                                   this->gain12Over6_.data(),
                                   this->gain12Over6_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.gain6Over1,
                                   this->gain6Over1_.data(),
                                   this->gain6Over1_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalPedestalsGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalPedestalsGPU.cc
@@ -44,9 +44,9 @@ EcalPedestalsGPU::Product::~Product() {
   cudaCheck(cudaFree(rms_x1));
 }
 
-EcalPedestalsGPU::Product const& EcalPedestalsGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalPedestalsGPU::Product const& EcalPedestalsGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalPedestalsGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalPedestalsGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(cudaMalloc((void**)&product.mean_x12, this->mean_x12_.size() * sizeof(float)));
         cudaCheck(cudaMalloc((void**)&product.rms_x12, this->mean_x12_.size() * sizeof(float)));
@@ -60,32 +60,32 @@ EcalPedestalsGPU::Product const& EcalPedestalsGPU::getProduct(cuda::stream_t<>& 
                                   this->mean_x12_.data(),
                                   this->mean_x12_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.rms_x12,
                                   this->rms_x12_.data(),
                                   this->rms_x12_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.mean_x6,
                                   this->mean_x6_.data(),
                                   this->mean_x6_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.rms_x6,
                                   this->rms_x6_.data(),
                                   this->rms_x6_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.mean_x1,
                                   this->mean_x1_.data(),
                                   this->mean_x1_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.rms_x1,
                                   this->rms_x1_.data(),
                                   this->rms_x1_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalPulseCovariancesGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalPulseCovariancesGPU.cc
@@ -11,9 +11,9 @@ EcalPulseCovariancesGPU::Product::~Product() {
   cudaCheck(cudaFree(values));
 }
 
-EcalPulseCovariancesGPU::Product const& EcalPulseCovariancesGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalPulseCovariancesGPU::Product const& EcalPulseCovariancesGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalPulseCovariancesGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalPulseCovariancesGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(cudaMalloc((void**)&product.values,
                              (this->valuesEE_.size() + this->valuesEB_.size()) * sizeof(EcalPulseCovariance)));
@@ -26,14 +26,14 @@ EcalPulseCovariancesGPU::Product const& EcalPulseCovariancesGPU::getProduct(cuda
                                   this->valuesEB_.data(),
                                   this->valuesEB_.size() * sizeof(EcalPulseCovariance),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
 
         // transfer ee starting at values + offset
         cudaCheck(cudaMemcpyAsync(product.values + offset,
                                   this->valuesEE_.data(),
                                   this->valuesEE_.size() * sizeof(EcalPulseCovariance),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalPulseShapesGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalPulseShapesGPU.cc
@@ -11,9 +11,9 @@ EcalPulseShapesGPU::Product::~Product() {
   cudaCheck(cudaFree(values));
 }
 
-EcalPulseShapesGPU::Product const& EcalPulseShapesGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalPulseShapesGPU::Product const& EcalPulseShapesGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalPulseShapesGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalPulseShapesGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(cudaMalloc((void**)&product.values,
                              (this->valuesEE_.size() + this->valuesEB_.size()) * sizeof(EcalPulseShape)));
@@ -26,14 +26,14 @@ EcalPulseShapesGPU::Product const& EcalPulseShapesGPU::getProduct(cuda::stream_t
                                   this->valuesEB_.data(),
                                   this->valuesEB_.size() * sizeof(EcalPulseShape),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
 
         // transfer ee starting at values + offset
         cudaCheck(cudaMemcpyAsync(product.values + offset,
                                   this->valuesEE_.data(),
                                   this->valuesEE_.size() * sizeof(EcalPulseShape),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalSamplesCorrelationGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalSamplesCorrelationGPU.cc
@@ -21,9 +21,9 @@ EcalSamplesCorrelationGPU::Product::~Product() {
   cudaCheck(cudaFree(EEG1SamplesCorrelation));
 }
 
-EcalSamplesCorrelationGPU::Product const& EcalSamplesCorrelationGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalSamplesCorrelationGPU::Product const& EcalSamplesCorrelationGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalSamplesCorrelationGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalSamplesCorrelationGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(cudaMalloc((void**)&product.EBG12SamplesCorrelation,
                              this->EBG12SamplesCorrelation_.size() * sizeof(double)));
@@ -42,32 +42,32 @@ EcalSamplesCorrelationGPU::Product const& EcalSamplesCorrelationGPU::getProduct(
                                   this->EBG12SamplesCorrelation_.data(),
                                   this->EBG12SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EBG6SamplesCorrelation,
                                   this->EBG6SamplesCorrelation_.data(),
                                   this->EBG6SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EBG1SamplesCorrelation,
                                   this->EBG1SamplesCorrelation_.data(),
                                   this->EBG1SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EEG12SamplesCorrelation,
                                   this->EEG12SamplesCorrelation_.data(),
                                   this->EEG12SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EEG6SamplesCorrelation,
                                   this->EEG6SamplesCorrelation_.data(),
                                   this->EEG6SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EEG1SamplesCorrelation,
                                   this->EEG1SamplesCorrelation_.data(),
                                   this->EEG1SamplesCorrelation_.size() * sizeof(double),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalTimeBiasCorrectionsGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalTimeBiasCorrectionsGPU.cc
@@ -17,9 +17,9 @@ EcalTimeBiasCorrectionsGPU::Product::~Product() {
   cudaCheck(cudaFree(EETimeCorrShiftBins));
 }
 
-EcalTimeBiasCorrectionsGPU::Product const& EcalTimeBiasCorrectionsGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalTimeBiasCorrectionsGPU::Product const& EcalTimeBiasCorrectionsGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalTimeBiasCorrectionsGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalTimeBiasCorrectionsGPU::Product& product, cudaStream_t cudaStream) {
         // to get the size of vectors later on
         // should be removed and host conditions' objects used directly
         product.EBTimeCorrAmplitudeBinsSize = this->EBTimeCorrAmplitudeBins_.size();
@@ -37,22 +37,22 @@ EcalTimeBiasCorrectionsGPU::Product const& EcalTimeBiasCorrectionsGPU::getProduc
                                   this->EBTimeCorrAmplitudeBins_.data(),
                                   this->EBTimeCorrAmplitudeBins_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EBTimeCorrShiftBins,
                                   this->EBTimeCorrShiftBins_.data(),
                                   this->EBTimeCorrShiftBins_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EETimeCorrAmplitudeBins,
                                   this->EETimeCorrAmplitudeBins_.data(),
                                   this->EETimeCorrAmplitudeBins_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.EETimeCorrShiftBins,
                                   this->EETimeCorrShiftBins_.data(),
                                   this->EETimeCorrShiftBins_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalTimeCalibConstantsGPU.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalTimeCalibConstantsGPU.cc
@@ -11,9 +11,9 @@ EcalTimeCalibConstantsGPU::Product::~Product() {
   cudaCheck(cudaFree(values));
 }
 
-EcalTimeCalibConstantsGPU::Product const& EcalTimeCalibConstantsGPU::getProduct(cuda::stream_t<>& cudaStream) const {
+EcalTimeCalibConstantsGPU::Product const& EcalTimeCalibConstantsGPU::getProduct(cudaStream_t cudaStream) const {
   auto const& product = product_.dataForCurrentDeviceAsync(
-      cudaStream, [this](EcalTimeCalibConstantsGPU::Product& product, cuda::stream_t<>& cudaStream) {
+      cudaStream, [this](EcalTimeCalibConstantsGPU::Product& product, cudaStream_t cudaStream) {
         // malloc
         cudaCheck(
             cudaMalloc((void**)&product.values, (this->valuesEB_.size() + this->valuesEE_.size()) * sizeof(float)));
@@ -26,12 +26,12 @@ EcalTimeCalibConstantsGPU::Product const& EcalTimeCalibConstantsGPU::getProduct(
                                   this->valuesEB_.data(),
                                   this->valuesEB_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
         cudaCheck(cudaMemcpyAsync(product.values + offset,
                                   this->valuesEE_.data(),
                                   this->valuesEE_.size() * sizeof(float),
                                   cudaMemcpyHostToDevice,
-                                  cudaStream.id()));
+                                  cudaStream));
       });
 
   return product;

--- a/RecoLocalCalo/EcalRecProducers/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecProducers/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="CondFormats/EcalObjects"/>
 <use   name="HeterogeneousCore/CUDACore"/>
 <use   name="HeterogeneousCore/CUDAUtilities"/>
-<use   name="cuda-api-wrappers"/>
 <use   name="cuda"/>
 <export>
   <lib   name="1"/>

--- a/RecoLocalCalo/EcalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecProducers/plugins/BuildFile.xml
@@ -16,7 +16,6 @@
 <use   name="CUDADataFormats/EcalRecHitSoA"/>
 <use   name="HeterogeneousCore/CUDACore"/>
 <use   name="HeterogeneousCore/CUDAUtilities"/>
-<use   name="cuda-api-wrappers"/>
 <use   name="cuda"/>
 <library   file="*.cc" name="RecoLocalCaloEcalRecProducersPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -51,7 +51,7 @@ private:
   void acquire(edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) override;
   void produce(edm::Event&, edm::EventSetup const&) override;
 
-  void transferToHost(RecHitType& ebRecHits, RecHitType& eeRecHits, cuda::stream_t<>& cudaStream);
+  void transferToHost(RecHitType& ebRecHits, RecHitType& eeRecHits, cudaStream_t cudaStream);
 
 private:
   edm::EDGetTokenT<EBDigiCollection> digisTokenEB_;
@@ -372,7 +372,7 @@ void EcalUncalibRecHitProducerGPU::produce(edm::Event& event, edm::EventSetup co
 
     // TODO
     // for now just sync on the host when transferring back products
-    cudaStreamSynchronize(ctx.stream().id());
+    cudaStreamSynchronize(ctx.stream());
   }
 
   event.put(std::move(ebRecHits_), recHitsLabelEB_);
@@ -381,85 +381,85 @@ void EcalUncalibRecHitProducerGPU::produce(edm::Event& event, edm::EventSetup co
 
 void EcalUncalibRecHitProducerGPU::transferToHost(RecHitType& ebRecHits,
                                                   RecHitType& eeRecHits,
-                                                  cuda::stream_t<>& cudaStream) {
+                                                  cudaStream_t cudaStream) {
   cudaCheck(cudaMemcpyAsync(ebRecHits.amplitude.data(),
                             eventOutputDataGPU_.amplitude,
                             ebRecHits.amplitude.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
   cudaCheck(cudaMemcpyAsync(eeRecHits.amplitude.data(),
                             eventOutputDataGPU_.amplitude + ebRecHits.amplitude.size(),
                             eeRecHits.amplitude.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
 
   cudaCheck(cudaMemcpyAsync(ebRecHits.pedestal.data(),
                             eventOutputDataGPU_.pedestal,
                             ebRecHits.pedestal.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
   cudaCheck(cudaMemcpyAsync(eeRecHits.pedestal.data(),
                             eventOutputDataGPU_.pedestal + ebRecHits.pedestal.size(),
                             eeRecHits.pedestal.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
 
   cudaCheck(cudaMemcpyAsync(ebRecHits.chi2.data(),
                             eventOutputDataGPU_.chi2,
                             ebRecHits.chi2.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
   cudaCheck(cudaMemcpyAsync(eeRecHits.chi2.data(),
                             eventOutputDataGPU_.chi2 + ebRecHits.chi2.size(),
                             eeRecHits.chi2.size() * sizeof(ecal::reco::StorageScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
 
   if (configParameters_.shouldRunTimingComputation) {
     cudaCheck(cudaMemcpyAsync(ebRecHits.jitter.data(),
                               eventOutputDataGPU_.jitter,
                               ebRecHits.jitter.size() * sizeof(ecal::reco::StorageScalarType),
                               cudaMemcpyDeviceToHost,
-                              cudaStream.id()));
+                              cudaStream));
     cudaCheck(cudaMemcpyAsync(eeRecHits.jitter.data(),
                               eventOutputDataGPU_.jitter + ebRecHits.jitter.size(),
                               eeRecHits.jitter.size() * sizeof(ecal::reco::StorageScalarType),
                               cudaMemcpyDeviceToHost,
-                              cudaStream.id()));
+                              cudaStream));
 
     cudaCheck(cudaMemcpyAsync(ebRecHits.jitterError.data(),
                               eventOutputDataGPU_.jitterError,
                               ebRecHits.jitterError.size() * sizeof(ecal::reco::StorageScalarType),
                               cudaMemcpyDeviceToHost,
-                              cudaStream.id()));
+                              cudaStream));
     cudaCheck(cudaMemcpyAsync(eeRecHits.jitterError.data(),
                               eventOutputDataGPU_.jitterError + ebRecHits.jitterError.size(),
                               eeRecHits.jitterError.size() * sizeof(ecal::reco::StorageScalarType),
                               cudaMemcpyDeviceToHost,
-                              cudaStream.id()));
+                              cudaStream));
   }
 
   cudaCheck(cudaMemcpyAsync(ebRecHits.flags.data(),
                             eventOutputDataGPU_.flags,
                             ebRecHits.flags.size() * sizeof(uint32_t),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
   cudaCheck(cudaMemcpyAsync(eeRecHits.flags.data(),
                             eventOutputDataGPU_.flags + ebRecHits.flags.size(),
                             eeRecHits.flags.size() * sizeof(uint32_t),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
 
   cudaCheck(cudaMemcpyAsync(ebRecHits.amplitudesAll.data(),
                             eventOutputDataGPU_.amplitudesAll,
                             ebRecHits.amplitudesAll.size() * sizeof(ecal::reco::ComputationScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
   cudaCheck(cudaMemcpyAsync(eeRecHits.amplitudesAll.data(),
                             eventOutputDataGPU_.amplitudesAll + ebRecHits.amplitudesAll.size(),
                             eeRecHits.amplitudesAll.size() * sizeof(ecal::reco::ComputationScalarType),
                             cudaMemcpyDeviceToHost,
-                            cudaStream.id()));
+                            cudaStream));
 }
 
 DEFINE_FWK_MODULE(EcalUncalibRecHitProducerGPU);

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPUWrapper.h
@@ -6,7 +6,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "RecoLocalTracker/SiPixelClusterizer/interface/SiPixelFedCablingMapGPU.h"
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include <set>
 
@@ -25,12 +25,12 @@ public:
   bool hasQuality() const { return hasQuality_; }
 
   // returns pointer to GPU memory
-  const SiPixelFedCablingMapGPU *getGPUProductAsync(cuda::stream_t<> &cudaStream) const;
+  const SiPixelFedCablingMapGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
 
   // returns pointer to GPU memory
-  const unsigned char *getModToUnpAllAsync(cuda::stream_t<> &cudaStream) const;
+  const unsigned char *getModToUnpAllAsync(cudaStream_t cudaStream) const;
   cudautils::device::unique_ptr<unsigned char[]> getModToUnpRegionalAsync(std::set<unsigned int> const &modules,
-                                                                          cuda::stream_t<> &cudaStream) const;
+                                                                          cudaStream_t cudaStream) const;
 
 private:
   const SiPixelFedCablingMap *cablingMap_;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -179,7 +179,7 @@ namespace pixelgpudetails {
                            bool useQualityInfo,
                            bool includeErrors,
                            bool debug,
-                           cuda::stream_t<>& stream);
+                           cudaStream_t stream);
 
     std::pair<SiPixelDigisCUDA, SiPixelClustersCUDA> getResults() {
       digis_d.setNModulesDigis(nModules_Clusters_h[0], nDigis);

--- a/RecoLocalTracker/SiPixelClusterizer/src/SiPixelFedCablingMapGPUWrapper.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/src/SiPixelFedCablingMapGPUWrapper.cc
@@ -102,33 +102,33 @@ SiPixelFedCablingMapGPUWrapper::SiPixelFedCablingMapGPUWrapper(SiPixelFedCabling
 
 SiPixelFedCablingMapGPUWrapper::~SiPixelFedCablingMapGPUWrapper() { cudaCheck(cudaFreeHost(cablingMapHost)); }
 
-const SiPixelFedCablingMapGPU* SiPixelFedCablingMapGPUWrapper::getGPUProductAsync(cuda::stream_t<>& cudaStream) const {
-  const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cuda::stream_t<>& stream) {
+const SiPixelFedCablingMapGPU* SiPixelFedCablingMapGPUWrapper::getGPUProductAsync(cudaStream_t cudaStream) const {
+  const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cudaStream_t stream) {
     // allocate
     cudaCheck(cudaMalloc(&data.cablingMapDevice, sizeof(SiPixelFedCablingMapGPU)));
 
     // transfer
     cudaCheck(cudaMemcpyAsync(
-        data.cablingMapDevice, this->cablingMapHost, sizeof(SiPixelFedCablingMapGPU), cudaMemcpyDefault, stream.id()));
+        data.cablingMapDevice, this->cablingMapHost, sizeof(SiPixelFedCablingMapGPU), cudaMemcpyDefault, stream));
   });
   return data.cablingMapDevice;
 }
 
-const unsigned char* SiPixelFedCablingMapGPUWrapper::getModToUnpAllAsync(cuda::stream_t<>& cudaStream) const {
+const unsigned char* SiPixelFedCablingMapGPUWrapper::getModToUnpAllAsync(cudaStream_t cudaStream) const {
   const auto& data =
-      modToUnp_.dataForCurrentDeviceAsync(cudaStream, [this](ModulesToUnpack& data, cuda::stream_t<>& stream) {
+      modToUnp_.dataForCurrentDeviceAsync(cudaStream, [this](ModulesToUnpack& data, cudaStream_t stream) {
         cudaCheck(cudaMalloc((void**)&data.modToUnpDefault, pixelgpudetails::MAX_SIZE_BYTE_BOOL));
         cudaCheck(cudaMemcpyAsync(data.modToUnpDefault,
                                   this->modToUnpDefault.data(),
                                   this->modToUnpDefault.size() * sizeof(unsigned char),
                                   cudaMemcpyDefault,
-                                  stream.id()));
+                                  stream));
       });
   return data.modToUnpDefault;
 }
 
 cudautils::device::unique_ptr<unsigned char[]> SiPixelFedCablingMapGPUWrapper::getModToUnpRegionalAsync(
-    std::set<unsigned int> const& modules, cuda::stream_t<>& cudaStream) const {
+    std::set<unsigned int> const& modules, cudaStream_t cudaStream) const {
   auto modToUnpDevice = cudautils::make_device_unique<unsigned char[]>(pixelgpudetails::MAX_SIZE, cudaStream);
   auto modToUnpHost = cudautils::make_host_unique<unsigned char[]>(pixelgpudetails::MAX_SIZE, cudaStream);
 
@@ -157,7 +157,7 @@ cudautils::device::unique_ptr<unsigned char[]> SiPixelFedCablingMapGPUWrapper::g
   }
 
   cuda::memory::async::copy(
-      modToUnpDevice.get(), modToUnpHost.get(), pixelgpudetails::MAX_SIZE * sizeof(unsigned char), cudaStream.id());
+      modToUnpDevice.get(), modToUnpHost.get(), pixelgpudetails::MAX_SIZE * sizeof(unsigned char), cudaStream);
   return modToUnpDevice;
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
@@ -13,7 +13,6 @@
 <use   name="vdt_headers"/>
 
 <use   name="cuda"/>
-<use   name="cuda-api-wrappers"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 
 <export>

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h
@@ -47,7 +47,7 @@ public:
 
   // The return value can only be used safely in kernels launched on
   // the same cudaStream, or after cudaStreamSynchronize.
-  const pixelCPEforGPU::ParamsOnGPU *getGPUProductAsync(cuda::stream_t<> &cudaStream) const;
+  const pixelCPEforGPU::ParamsOnGPU *getGPUProductAsync(cudaStream_t cudaStream) const;
 
   pixelCPEforGPU::ParamsOnGPU const &getCPUProduct() const { return cpuData_; }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -9,6 +9,5 @@
 <use name="RecoLocalTracker/SiPixelRecHits"/>
 <library file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
   <use name="cuda"/>
-  <use name="cuda-api-wrappers"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "CUDADataFormats/SiPixelCluster/interface/SiPixelClustersCUDA.h"
@@ -26,7 +26,7 @@ namespace pixelgpudetails {
                                        SiPixelClustersCUDA const& clusters_d,
                                        BeamSpotCUDA const& bs_d,
                                        pixelCPEforGPU::ParamsOnGPU const* cpeParams,
-                                       cuda::stream_t<>& stream) const;
+                                       cudaStream_t stream) const;
   };
 }  // namespace pixelgpudetails
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
@@ -151,8 +151,7 @@ void SiPixelRecHitSoAFromLegacy::produce(edm::StreamID streamID, edm::Event& iEv
   assert(numberOfClusters == int(hitsModuleStart[2000]));
 
   // output SoA
-  auto dummyStream = cuda::stream::wrap(0, 0, false);
-  auto output = std::make_unique<TrackingRecHit2DCPU>(numberOfClusters, &cpeView, hitsModuleStart, dummyStream);
+  auto output = std::make_unique<TrackingRecHit2DCPU>(numberOfClusters, &cpeView, hitsModuleStart, nullptr);
 
   if (0 == numberOfClusters) {
     iEvent.put(std::move(output));

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -70,8 +70,8 @@ PixelCPEFast::PixelCPEFast(edm::ParameterSet const& conf,
   };
 }
 
-const pixelCPEforGPU::ParamsOnGPU* PixelCPEFast::getGPUProductAsync(cuda::stream_t<>& cudaStream) const {
-  const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cuda::stream_t<>& stream) {
+const pixelCPEforGPU::ParamsOnGPU* PixelCPEFast::getGPUProductAsync(cudaStream_t cudaStream) const {
+  const auto& data = gpuData_.dataForCurrentDeviceAsync(cudaStream, [this](GPUData& data, cudaStream_t stream) {
     // and now copy to device...
     cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_commonParams, sizeof(pixelCPEforGPU::CommonParams)));
     cudaCheck(cudaMalloc((void**)&data.h_paramsOnGPU.m_detParams,
@@ -81,27 +81,27 @@ const pixelCPEforGPU::ParamsOnGPU* PixelCPEFast::getGPUProductAsync(cuda::stream
     cudaCheck(cudaMalloc((void**)&data.d_paramsOnGPU, sizeof(pixelCPEforGPU::ParamsOnGPU)));
 
     cudaCheck(cudaMemcpyAsync(
-        data.d_paramsOnGPU, &data.h_paramsOnGPU, sizeof(pixelCPEforGPU::ParamsOnGPU), cudaMemcpyDefault, stream.id()));
+        data.d_paramsOnGPU, &data.h_paramsOnGPU, sizeof(pixelCPEforGPU::ParamsOnGPU), cudaMemcpyDefault, stream));
     cudaCheck(cudaMemcpyAsync((void*)data.h_paramsOnGPU.m_commonParams,
                               &this->m_commonParamsGPU,
                               sizeof(pixelCPEforGPU::CommonParams),
                               cudaMemcpyDefault,
-                              stream.id()));
+                              stream));
     cudaCheck(cudaMemcpyAsync((void*)data.h_paramsOnGPU.m_averageGeometry,
                               &this->m_averageGeometry,
                               sizeof(pixelCPEforGPU::AverageGeometry),
                               cudaMemcpyDefault,
-                              stream.id()));
+                              stream));
     cudaCheck(cudaMemcpyAsync((void*)data.h_paramsOnGPU.m_layerGeometry,
                               &this->m_layerGeometry,
                               sizeof(pixelCPEforGPU::LayerGeometry),
                               cudaMemcpyDefault,
-                              stream.id()));
+                              stream));
     cudaCheck(cudaMemcpyAsync((void*)data.h_paramsOnGPU.m_detParams,
                               this->m_detParamsGPU.data(),
                               this->m_detParamsGPU.size() * sizeof(pixelCPEforGPU::DetParams),
                               cudaMemcpyDefault,
-                              stream.id()));
+                              stream));
   });
   return data.d_paramsOnGPU;
 }

--- a/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
@@ -36,7 +36,6 @@
 <bin file="testEigenGPU.cu" name="testRiemannFitGPU_t">
   <use name="eigen"/>
   <use name="cuda"/>
-  <use name="cuda-api-wrappers"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <flags CXXFLAGS="-g"/>
 </bin>
@@ -44,7 +43,6 @@
 <bin file="testEigenGPU.cu" name="testBrokenLineFitGPU_t">
   <use name="eigen"/>
   <use name="cuda"/>
-  <use name="cuda-api-wrappers"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <flags CXXFLAGS="-g -DUSE_BL"/>
 </bin>
@@ -52,7 +50,6 @@
 <bin file="testEigenGPUNoFit.cu" name="testEigenGPUNoFit_t">
   <use name="eigen"/>
   <use name="cuda"/>
-  <use name="cuda-api-wrappers"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <flags CXXFLAGS="-g"/>
 </bin>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.cu
@@ -4,7 +4,7 @@
 void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
                                             uint32_t hitsInFit,
                                             uint32_t maxNumberOfTuples,
-                                            cuda::stream_t<> &stream) {
+                                            cudaStream_t stream) {
   assert(tuples_d);
 
   auto blockSize = 64;
@@ -20,64 +20,64 @@ void HelixFitOnGPU::launchBrokenLineKernels(HitsView const *hv,
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // fit triplets
-    kernelBLFastFit<3><<<numberOfBlocks, blockSize, 0, stream.id()>>>(
+    kernelBLFastFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(
         tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 3, offset);
     cudaCheck(cudaGetLastError());
 
-    kernelBLFit<3><<<numberOfBlocks, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                  bField_,
-                                                                  outputSoa_d,
-                                                                  hitsGPU_.get(),
-                                                                  hits_geGPU_.get(),
-                                                                  fast_fit_resultsGPU_.get(),
-                                                                  3,
-                                                                  offset);
+    kernelBLFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                             bField_,
+                                                             outputSoa_d,
+                                                             hitsGPU_.get(),
+                                                             hits_geGPU_.get(),
+                                                             fast_fit_resultsGPU_.get(),
+                                                             3,
+                                                             offset);
     cudaCheck(cudaGetLastError());
 
     // fit quads
-    kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+    kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
         tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 4, offset);
     cudaCheck(cudaGetLastError());
 
-    kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                      bField_,
-                                                                      outputSoa_d,
-                                                                      hitsGPU_.get(),
-                                                                      hits_geGPU_.get(),
-                                                                      fast_fit_resultsGPU_.get(),
-                                                                      4,
-                                                                      offset);
+    kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                 bField_,
+                                                                 outputSoa_d,
+                                                                 hitsGPU_.get(),
+                                                                 hits_geGPU_.get(),
+                                                                 fast_fit_resultsGPU_.get(),
+                                                                 4,
+                                                                 offset);
     cudaCheck(cudaGetLastError());
 
     if (fit5as4_) {
       // fit penta (only first 4)
-      kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+      kernelBLFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
           tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
       cudaCheck(cudaGetLastError());
 
-      kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                        bField_,
-                                                                        outputSoa_d,
-                                                                        hitsGPU_.get(),
-                                                                        hits_geGPU_.get(),
-                                                                        fast_fit_resultsGPU_.get(),
-                                                                        5,
-                                                                        offset);
+      kernelBLFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                   bField_,
+                                                                   outputSoa_d,
+                                                                   hitsGPU_.get(),
+                                                                   hits_geGPU_.get(),
+                                                                   fast_fit_resultsGPU_.get(),
+                                                                   5,
+                                                                   offset);
       cudaCheck(cudaGetLastError());
     } else {
       // fit penta (all 5)
-      kernelBLFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+      kernelBLFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
           tuples_d, tupleMultiplicity_d, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), 5, offset);
       cudaCheck(cudaGetLastError());
 
-      kernelBLFit<5><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                        bField_,
-                                                                        outputSoa_d,
-                                                                        hitsGPU_.get(),
-                                                                        hits_geGPU_.get(),
-                                                                        fast_fit_resultsGPU_.get(),
-                                                                        5,
-                                                                        offset);
+      kernelBLFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                   bField_,
+                                                                   outputSoa_d,
+                                                                   hitsGPU_.get(),
+                                                                   hits_geGPU_.get(),
+                                                                   fast_fit_resultsGPU_.get(),
+                                                                   5,
+                                                                   offset);
       cudaCheck(cudaGetLastError());
     }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="cuda"/>
-<use name="cuda-api-wrappers"/>
 <use name="ofast-flag"/>
 <use name="CommonTools/RecoAlgos"/>
 <use name="FWCore/Framework"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -11,7 +11,7 @@ void CAHitNtupletGeneratorKernelsCPU::fillHitDetIndices(HitsView const *hv, TkSo
 }
 
 template <>
-void CAHitNtupletGeneratorKernelsCPU::buildDoublets(HitsOnCPU const &hh, cuda::stream_t<> &stream) {
+void CAHitNtupletGeneratorKernelsCPU::buildDoublets(HitsOnCPU const &hh, cudaStream_t stream) {
   auto nhits = hh.nHits();
 
 #ifdef NTUPLE_DEBUG

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -147,7 +147,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 }
 
 template <>
-void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cuda::stream_t<> &stream) {
+void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStream_t stream) {
   auto nhits = hh.nHits();
 
 #ifdef NTUPLE_DEBUG
@@ -166,12 +166,12 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cuda::s
     int threadsPerBlock = 128;
     // at least one block!
     int blocks = (std::max(1U, nhits) + threadsPerBlock - 1) / threadsPerBlock;
-    gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0, stream.id()>>>(device_isOuterHitOfCell_.get(),
-                                                                                nhits,
-                                                                                device_theCellNeighbors_,
-                                                                                device_theCellNeighborsContainer_.get(),
-                                                                                device_theCellTracks_,
-                                                                                device_theCellTracksContainer_.get());
+    gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0, stream>>>(device_isOuterHitOfCell_.get(),
+                                                                           nhits,
+                                                                           device_theCellNeighbors_,
+                                                                           device_theCellNeighborsContainer_.get(),
+                                                                           device_theCellTracks_,
+                                                                           device_theCellTracksContainer_.get());
     cudaCheck(cudaGetLastError());
   }
 
@@ -199,18 +199,18 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cuda::s
   int blocks = (2 * nhits + threadsPerBlock - 1) / threadsPerBlock;
   dim3 blks(1, blocks, 1);
   dim3 thrs(stride, threadsPerBlock, 1);
-  gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0, stream.id()>>>(device_theCells_.get(),
-                                                                         device_nCells_,
-                                                                         device_theCellNeighbors_,
-                                                                         device_theCellTracks_,
-                                                                         hh.view(),
-                                                                         device_isOuterHitOfCell_.get(),
-                                                                         nActualPairs,
-                                                                         m_params.idealConditions_,
-                                                                         m_params.doClusterCut_,
-                                                                         m_params.doZCut_,
-                                                                         m_params.doPhiCut_,
-                                                                         m_params.maxNumberOfDoublets_);
+  gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0, stream>>>(device_theCells_.get(),
+                                                                    device_nCells_,
+                                                                    device_theCellNeighbors_,
+                                                                    device_theCellTracks_,
+                                                                    hh.view(),
+                                                                    device_isOuterHitOfCell_.get(),
+                                                                    nActualPairs,
+                                                                    m_params.idealConditions_,
+                                                                    m_params.doClusterCut_,
+                                                                    m_params.doZCut_,
+                                                                    m_params.doPhiCut_,
+                                                                    m_params.maxNumberOfDoublets_);
   cudaCheck(cudaGetLastError());
 
 #ifdef GPU_DEBUG

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -170,8 +170,8 @@ public:
 
   void fillHitDetIndices(HitsView const* hv, TkSoA* tuples_d, cudaStream_t cudaStream);
 
-  void buildDoublets(HitsOnCPU const& hh, cuda::stream_t<>& stream);
-  void allocateOnGPU(cuda::stream_t<>& stream);
+  void buildDoublets(HitsOnCPU const& hh, cudaStream_t stream);
+  void allocateOnGPU(cudaStream_t stream);
   void cleanup(cudaStream_t cudaStream);
 
   static void printCounters(Counters const* counters);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -4,9 +4,9 @@
 
 template <>
 #ifdef __CUDACC__
-void CAHitNtupletGeneratorKernelsGPU::allocateOnGPU(cuda::stream_t<>& stream) {
+void CAHitNtupletGeneratorKernelsGPU::allocateOnGPU(cudaStream_t stream) {
 #else
-void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cuda::stream_t<>& stream) {
+void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
 #endif
   //////////////////////////////////////////////////////////
   // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)
@@ -42,10 +42,10 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cuda::stream_t<>& stream) {
       constexpr
 #endif
       (std::is_same<Traits, cudaCompat::GPUTraits>::value) {
-    cudaCheck(cudaMemsetAsync(device_nCells_, 0, sizeof(uint32_t), stream.id()));
+    cudaCheck(cudaMemsetAsync(device_nCells_, 0, sizeof(uint32_t), stream));
   } else {
     *device_nCells_ = 0;
   }
-  cudautils::launchZero(device_tupleMultiplicity_.get(), stream.id());
-  cudautils::launchZero(device_hitToTuple_.get(), stream.id());  // we may wish to keep it in the edm...
+  cudautils::launchZero(device_tupleMultiplicity_.get(), stream);
+  cudautils::launchZero(device_hitToTuple_.get(), stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.h
@@ -47,18 +47,16 @@ public:
   static void fillDescriptions(edm::ParameterSetDescription& desc);
   static const char* fillDescriptionsLabel() { return "caHitNtupletOnGPU"; }
 
-  PixelTrackHeterogeneous makeTuplesAsync(TrackingRecHit2DGPU const& hits_d,
-                                          float bfield,
-                                          cuda::stream_t<>& stream) const;
+  PixelTrackHeterogeneous makeTuplesAsync(TrackingRecHit2DGPU const& hits_d, float bfield, cudaStream_t stream) const;
 
   PixelTrackHeterogeneous makeTuples(TrackingRecHit2DCPU const& hits_d, float bfield) const;
 
 private:
-  void buildDoublets(HitsOnCPU const& hh, cuda::stream_t<>& stream) const;
+  void buildDoublets(HitsOnCPU const& hh, cudaStream_t stream) const;
 
-  void hitNtuplets(HitsOnCPU const& hh, const edm::EventSetup& es, bool useRiemannFit, cuda::stream_t<>& cudaStream);
+  void hitNtuplets(HitsOnCPU const& hh, const edm::EventSetup& es, bool useRiemannFit, cudaStream_t cudaStream);
 
-  void launchKernels(HitsOnCPU const& hh, bool useRiemannFit, cuda::stream_t<>& cudaStream) const;
+  void launchKernels(HitsOnCPU const& hh, bool useRiemannFit, cudaStream_t cudaStream) const;
 
   Params m_params;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/HelixFitOnGPU.h
@@ -45,14 +45,8 @@ public:
   ~HelixFitOnGPU() { deallocateOnGPU(); }
 
   void setBField(double bField) { bField_ = bField; }
-  void launchRiemannKernels(HitsView const *hv,
-                            uint32_t nhits,
-                            uint32_t maxNumberOfTuples,
-                            cuda::stream_t<> &cudaStream);
-  void launchBrokenLineKernels(HitsView const *hv,
-                               uint32_t nhits,
-                               uint32_t maxNumberOfTuples,
-                               cuda::stream_t<> &cudaStream);
+  void launchRiemannKernels(HitsView const *hv, uint32_t nhits, uint32_t maxNumberOfTuples, cudaStream_t cudaStream);
+  void launchBrokenLineKernels(HitsView const *hv, uint32_t nhits, uint32_t maxNumberOfTuples, cudaStream_t cudaStream);
 
   void launchRiemannKernelsOnCPU(HitsView const *hv, uint32_t nhits, uint32_t maxNumberOfTuples);
   void launchBrokenLineKernelsOnCPU(HitsView const *hv, uint32_t nhits, uint32_t maxNumberOfTuples);

--- a/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.cu
@@ -4,7 +4,7 @@
 void HelixFitOnGPU::launchRiemannKernels(HitsView const *hv,
                                          uint32_t nhits,
                                          uint32_t maxNumberOfTuples,
-                                         cuda::stream_t<> &stream) {
+                                         cudaStream_t stream) {
   assert(tuples_d);
 
   auto blockSize = 64;
@@ -23,108 +23,108 @@ void HelixFitOnGPU::launchRiemannKernels(HitsView const *hv,
 
   for (uint32_t offset = 0; offset < maxNumberOfTuples; offset += maxNumberOfConcurrentFits_) {
     // triplets
-    kernelFastFit<3><<<numberOfBlocks, blockSize, 0, stream.id()>>>(
+    kernelFastFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(
         tuples_d, tupleMultiplicity_d, 3, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
     cudaCheck(cudaGetLastError());
 
-    kernelCircleFit<3><<<numberOfBlocks, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                      3,
-                                                                      bField_,
-                                                                      hitsGPU_.get(),
-                                                                      hits_geGPU_.get(),
-                                                                      fast_fit_resultsGPU_.get(),
-                                                                      circle_fit_resultsGPU_,
-                                                                      offset);
+    kernelCircleFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                 3,
+                                                                 bField_,
+                                                                 hitsGPU_.get(),
+                                                                 hits_geGPU_.get(),
+                                                                 fast_fit_resultsGPU_.get(),
+                                                                 circle_fit_resultsGPU_,
+                                                                 offset);
     cudaCheck(cudaGetLastError());
 
-    kernelLineFit<3><<<numberOfBlocks, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                    3,
-                                                                    bField_,
-                                                                    outputSoa_d,
-                                                                    hitsGPU_.get(),
-                                                                    hits_geGPU_.get(),
-                                                                    fast_fit_resultsGPU_.get(),
-                                                                    circle_fit_resultsGPU_,
-                                                                    offset);
+    kernelLineFit<3><<<numberOfBlocks, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                               3,
+                                                               bField_,
+                                                               outputSoa_d,
+                                                               hitsGPU_.get(),
+                                                               hits_geGPU_.get(),
+                                                               fast_fit_resultsGPU_.get(),
+                                                               circle_fit_resultsGPU_,
+                                                               offset);
     cudaCheck(cudaGetLastError());
 
     // quads
-    kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+    kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
         tuples_d, tupleMultiplicity_d, 4, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
     cudaCheck(cudaGetLastError());
 
-    kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                          4,
-                                                                          bField_,
-                                                                          hitsGPU_.get(),
-                                                                          hits_geGPU_.get(),
-                                                                          fast_fit_resultsGPU_.get(),
-                                                                          circle_fit_resultsGPU_,
-                                                                          offset);
+    kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                     4,
+                                                                     bField_,
+                                                                     hitsGPU_.get(),
+                                                                     hits_geGPU_.get(),
+                                                                     fast_fit_resultsGPU_.get(),
+                                                                     circle_fit_resultsGPU_,
+                                                                     offset);
     cudaCheck(cudaGetLastError());
 
-    kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                        4,
-                                                                        bField_,
-                                                                        outputSoa_d,
-                                                                        hitsGPU_.get(),
-                                                                        hits_geGPU_.get(),
-                                                                        fast_fit_resultsGPU_.get(),
-                                                                        circle_fit_resultsGPU_,
-                                                                        offset);
+    kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                   4,
+                                                                   bField_,
+                                                                   outputSoa_d,
+                                                                   hitsGPU_.get(),
+                                                                   hits_geGPU_.get(),
+                                                                   fast_fit_resultsGPU_.get(),
+                                                                   circle_fit_resultsGPU_,
+                                                                   offset);
     cudaCheck(cudaGetLastError());
 
     if (fit5as4_) {
       // penta
-      kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+      kernelFastFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
           tuples_d, tupleMultiplicity_d, 5, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
       cudaCheck(cudaGetLastError());
 
-      kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                            5,
-                                                                            bField_,
-                                                                            hitsGPU_.get(),
-                                                                            hits_geGPU_.get(),
-                                                                            fast_fit_resultsGPU_.get(),
-                                                                            circle_fit_resultsGPU_,
-                                                                            offset);
+      kernelCircleFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                       5,
+                                                                       bField_,
+                                                                       hitsGPU_.get(),
+                                                                       hits_geGPU_.get(),
+                                                                       fast_fit_resultsGPU_.get(),
+                                                                       circle_fit_resultsGPU_,
+                                                                       offset);
       cudaCheck(cudaGetLastError());
 
-      kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                          5,
-                                                                          bField_,
-                                                                          outputSoa_d,
-                                                                          hitsGPU_.get(),
-                                                                          hits_geGPU_.get(),
-                                                                          fast_fit_resultsGPU_.get(),
-                                                                          circle_fit_resultsGPU_,
-                                                                          offset);
+      kernelLineFit<4><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                     5,
+                                                                     bField_,
+                                                                     outputSoa_d,
+                                                                     hitsGPU_.get(),
+                                                                     hits_geGPU_.get(),
+                                                                     fast_fit_resultsGPU_.get(),
+                                                                     circle_fit_resultsGPU_,
+                                                                     offset);
       cudaCheck(cudaGetLastError());
     } else {
       // penta all 5
-      kernelFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(
+      kernelFastFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(
           tuples_d, tupleMultiplicity_d, 5, hv, hitsGPU_.get(), hits_geGPU_.get(), fast_fit_resultsGPU_.get(), offset);
       cudaCheck(cudaGetLastError());
 
-      kernelCircleFit<5><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                            5,
-                                                                            bField_,
-                                                                            hitsGPU_.get(),
-                                                                            hits_geGPU_.get(),
-                                                                            fast_fit_resultsGPU_.get(),
-                                                                            circle_fit_resultsGPU_,
-                                                                            offset);
+      kernelCircleFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                       5,
+                                                                       bField_,
+                                                                       hitsGPU_.get(),
+                                                                       hits_geGPU_.get(),
+                                                                       fast_fit_resultsGPU_.get(),
+                                                                       circle_fit_resultsGPU_,
+                                                                       offset);
       cudaCheck(cudaGetLastError());
 
-      kernelLineFit<5><<<numberOfBlocks / 4, blockSize, 0, stream.id()>>>(tupleMultiplicity_d,
-                                                                          5,
-                                                                          bField_,
-                                                                          outputSoa_d,
-                                                                          hitsGPU_.get(),
-                                                                          hits_geGPU_.get(),
-                                                                          fast_fit_resultsGPU_.get(),
-                                                                          circle_fit_resultsGPU_,
-                                                                          offset);
+      kernelLineFit<5><<<numberOfBlocks / 4, blockSize, 0, stream>>>(tupleMultiplicity_d,
+                                                                     5,
+                                                                     bField_,
+                                                                     outputSoa_d,
+                                                                     hitsGPU_.get(),
+                                                                     hits_geGPU_.get(),
+                                                                     fast_fit_resultsGPU_.get(),
+                                                                     circle_fit_resultsGPU_,
+                                                                     offset);
       cudaCheck(cudaGetLastError());
     }
   }

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
@@ -61,7 +61,7 @@ namespace gpuVertexFinder {
 
     ~Producer() = default;
 
-    ZVertexHeterogeneous makeAsync(cuda::stream_t<>& stream, TkSoA const* tksoa, float ptMin) const;
+    ZVertexHeterogeneous makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin) const;
     ZVertexHeterogeneous make(TkSoA const* tksoa, float ptMin) const;
 
   private:

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinderImpl.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinderImpl.h
@@ -46,7 +46,7 @@ namespace gpuVertexFinder {
   }
 
 #ifdef __CUDACC__
-  ZVertexHeterogeneous Producer::makeAsync(cuda::stream_t<>& stream, TkSoA const* tksoa, float ptMin) const {
+  ZVertexHeterogeneous Producer::makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin) const {
     // std::cout << "producing Vertices on GPU" << std::endl;
     ZVertexHeterogeneous vertices(std::move(cudautils::make_device_unique<ZVertexSoA>(stream)));
 #else
@@ -65,10 +65,10 @@ namespace gpuVertexFinder {
 #endif
 
 #ifdef __CUDACC__
-    init<<<1, 1, 0, stream.id()>>>(soa, ws_d.get());
+    init<<<1, 1, 0, stream>>>(soa, ws_d.get());
     auto blockSize = 128;
     auto numberOfBlocks = (TkSoA::stride() + blockSize - 1) / blockSize;
-    loadTracks<<<numberOfBlocks, blockSize, 0, stream.id()>>>(tksoa, soa, ws_d.get(), ptMin);
+    loadTracks<<<numberOfBlocks, blockSize, 0, stream>>>(tksoa, soa, ws_d.get(), ptMin);
     cudaCheck(cudaGetLastError());
 #else
     cudaCompat::resetGrid();
@@ -78,14 +78,14 @@ namespace gpuVertexFinder {
 
 #ifdef __CUDACC__
     if (useDensity_) {
-      clusterTracksByDensity<<<1, 1024 - 256, 0, stream.id()>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
+      clusterTracksByDensity<<<1, 1024 - 256, 0, stream>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
     } else if (useDBSCAN_) {
-      clusterTracksDBSCAN<<<1, 1024 - 256, 0, stream.id()>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
+      clusterTracksDBSCAN<<<1, 1024 - 256, 0, stream>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
     } else if (useIterative_) {
-      clusterTracksIterative<<<1, 1024 - 256, 0, stream.id()>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
+      clusterTracksIterative<<<1, 1024 - 256, 0, stream>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
     }
     cudaCheck(cudaGetLastError());
-    fitVertices<<<1, 1024 - 256, 0, stream.id()>>>(soa, ws_d.get(), 50.);
+    fitVertices<<<1, 1024 - 256, 0, stream>>>(soa, ws_d.get(), 50.);
     cudaCheck(cudaGetLastError());
 #else
     if (useDensity_) {
@@ -101,12 +101,12 @@ namespace gpuVertexFinder {
 
 #ifdef __CUDACC__
     // one block per vertex...
-    splitVertices<<<1024, 128, 0, stream.id()>>>(soa, ws_d.get(), 9.f);
+    splitVertices<<<1024, 128, 0, stream>>>(soa, ws_d.get(), 9.f);
     cudaCheck(cudaGetLastError());
-    fitVertices<<<1, 1024 - 256, 0, stream.id()>>>(soa, ws_d.get(), 5000.);
+    fitVertices<<<1, 1024 - 256, 0, stream>>>(soa, ws_d.get(), 5000.);
     cudaCheck(cudaGetLastError());
 
-    sortByPt2<<<1, 256, 0, stream.id()>>>(soa, ws_d.get());
+    sortByPt2<<<1, 256, 0, stream>>>(soa, ws_d.get());
     cudaCheck(cudaGetLastError());
 #else
     for (blockIdx.x = 0; blockIdx.x < 1024; ++blockIdx.x) {

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -19,7 +19,6 @@
   <use name="HeterogeneousCore/CUDACore"/>
   <use name="HeterogeneousCore/CUDAServices"/>
   <use name="cuda"/>
-  <use name="cuda-api-wrappers"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library   file="BeamSpotOnlineProducer.cc" name="BeamSpotOnlineProducer">

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterSLOnGPU.h
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterSLOnGPU.h
@@ -2,7 +2,6 @@
 #define SimTracker_TrackerHitAssociation_plugins_ClusterSLOnGPU_h
 
 #include <cuda_runtime.h>
-#include <cuda/api_wrappers.h>
 
 #include "CUDADataFormats/SiPixelDigi/interface/SiPixelDigisCUDA.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
@@ -22,18 +21,18 @@ namespace clusterSLOnGPU {
 
   class Kernel {
   public:
-    Kernel(cuda::stream_t<>& stream, bool dump);
+    Kernel(cudaStream_t stream, bool dump);
     ~Kernel() { deAlloc(); }
     void algo(SiPixelDigisCUDA const& dd,
               uint32_t ndigis,
               HitsOnCPU const& hh,
               uint32_t nhits,
               uint32_t n,
-              cuda::stream_t<>& stream);
+              cudaStream_t stream);
     GPUProduct getProduct() { return GPUProduct{slgpu.me_d}; }
 
   private:
-    void alloc(cuda::stream_t<>& stream);
+    void alloc(cudaStream_t stream);
     void deAlloc();
     void zero(cudaStream_t stream);
 

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
@@ -143,7 +143,7 @@ void ClusterTPAssociationHeterogeneous::fillDescriptions(edm::ConfigurationDescr
 }
 
 void ClusterTPAssociationHeterogeneous::beginStreamGPUCuda(edm::StreamID streamId, cuda::stream_t<> &cudaStream) {
-  gpuAlgo = std::make_unique<clusterSLOnGPU::Kernel>(cudaStream, doDump);
+  gpuAlgo = std::make_unique<clusterSLOnGPU::Kernel>(cudaStream.id(), doDump);
 }
 
 void ClusterTPAssociationHeterogeneous::makeMap(const edm::HeterogeneousEvent &iEvent) {
@@ -233,7 +233,7 @@ void ClusterTPAssociationHeterogeneous::acquireGPUCuda(const edm::HeterogeneousE
   std::sort(digi2tp.begin(), digi2tp.end());
   cudaCheck(cudaMemcpyAsync(
       gpuAlgo->slgpu.links_d, digi2tp.data(), sizeof(Clus2TP) * digi2tp.size(), cudaMemcpyDefault, cudaStream.id()));
-  gpuAlgo->algo(gDigis, ndigis, gHits, nhits, digi2tp.size(), cudaStream);
+  gpuAlgo->algo(gDigis, ndigis, gHits, nhits, digi2tp.size(), cudaStream.id());
 
   //  end gpu stuff ---------------------
 }

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationHeterogeneous.cc
@@ -32,6 +32,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDACore/interface/GPUCuda.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
@@ -196,11 +197,11 @@ void ClusterTPAssociationHeterogeneous::acquireGPUCuda(const edm::HeterogeneousE
   // synchronize explicitly (implementation is from
   // CUDAScopedContext). In practice these should not be needed
   // (because of synchronizations upstream), but let's play generic.
-  if (not gd->isAvailable() and not gd->event()->has_occurred()) {
-    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gd->event()->id(), 0));
+  if (not gd->isAvailable() and not cudautils::eventIsOccurred(gd->event())) {
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gd->event(), 0));
   }
-  if (not gh->isAvailable() and not gh->event()->has_occurred()) {
-    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gh->event()->id(), 0));
+  if (not gh->isAvailable() and not cudautils::eventIsOccurred(gh->event())) {
+    cudaCheck(cudaStreamWaitEvent(cudaStream.id(), gh->event(), 0));
   }
 
   CUDAScopedContextProduce ctx{*gd};


### PR DESCRIPTION
#### PR description:

This PR is part of #386 and replaces the use of `cuda::stream_t<>` and `cuda::event_t` in the interfaces and in the user code. The "framework" part still uses them as replacing them in the stream and event caches requires https://github.com/cms-sw/cmssw/pull/28004. Anyway, this PR minimizes the impact of the later PR.

I also left `HeterogeneousCore/Product` and `HeterogeneousCore/Producer` out from this exercise as they will get nuked as soon as `ClusterTPAssociationHeterogeneous` is migrated away from those (https://github.com/cms-patatrack/cmssw/issues/229#issuecomment-530071384). 

#### PR validation:

Unit tests run, profiling workflow runs. Code formatting was run.
