### PR TITLE
Synchronize event in the CUDAProductBase destructor

### DIFF
--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -17,7 +17,10 @@ namespace impl {
 class CUDAProductBase {
 public:
   CUDAProductBase() = default;  // Needed only for ROOT dictionary generation
+  ~CUDAProductBase();
 
+  CUDAProductBase(const CUDAProductBase&) = delete;
+  CUDAProductBase& operator=(const CUDAProductBase&) = delete;
   CUDAProductBase(CUDAProductBase&& other)
       : stream_{std::move(other.stream_)},
         event_{std::move(other.event_)},

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -8,3 +8,15 @@ bool CUDAProductBase::isAvailable() const {
   }
   return event_->has_occurred();
 }
+
+CUDAProductBase::~CUDAProductBase() {
+  // Make sure that the production of the product in the GPU is
+  // complete before destructing the product. This is to make sure
+  // that the EDM stream does not move to the next event before all
+  // asynchronous processing of the current is complete.
+  if (event_) {
+    // TODO: a callback notifying a WaitingTaskHolder (or similar)
+    // would avoid blocking the CPU, but would also require more work.
+    event_->synchronize();
+  }
+}

--- a/CUDADataFormats/Track/BuildFile.xml
+++ b/CUDADataFormats/Track/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="cuda-api-wrappers"/>
 <use name="rootcore"/>
+<use name="CUDADataFormats/Common"/>
 <use name="DataFormats/Common"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="eigen"/>

--- a/CUDADataFormats/Vertex/BuildFile.xml
+++ b/CUDADataFormats/Vertex/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="cuda-api-wrappers"/>
 <use name="rootcore"/>
+<use name="CUDADataFormats/Common"/>
 <use name="DataFormats/Common"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="eigen"/>


### PR DESCRIPTION
#### PR description:

This PR is an updated version of #334:
> Otherwise there are possibilities for weird races (e.g. combination non-ExternalWork producers, consumed-but-not-read CUDAProducts, CUDA streams executing work later than expected (= on the next event)).

The difference is that this PR synchronizes wrt. the CUDA event (if there is one) instead of the stream (hence new PR), in this way the destruction of a product A does not have to wait for completion of work queued on the CUDA stream after the product A was made.

#### PR validation:

Profiling workflow runs, unit test run.

On `felk40` with 8 EDM streams and threads I see ~1 % throughput decrease.
