### PR TITLE
Replace use of API wrapper stream and event with plain CUDA, part 2

### DIFF
--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-#include <cuda/api_wrappers.h>
-
 #include "CUDADataFormats/Common/interface/CUDAProductBase.h"
 
 namespace edm {
@@ -44,11 +42,11 @@ private:
   friend class CUDAScopedContextProduce;
   friend class edm::Wrapper<CUDAProduct<T>>;
 
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, T data)
+  explicit CUDAProduct(int device, cudautils::SharedStreamPtr stream, T data)
       : CUDAProductBase(device, std::move(stream)), data_(std::move(data)) {}
 
   template <typename... Args>
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, Args&&... args)
+  explicit CUDAProduct(int device, cudautils::SharedStreamPtr stream, Args&&... args)
       : CUDAProductBase(device, std::move(stream)), data_(std::forward<Args>(args)...) {}
 
   T data_;  //!

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -6,6 +6,8 @@
 
 #include <cuda/api_wrappers.h>
 
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
+
 namespace impl {
   class CUDAScopedContextBase;
 }
@@ -43,7 +45,7 @@ public:
   // mutable access is needed even if the CUDAScopedContext itself
   // would be const. Therefore it is ok to return a non-const
   // pointer from a const method here.
-  cudaStream_t stream() const { return stream_->id(); }
+  cudaStream_t stream() const { return stream_.get(); }
 
   // cudaEvent_t is a pointer to a thread-safe object, for which a
   // mutable access is needed even if the CUDAScopedContext itself
@@ -52,7 +54,7 @@ public:
   cudaEvent_t event() const { return event_ ? event_->id() : nullptr; }
 
 protected:
-  explicit CUDAProductBase(int device, std::shared_ptr<cuda::stream_t<>> stream)
+  explicit CUDAProductBase(int device, cudautils::SharedStreamPtr stream)
       : stream_{std::move(stream)}, device_{device} {}
 
 private:
@@ -61,7 +63,7 @@ private:
 
   // The following functions are intended to be used only from CUDAScopedContext
   void setEvent(std::shared_ptr<cuda::event_t> event) { event_ = std::move(event); }
-  const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
+  const cudautils::SharedStreamPtr& streamPtr() const { return stream_; }
 
   bool mayReuseStream() const {
     bool expected = true;
@@ -71,9 +73,9 @@ private:
     return changed;
   }
 
-  // The cuda::stream_t is really shared among edm::Event products, so
+  // The cudaStream_t is really shared among edm::Event products, so
   // using shared_ptr also here
-  std::shared_ptr<cuda::stream_t<>> stream_;  //!
+  cudautils::SharedStreamPtr stream_;  //!
   // shared_ptr because of caching in CUDAEventCache
   std::shared_ptr<cuda::event_t> event_;  //!
 

