### PR TITLE
Use non-blocking CUDA streams

### DIFF
--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -13,7 +13,7 @@ int main() {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   // inner scope to deallocate memory before destroying the stream
   {

--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -52,7 +52,7 @@ namespace heterogeneous {
     // Create the CUDA stream for this module-edm::Stream pair
     auto current_device = cuda::device::current::get();
     cudaStream_ = std::make_unique<cuda::stream_t<>>(
-        current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream));
+        current_device.create_stream(cuda::stream::no_implicit_synchronization_with_default_stream));
 
     beginStreamGPUCuda(id, *cudaStream_);
   }

--- a/HeterogeneousCore/CUDAUtilities/src/CUDAStreamCache.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/CUDAStreamCache.cc
@@ -21,7 +21,7 @@ namespace cudautils {
     const auto dev = cudautils::currentDevice();
     return cache_[dev].makeOrGet([dev]() {
       cudaStream_t stream;
-      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamDefault));
+      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
       return std::unique_ptr<BareStream, Deleter>(stream, Deleter{dev});
     });
   }

--- a/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
@@ -10,7 +10,7 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Host to device") {
     SECTION("Single element") {

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -8,7 +8,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cudautils::make_device_unique<int>(stream);

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -8,7 +8,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cudautils::make_host_unique<int>(stream);

--- a/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
@@ -11,7 +11,7 @@ TEST_CASE("memsetAsync", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto host_orig = cudautils::make_host_unique<int>(stream);

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUHelpers.cu
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUHelpers.cu
@@ -64,7 +64,7 @@ int TestAcceleratorServiceProducerGPUHelpers_simple_kernel(int input) {
   constexpr int NUM_VALUES = 10000;
 
   auto current_device = cuda::device::current::get();
-  auto stream = current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream);
+  auto stream = current_device.create_stream(cuda::stream::no_implicit_synchronization_with_default_stream);
 
   auto h_a = cudautils::make_host_unique<int[]>(NUM_VALUES, nullptr);
   auto h_b = cudautils::make_host_unique<int[]>(NUM_VALUES, nullptr);


### PR DESCRIPTION
Specifies that work running in the created stream may run concurrently
with work in stream 0 (the NULL stream), and that the created stream
should perform no implicit synchronization with stream 0.