### PR TITLE
Let cudaCheck throw an exception instead of aborting

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -4,6 +4,7 @@
 // C++ standard headers
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 // CUDA headers
 #include <cuda.h>
@@ -18,8 +19,7 @@ namespace {
     out << file << ", line " << line << ":\n";
     out << "cudaCheck(" << cmd << ");\n";
     out << error << ": " << message << "\n";
-    std::cerr << out.str() << std::flush;
-    abort();
+    throw std::runtime_error(out.str());
   }
 
 }  // namespace


### PR DESCRIPTION
#### PR description:

Change the behaviour of `cudaCheck(...)` to throw an `std::runtime_error` instead of calling `abort()`.

If the exception is not handled, the result should be roughly the same, for example:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  
test.cu, line 20:
cudaCheck(cudaMalloc(&device_x, kDataLen * sizeof(float)));
cudaErrorNoDevice: no CUDA-capable device is detected

Aborted (core dumped)
```

#### PR validation:

None.
