### PR TITLE
Fix two tests

### DIFF
--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -33,6 +33,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
   exitSansCUDADevices();
 
   constexpr int defaultDevice = 0;
+  cudaCheck(cudaSetDevice(defaultDevice));
   {
     auto ctx = cudatest::TestCUDAScopedContext::make(defaultDevice, true);
     std::unique_ptr<CUDAProduct<int>> dataPtr = ctx.wrap(10);
@@ -59,9 +60,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
     }
   }
 
-  // Destroy and clean up all resources so that the next test can
-  // assume to start from a clean state.
   cudaCheck(cudaSetDevice(defaultDevice));
   cudaCheck(cudaDeviceSynchronize());
-  cudaDeviceReset();
+  // Note: CUDA resources are cleaned up by the destructors of the global cache objects
 }

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.cu
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.cu
@@ -69,7 +69,8 @@ cudautils::device::unique_ptr<float[]> TestCUDAProducerGPUKernel::runAlgo(const 
   // First make the sanity check
   if (d_input != nullptr) {
     auto h_check = std::make_unique<float[]>(NUM_VALUES);
-    cudaCheck(cudaMemcpy(h_check.get(), d_input, NUM_VALUES * sizeof(float), cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpyAsync(h_check.get(), d_input, NUM_VALUES * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaStreamSynchronize(stream));
     for (int i = 0; i < NUM_VALUES; ++i) {
       if (h_check[i] != i) {
         throw cms::Exception("Assert") << "Sanity check on element " << i << " failed, expected " << i << " got "


### PR DESCRIPTION
#### PR description:

The `CUDADataFormats/Common` unit test got broken at some point (likely by me, apologies). Problem is that the stream+event caches are effectively singletons, and the `cudaDeviceReset()` here makes the cached stream+event objects invalid before the caches are cleared in their destructors. I can't remember the motivation for the `cudaDeviceReset()`, so easiest fix was to remove it.

While testing the aforementioned fix, I noticed that `TestCUDAProducerGPUKernel.cu` got broken by making our CUDA streams no longer synchronize with the default stream. I fixed that with explicit `cudaStreamSynchronize()` in the test.

#### PR validation:

The unit test runs.