### PR TITLE
Make sure caching allocators and stream/event caches are constructed during CUDAService constructor

### DIFF
--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -296,11 +296,13 @@ CUDAService::CUDAService(edm::ParameterSet const& config, edm::ActivityRegistry&
   }
   log << "\n";
 
-  // Make sure the caching allocators are constructed before declaring successful construction
-    if constexpr (cudautils::allocator::useCaching) {
-      cudautils::allocator::getCachingDeviceAllocator();
-      cudautils::allocator::getCachingHostAllocator();
-    }
+  // Make sure the caching allocators and stream/event caches are constructed before declaring successful construction
+  if constexpr (cudautils::allocator::useCaching) {
+    cudautils::allocator::getCachingDeviceAllocator();
+    cudautils::allocator::getCachingHostAllocator();
+  }
+  cudautils::getCUDAEventCache().clear();
+  cudautils::getCUDAStreamCache().clear();
 
   log << "CUDAService fully initialized";
   enabled_ = true;

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -296,6 +296,12 @@ CUDAService::CUDAService(edm::ParameterSet const& config, edm::ActivityRegistry&
   }
   log << "\n";
 
+  // Make sure the caching allocators are constructed before declaring successful construction
+    if constexpr (cudautils::allocator::useCaching) {
+      cudautils::allocator::getCachingDeviceAllocator();
+      cudautils::allocator::getCachingHostAllocator();
+    }
+
   log << "CUDAService fully initialized";
   enabled_ = true;
 


### PR DESCRIPTION
#### PR description:

Otherwise it could happen that the caching allocators or caches would be constructed in the `CUDAService` destructor, and that could lead to exceptions being thrown from the destructor.

#### PR validation:

Profiling workflow runs.