--- a/CUDADataFormats/Common/interface/CUDAProductBase.h
+++ b/CUDADataFormats/Common/interface/CUDAProductBase.h
@@ -7,6 +7,7 @@
 #include <cuda/api_wrappers.h>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h"
 
 namespace impl {
   class CUDAScopedContextBase;
@@ -51,7 +52,7 @@ public:
   // mutable access is needed even if the CUDAScopedContext itself
   // would be const. Therefore it is ok to return a non-const
   // pointer from a const method here.
-  cudaEvent_t event() const { return event_ ? event_->id() : nullptr; }
+  cudaEvent_t event() const { return event_ ? event_.get() : nullptr; }
 
 protected:
   explicit CUDAProductBase(int device, cudautils::SharedStreamPtr stream)
@@ -62,7 +63,7 @@ private:
   friend class CUDAScopedContextProduce;
 
   // The following functions are intended to be used only from CUDAScopedContext
-  void setEvent(std::shared_ptr<cuda::event_t> event) { event_ = std::move(event); }
+  void setEvent(cudautils::SharedEventPtr event) { event_ = std::move(event); }
   const cudautils::SharedStreamPtr& streamPtr() const { return stream_; }
 
   bool mayReuseStream() const {
@@ -77,7 +78,7 @@ private:
   // using shared_ptr also here
   cudautils::SharedStreamPtr stream_;  //!
   // shared_ptr because of caching in CUDAEventCache
-  std::shared_ptr<cuda::event_t> event_;  //!
+  cudautils::SharedEventPtr event_;  //!
 
   // This flag tells whether the CUDA stream may be reused by a
   // consumer or not. The goal is to have a "chain" of modules to

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -7,7 +7,7 @@ bool CUDAProductBase::isAvailable() const {
   if (not event_) {
     return true;
   }
-  return cudautils::eventIsOccurred(event_->id());
+  return cudautils::eventIsOccurred(event_.get());
 }
 
 CUDAProductBase::~CUDAProductBase() {
@@ -18,6 +18,10 @@ CUDAProductBase::~CUDAProductBase() {
   if (event_) {
     // TODO: a callback notifying a WaitingTaskHolder (or similar)
     // would avoid blocking the CPU, but would also require more work.
-    event_->synchronize();
+    //
+    // Intentionally not checking the return value to avoid throwing
+    // exceptions. If this call would fail, we should get failures
+    // elsewhere as well.
+    cudaEventSynchronize(event_.get());
   }
 }

--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -5,6 +5,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 
 #include <cuda_runtime_api.h>
 
@@ -12,10 +13,9 @@ namespace cudatest {
   class TestCUDAScopedContext {
   public:
     static CUDAScopedContextProduce make(int dev, bool createEvent) {
-      auto device = cuda::device::get(dev);
-      std::unique_ptr<cuda::event_t> event;
+      cudautils::SharedEventPtr event;
       if (createEvent) {
-        event = std::make_unique<cuda::event_t>(device.create_event());
+        event = cudautils::getCUDAEventCache().getCUDAEvent();
       }
       return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }

--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -4,6 +4,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
 
 #include <cuda_runtime_api.h>
 
@@ -16,10 +17,7 @@ namespace cudatest {
       if (createEvent) {
         event = std::make_unique<cuda::event_t>(device.create_event());
       }
-      return CUDAScopedContextProduce(dev,
-                                      std::make_unique<cuda::stream_t<>>(device.create_stream(
-                                          cuda::stream::implicitly_synchronizes_with_default_stream)),
-                                      std::move(event));
+      return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }
   };
 }  // namespace cudatest

--- a/HeterogeneousCore/CUDACore/interface/CUDAContextState.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAContextState.h
@@ -40,6 +40,10 @@ private:
 
   cudautils::SharedStreamPtr releaseStreamPtr() {
     throwIfNoStream();
+    // This function needs to effectively reset stream_ (i.e. stream_
+    // must be empty after this function). This behavior ensures that
+    // the SharedStreamPtr is not hold for inadvertedly long (i.e. to
+    // the next event), and is checked at run time.
     return std::move(stream_);
   }
 

--- a/HeterogeneousCore/CUDACore/interface/CUDAContextState.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAContextState.h
@@ -1,7 +1,7 @@
 #ifndef HeterogeneousCore_CUDACore_CUDAContextState_h
 #define HeterogeneousCore_CUDACore_CUDAContextState_h
 
-#include <cuda/api_wrappers.h>
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
 
 #include <memory>
 
@@ -25,7 +25,7 @@ private:
   friend class CUDAScopedContextProduce;
   friend class CUDAScopedContextTask;
 
-  void set(int device, std::shared_ptr<cuda::stream_t<>> stream) {
+  void set(int device, cudautils::SharedStreamPtr stream) {
     throwIfStream();
     device_ = device;
     stream_ = std::move(stream);
@@ -33,20 +33,20 @@ private:
 
   int device() const { return device_; }
 
-  std::shared_ptr<cuda::stream_t<>>& streamPtr() {
+  const cudautils::SharedStreamPtr& streamPtr() const {
     throwIfNoStream();
     return stream_;
   }
 
-  const std::shared_ptr<cuda::stream_t<>>& streamPtr() const {
+  cudautils::SharedStreamPtr releaseStreamPtr() {
     throwIfNoStream();
-    return stream_;
+    return std::move(stream_);
   }
 
   void throwIfStream() const;
   void throwIfNoStream() const;
 
-  std::shared_ptr<cuda::stream_t<>> stream_;
+  cudautils::SharedStreamPtr stream_;
   int device_;
 };
 

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -9,6 +9,7 @@
 #include "CUDADataFormats/Common/interface/CUDAProduct.h"
 #include "HeterogeneousCore/CUDACore/interface/CUDAContextState.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h"
 
 #include <cuda/api_wrappers.h>
 
@@ -177,12 +178,12 @@ private:
   friend class cudatest::TestCUDAScopedContext;
 
   // This construcor is only meant for testing
-  explicit CUDAScopedContextProduce(int device, cudautils::SharedStreamPtr stream, std::unique_ptr<cuda::event_t> event)
+  explicit CUDAScopedContextProduce(int device, cudautils::SharedStreamPtr stream, cudautils::SharedEventPtr event)
       : CUDAScopedContextGetterBase(device, std::move(stream)), event_{std::move(event)} {}
 
   void createEventIfStreamBusy();
 
-  std::shared_ptr<cuda::event_t> event_;
+  cudautils::SharedEventPtr event_;
 };
 
 /**

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -8,6 +8,7 @@
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "CUDADataFormats/Common/interface/CUDAProduct.h"
 #include "HeterogeneousCore/CUDACore/interface/CUDAContextState.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
 
 #include <cuda/api_wrappers.h>
 
@@ -27,22 +28,20 @@ namespace impl {
     // mutable access is needed even if the CUDAScopedContext itself
     // would be const. Therefore it is ok to return a non-const
     // pointer from a const method here.
-    cudaStream_t stream() const { return stream_->id(); }
-    const std::shared_ptr<cuda::stream_t<>>& streamPtr() const { return stream_; }
+    cudaStream_t stream() const { return stream_.get(); }
+    const cudautils::SharedStreamPtr& streamPtr() const { return stream_; }
 
   protected:
     explicit CUDAScopedContextBase(edm::StreamID streamID);
 
     explicit CUDAScopedContextBase(const CUDAProductBase& data);
 
-    explicit CUDAScopedContextBase(int device, std::shared_ptr<cuda::stream_t<>> stream);
-
-    std::shared_ptr<cuda::stream_t<>>& streamPtr() { return stream_; }
+    explicit CUDAScopedContextBase(int device, cudautils::SharedStreamPtr stream);
 
   private:
     int currentDevice_;
     cuda::device::current::scoped_override_t<> setDeviceForThisScope_;
-    std::shared_ptr<cuda::stream_t<>> stream_;
+    cudautils::SharedStreamPtr stream_;
   };
 
   class CUDAScopedContextGetterBase : public CUDAScopedContextBase {
@@ -148,8 +147,8 @@ public:
   explicit CUDAScopedContextProduce(const CUDAProductBase& data) : CUDAScopedContextGetterBase(data) {}
 
   /// Constructor to re-use the CUDA stream of acquire() (ExternalWork module)
-  explicit CUDAScopedContextProduce(CUDAContextState& token)
-      : CUDAScopedContextGetterBase(token.device(), std::move(token.streamPtr())) {}
+  explicit CUDAScopedContextProduce(CUDAContextState& state)
+      : CUDAScopedContextGetterBase(state.device(), state.releaseStreamPtr()) {}
 
   ~CUDAScopedContextProduce();
 
@@ -178,9 +177,7 @@ private:
   friend class cudatest::TestCUDAScopedContext;
 
   // This construcor is only meant for testing
-  explicit CUDAScopedContextProduce(int device,
-                                    std::unique_ptr<cuda::stream_t<>> stream,
-                                    std::unique_ptr<cuda::event_t> event)
+  explicit CUDAScopedContextProduce(int device, cudautils::SharedStreamPtr stream, std::unique_ptr<cuda::event_t> event)
       : CUDAScopedContextGetterBase(device, std::move(stream)), event_{std::move(event)} {}
 
   void createEventIfStreamBusy();

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -52,7 +52,7 @@ namespace impl {
     }
   }
 
-  CUDAScopedContextBase::CUDAScopedContextBase(int device, std::shared_ptr<cuda::stream_t<>> stream)
+  CUDAScopedContextBase::CUDAScopedContextBase(int device, cudautils::SharedStreamPtr stream)
       : currentDevice_(device), setDeviceForThisScope_(device), stream_(std::move(stream)) {}
 
   ////////////////////

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -106,7 +106,7 @@ void CUDAScopedContextAcquire::throwNoState() {
 
 CUDAScopedContextProduce::~CUDAScopedContextProduce() {
   if (event_) {
-    event_->record(stream());
+    cudaCheck(cudaEventRecord(event_.get(), stream()));
   }
 }
 

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -10,6 +10,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 
 #include "test_CUDAScopedContextKernels.h"
 
@@ -17,10 +18,9 @@ namespace cudatest {
   class TestCUDAScopedContext {
   public:
     static CUDAScopedContextProduce make(int dev, bool createEvent) {
-      auto device = cuda::device::get(dev);
-      std::unique_ptr<cuda::event_t> event;
+      cudautils::SharedEventPtr event;
       if (createEvent) {
-        event = std::make_unique<cuda::event_t>(device.create_event());
+        event = cudautils::getCUDAEventCache().getCUDAEvent();
       }
       return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -9,6 +9,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
 
 #include "test_CUDAScopedContextKernels.h"
 
@@ -21,10 +22,7 @@ namespace cudatest {
       if (createEvent) {
         event = std::make_unique<cuda::event_t>(device.create_event());
       }
-      return CUDAScopedContextProduce(dev,
-                                      std::make_unique<cuda::stream_t<>>(device.create_stream(
-                                          cuda::stream::implicitly_synchronizes_with_default_stream)),
-                                      std::move(event));
+      return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }
   };
 }  // namespace cudatest

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -95,7 +95,7 @@ namespace {
     std::vector<UniquePtr<char[]> > buffers;
     buffers.reserve(bufferSizes.size());
     for (auto size : bufferSizes) {
-      buffers.push_back(allocate(size, streamPtr->id()));
+      buffers.push_back(allocate(size, streamPtr.get()));
     }
   }
 

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
@@ -40,7 +40,7 @@ TestCUDAAnalyzerGPU::TestCUDAAnalyzerGPU(const edm::ParameterSet& iConfig)
   edm::Service<CUDAService> cs;
   if (cs->enabled()) {
     auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(streamPtr->id());
+    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(streamPtr.get());
   }
 }
 
@@ -70,7 +70,7 @@ void TestCUDAAnalyzerGPU::endJob() {
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << " TestCUDAAnalyzerGPU::endJob begin";
 
   auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-  auto value = gpuAlgo_->value(streamPtr->id());
+  auto value = gpuAlgo_->value(streamPtr.get());
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << "  accumulated value " << value;
   assert(minValue_ <= value && value <= maxValue_);
 

--- a/HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h
@@ -1,30 +1,43 @@
 #ifndef HeterogeneousCore_CUDAUtilities_CUDAEventCache_h
 #define HeterogeneousCore_CUDAUtilities_CUDAEventCache_h
 
-#include <memory>
+#include <vector>
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h"
 
 class CUDAService;
 
 namespace cudautils {
   class CUDAEventCache {
   public:
+    using BareEvent = SharedEventPtr::element_type;
+
     CUDAEventCache();
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor.
     // This function is thread safe
-    std::shared_ptr<cuda::event_t> getCUDAEvent();
+    SharedEventPtr getCUDAEvent();
 
   private:
     friend class ::CUDAService;
     // intended to be called only from CUDAService destructor
     void clear();
 
-    std::vector<edm::ReusableObjectHolder<cuda::event_t>> cache_;
+    class Deleter {
+    public:
+      Deleter() = default;
+      Deleter(int d) : device_{d} {}
+      void operator()(cudaEvent_t event) const;
+
+    private:
+      int device_ = -1;
+    };
+
+    std::vector<edm::ReusableObjectHolder<BareEvent, Deleter>> cache_;
   };
 
   // Gets the global instance of a CUDAEventCache

--- a/HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h
@@ -1,30 +1,43 @@
 #ifndef HeterogeneousCore_CUDAUtilities_CUDAStreamCache_h
 #define HeterogeneousCore_CUDAUtilities_CUDAStreamCache_h
 
-#include <memory>
+#include <vector>
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
 
 class CUDAService;
 
 namespace cudautils {
   class CUDAStreamCache {
   public:
+    using BareStream = SharedStreamPtr::element_type;
+
     CUDAStreamCache();
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
     // This function is thread safe
-    std::shared_ptr<cuda::stream_t<>> getCUDAStream();
+    SharedStreamPtr getCUDAStream();
 
   private:
     friend class ::CUDAService;
     // intended to be called only from CUDAService destructor
     void clear();
 
-    std::vector<edm::ReusableObjectHolder<cuda::stream_t<>>> cache_;
+    class Deleter {
+    public:
+      Deleter() = default;
+      Deleter(int d) : device_{d} {}
+      void operator()(cudaStream_t stream) const;
+
+    private:
+      int device_ = -1;
+    };
+
+    std::vector<edm::ReusableObjectHolder<BareStream, Deleter>> cache_;
   };
 
   // Gets the global instance of a CUDAStreamCache

--- a/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
@@ -1,0 +1,28 @@
+#ifndef HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+#define HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  class ScopedSetDevice {
+  public:
+    explicit ScopedSetDevice(int newDevice) {
+      cudaCheck(cudaGetDevice(&prevDevice_));
+      cudaCheck(cudaSetDevice(newDevice));
+    }
+
+    ~ScopedSetDevice() {
+      // Intentionally don't check the return value to avoid
+      // exceptions to be thrown. If this call fails, the process is
+      // doomed anyway.
+      cudaSetDevice(prevDevice_);
+    }
+
+  private:
+    int prevDevice_;
+  };
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  // cudaEvent_t itself is a typedef for a pointer, for the use with
+  // edm::ReusableObjectHolder the pointed-to type is more interesting
+  // to avoid extra layer of indirection
+  using SharedEventPtr = std::shared_ptr<std::remove_pointer_t<cudaEvent_t>>;
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  // cudaStream_t itself is a typedef for a pointer, for the use with
+  // edm::ReusableObjectHolder the pointed-to type is more interesting
+  // to avoid extra layer of indirection
+  using SharedStreamPtr = std::shared_ptr<std::remove_pointer_t<cudaStream_t>>;
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
@@ -1,0 +1,16 @@
+#ifndef HeterogenousCore_CUDAUtilities_currentDevice_h
+#define HeterogenousCore_CUDAUtilities_currentDevice_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  inline int currentDevice() {
+    int dev;
+    cudaCheck(cudaGetDevice(&dev));
+    return dev;
+  }
+}  // namespace cudautils
+
+#endif


### PR DESCRIPTION
#### PR description:

This PR is part of #386 and replaces the remaining use of `cuda::stream_t<>` and `cuda::event_t` in the stream and event caches.

As in #389, `HeterogeneousCore/Product` and `HeterogeneousCore/Producer` out from this exercise as they will get nuked as soon as `ClusterTPAssociationHeterogeneous` is migrated away from those (#229 (comment)).

#### PR validation:

Code  compiles, profiling workflow runs. Code formatting was run.