### PR TITLE
Small Optimization in doublet code

### DIFF
--- a/CUDADataFormats/Common/interface/CUDAProduct.h
+++ b/CUDADataFormats/Common/interface/CUDAProduct.h
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-#include <cuda/api_wrappers.h>
-
 #include "CUDADataFormats/Common/interface/CUDAProductBase.h"
 
 namespace edm {
@@ -44,11 +42,11 @@ private:
   friend class CUDAScopedContextProduce;
   friend class edm::Wrapper<CUDAProduct<T>>;
 
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, T data)
+  explicit CUDAProduct(int device, cudautils::SharedStreamPtr stream, T data)
       : CUDAProductBase(device, std::move(stream)), data_(std::move(data)) {}
 
   template <typename... Args>
-  explicit CUDAProduct(int device, std::shared_ptr<cuda::stream_t<>> stream, Args&&... args)
+  explicit CUDAProduct(int device, cudautils::SharedStreamPtr stream, Args&&... args)
       : CUDAProductBase(device, std::move(stream)), data_(std::forward<Args>(args)...) {}
 
   T data_;  //!

--- a/CUDADataFormats/Common/src/CUDAProductBase.cc
+++ b/CUDADataFormats/Common/src/CUDAProductBase.cc
@@ -7,7 +7,7 @@ bool CUDAProductBase::isAvailable() const {
   if (not event_) {
     return true;
   }
-  return cudautils::eventIsOccurred(event_->id());
+  return cudautils::eventIsOccurred(event_.get());
 }
 
 CUDAProductBase::~CUDAProductBase() {
@@ -18,6 +18,10 @@ CUDAProductBase::~CUDAProductBase() {
   if (event_) {
     // TODO: a callback notifying a WaitingTaskHolder (or similar)
     // would avoid blocking the CPU, but would also require more work.
-    event_->synchronize();
+    //
+    // Intentionally not checking the return value to avoid throwing
+    // exceptions. If this call would fail, we should get failures
+    // elsewhere as well.
+    cudaEventSynchronize(event_.get());
   }
 }

--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -33,6 +33,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
   exitSansCUDADevices();
 
   constexpr int defaultDevice = 0;
+  cudaCheck(cudaSetDevice(defaultDevice));
   {
     auto ctx = cudatest::TestCUDAScopedContext::make(defaultDevice, true);
     std::unique_ptr<CUDAProduct<int>> dataPtr = ctx.wrap(10);
@@ -59,9 +60,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
     }
   }
 
-  // Destroy and clean up all resources so that the next test can
-  // assume to start from a clean state.
   cudaCheck(cudaSetDevice(defaultDevice));
   cudaCheck(cudaDeviceSynchronize());
-  cudaDeviceReset();
+  // Note: CUDA resources are cleaned up by the destructors of the global cache objects
 }

--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -4,6 +4,8 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 
 #include <cuda_runtime_api.h>
 
@@ -11,15 +13,11 @@ namespace cudatest {
   class TestCUDAScopedContext {
   public:
     static CUDAScopedContextProduce make(int dev, bool createEvent) {
-      auto device = cuda::device::get(dev);
-      std::unique_ptr<cuda::event_t> event;
+      cudautils::SharedEventPtr event;
       if (createEvent) {
-        event = std::make_unique<cuda::event_t>(device.create_event());
+        event = cudautils::getCUDAEventCache().getCUDAEvent();
       }
-      return CUDAScopedContextProduce(dev,
-                                      std::make_unique<cuda::stream_t<>>(device.create_stream(
-                                          cuda::stream::implicitly_synchronizes_with_default_stream)),
-                                      std::move(event));
+      return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }
   };
 }  // namespace cudatest

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -13,7 +13,7 @@ int main() {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   // inner scope to deallocate memory before destroying the stream
   {

--- a/DataFormats/Math/test/testAtan2.cpp
+++ b/DataFormats/Math/test/testAtan2.cpp
@@ -195,6 +195,12 @@ void testIntPhi() {
 }
 
 int main() {
+
+  constexpr float p2i = ((int)(std::numeric_limits<short>::max()) + 1) / M_PI;
+  constexpr float i2p = M_PI / ((int)(std::numeric_limits<short>::max()) + 1);
+  std::cout << std::hexfloat << "p2i i2p " << p2i <<" "<< i2p << std::defaultfloat << std::endl;
+
+
   std::cout << unsafe_atan2f<5>(0.f, 0.f) << " " << std::atan2(0., 0.) << std::endl;
   std::cout << unsafe_atan2f<5>(0.5f, 0.5f) << " " << std::atan2(0.5, 0.5) << std::endl;
   std::cout << unsafe_atan2f<5>(0.5f, -0.5f) << " " << std::atan2(0.5, -0.5) << std::endl;

--- a/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h
@@ -33,6 +33,12 @@ namespace impl {
     const cudautils::SharedStreamPtr& streamPtr() const { return stream_; }
 
   protected:
+    // The constructors set the current device device, but the device
+    // is not set back to the previous value at the destructor. This
+    // should be sufficient (and tiny bit faster) as all CUDA API
+    // functions relying on the current device should be called from
+    // the scope where this context is. The current device doesn't
+    // really matter between modules (or across TBB tasks).
     explicit CUDAScopedContextBase(edm::StreamID streamID);
 
     explicit CUDAScopedContextBase(const CUDAProductBase& data);
@@ -41,7 +47,6 @@ namespace impl {
 
   private:
     int currentDevice_;
-    cuda::device::current::scoped_override_t<> setDeviceForThisScope_;
     cudautils::SharedStreamPtr stream_;
   };
 

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -39,12 +39,14 @@ namespace {
 
 namespace impl {
   CUDAScopedContextBase::CUDAScopedContextBase(edm::StreamID streamID)
-      : currentDevice_(cudacore::chooseCUDADevice(streamID)), setDeviceForThisScope_(currentDevice_) {
+      : currentDevice_(cudacore::chooseCUDADevice(streamID)) {
+    cudaCheck(cudaSetDevice(currentDevice_));
     stream_ = cudautils::getCUDAStreamCache().getCUDAStream();
   }
 
   CUDAScopedContextBase::CUDAScopedContextBase(const CUDAProductBase& data)
-      : currentDevice_(data.device()), setDeviceForThisScope_(currentDevice_) {
+      : currentDevice_(data.device()) {
+    cudaCheck(cudaSetDevice(currentDevice_));
     if (data.mayReuseStream()) {
       stream_ = data.streamPtr();
     } else {
@@ -53,7 +55,9 @@ namespace impl {
   }
 
   CUDAScopedContextBase::CUDAScopedContextBase(int device, cudautils::SharedStreamPtr stream)
-      : currentDevice_(device), setDeviceForThisScope_(device), stream_(std::move(stream)) {}
+      : currentDevice_(device), stream_(std::move(stream)) {
+    cudaCheck(cudaSetDevice(currentDevice_));
+  }
 
   ////////////////////
 

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -52,7 +52,7 @@ namespace impl {
     }
   }
 
-  CUDAScopedContextBase::CUDAScopedContextBase(int device, std::shared_ptr<cuda::stream_t<>> stream)
+  CUDAScopedContextBase::CUDAScopedContextBase(int device, cudautils::SharedStreamPtr stream)
       : currentDevice_(device), setDeviceForThisScope_(device), stream_(std::move(stream)) {}
 
   ////////////////////
@@ -106,7 +106,7 @@ void CUDAScopedContextAcquire::throwNoState() {
 
 CUDAScopedContextProduce::~CUDAScopedContextProduce() {
   if (event_) {
-    event_->record(stream());
+    cudaCheck(cudaEventRecord(event_.get(), stream()));
   }
 }
 

--- a/HeterogeneousCore/CUDACore/src/GPUCuda.cc
+++ b/HeterogeneousCore/CUDACore/src/GPUCuda.cc
@@ -52,7 +52,7 @@ namespace heterogeneous {
     // Create the CUDA stream for this module-edm::Stream pair
     auto current_device = cuda::device::current::get();
     cudaStream_ = std::make_unique<cuda::stream_t<>>(
-        current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream));
+        current_device.create_stream(cuda::stream::no_implicit_synchronization_with_default_stream));
 
     beginStreamGPUCuda(id, *cudaStream_);
   }

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -9,6 +9,8 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 
 #include "test_CUDAScopedContextKernels.h"
 
@@ -16,15 +18,11 @@ namespace cudatest {
   class TestCUDAScopedContext {
   public:
     static CUDAScopedContextProduce make(int dev, bool createEvent) {
-      auto device = cuda::device::get(dev);
-      std::unique_ptr<cuda::event_t> event;
+      cudautils::SharedEventPtr event;
       if (createEvent) {
-        event = std::make_unique<cuda::event_t>(device.create_event());
+        event = cudautils::getCUDAEventCache().getCUDAEvent();
       }
-      return CUDAScopedContextProduce(dev,
-                                      std::make_unique<cuda::stream_t<>>(device.create_stream(
-                                          cuda::stream::implicitly_synchronizes_with_default_stream)),
-                                      std::move(event));
+      return CUDAScopedContextProduce(dev, cudautils::getCUDAStreamCache().getCUDAStream(), std::move(event));
     }
   };
 }  // namespace cudatest

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -11,6 +11,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h"
 
 #include "test_CUDAScopedContextKernels.h"
 
@@ -84,7 +85,7 @@ TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
     }
 
     SECTION("Joining multiple CUDA streams") {
-      cuda::device::current::scoped_override_t<> setDeviceForThisScope(defaultDevice);
+      cudautils::ScopedSetDevice setDeviceForThisScope(defaultDevice);
       auto current_device = cuda::device::current::get();
 
       // Mimick a producer on the first CUDA stream

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -95,7 +95,7 @@ namespace {
     std::vector<UniquePtr<char[]> > buffers;
     buffers.reserve(bufferSizes.size());
     for (auto size : bufferSizes) {
-      buffers.push_back(allocate(size, streamPtr->id()));
+      buffers.push_back(allocate(size, streamPtr.get()));
     }
   }
 

--- a/HeterogeneousCore/CUDAServices/src/CUDAService.cc
+++ b/HeterogeneousCore/CUDAServices/src/CUDAService.cc
@@ -296,6 +296,14 @@ CUDAService::CUDAService(edm::ParameterSet const& config, edm::ActivityRegistry&
   }
   log << "\n";
 
+  // Make sure the caching allocators and stream/event caches are constructed before declaring successful construction
+  if constexpr (cudautils::allocator::useCaching) {
+    cudautils::allocator::getCachingDeviceAllocator();
+    cudautils::allocator::getCachingHostAllocator();
+  }
+  cudautils::getCUDAEventCache().clear();
+  cudautils::getCUDAStreamCache().clear();
+
   log << "CUDAService fully initialized";
   enabled_ = true;
 

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAAnalyzerGPU.cc
@@ -40,7 +40,7 @@ TestCUDAAnalyzerGPU::TestCUDAAnalyzerGPU(const edm::ParameterSet& iConfig)
   edm::Service<CUDAService> cs;
   if (cs->enabled()) {
     auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(streamPtr->id());
+    gpuAlgo_ = std::make_unique<TestCUDAAnalyzerGPUKernel>(streamPtr.get());
   }
 }
 
@@ -70,7 +70,7 @@ void TestCUDAAnalyzerGPU::endJob() {
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << " TestCUDAAnalyzerGPU::endJob begin";
 
   auto streamPtr = cudautils::getCUDAStreamCache().getCUDAStream();
-  auto value = gpuAlgo_->value(streamPtr->id());
+  auto value = gpuAlgo_->value(streamPtr.get());
   edm::LogVerbatim("TestCUDAAnalyzerGPU") << label_ << "  accumulated value " << value;
   assert(minValue_ <= value && value <= maxValue_);
 

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.cu
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.cu
@@ -69,7 +69,8 @@ cudautils::device::unique_ptr<float[]> TestCUDAProducerGPUKernel::runAlgo(const 
   // First make the sanity check
   if (d_input != nullptr) {
     auto h_check = std::make_unique<float[]>(NUM_VALUES);
-    cudaCheck(cudaMemcpy(h_check.get(), d_input, NUM_VALUES * sizeof(float), cudaMemcpyDeviceToHost));
+    cudaCheck(cudaMemcpyAsync(h_check.get(), d_input, NUM_VALUES * sizeof(float), cudaMemcpyDeviceToHost, stream));
+    cudaCheck(cudaStreamSynchronize(stream));
     for (int i = 0; i < NUM_VALUES; ++i) {
       if (h_check[i] != i) {
         throw cms::Exception("Assert") << "Sanity check on element " << i << " failed, expected " << i << " got "

--- a/HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h
@@ -1,30 +1,43 @@
 #ifndef HeterogeneousCore_CUDAUtilities_CUDAEventCache_h
 #define HeterogeneousCore_CUDAUtilities_CUDAEventCache_h
 
-#include <memory>
+#include <vector>
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h"
 
 class CUDAService;
 
 namespace cudautils {
   class CUDAEventCache {
   public:
+    using BareEvent = SharedEventPtr::element_type;
+
     CUDAEventCache();
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor.
     // This function is thread safe
-    std::shared_ptr<cuda::event_t> getCUDAEvent();
+    SharedEventPtr getCUDAEvent();
 
   private:
     friend class ::CUDAService;
     // intended to be called only from CUDAService destructor
     void clear();
 
-    std::vector<edm::ReusableObjectHolder<cuda::event_t>> cache_;
+    class Deleter {
+    public:
+      Deleter() = default;
+      Deleter(int d) : device_{d} {}
+      void operator()(cudaEvent_t event) const;
+
+    private:
+      int device_ = -1;
+    };
+
+    std::vector<edm::ReusableObjectHolder<BareEvent, Deleter>> cache_;
   };
 
   // Gets the global instance of a CUDAEventCache

--- a/HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h
@@ -1,30 +1,43 @@
 #ifndef HeterogeneousCore_CUDAUtilities_CUDAStreamCache_h
 #define HeterogeneousCore_CUDAUtilities_CUDAStreamCache_h
 
-#include <memory>
+#include <vector>
 
-#include <cuda/api_wrappers.h>
+#include <cuda_runtime.h>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
 
 class CUDAService;
 
 namespace cudautils {
   class CUDAStreamCache {
   public:
+    using BareStream = SharedStreamPtr::element_type;
+
     CUDAStreamCache();
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
     // This function is thread safe
-    std::shared_ptr<cuda::stream_t<>> getCUDAStream();
+    SharedStreamPtr getCUDAStream();
 
   private:
     friend class ::CUDAService;
     // intended to be called only from CUDAService destructor
     void clear();
 
-    std::vector<edm::ReusableObjectHolder<cuda::stream_t<>>> cache_;
+    class Deleter {
+    public:
+      Deleter() = default;
+      Deleter(int d) : device_{d} {}
+      void operator()(cudaStream_t stream) const;
+
+    private:
+      int device_ = -1;
+    };
+
+    std::vector<edm::ReusableObjectHolder<BareStream, Deleter>> cache_;
   };
 
   // Gets the global instance of a CUDAStreamCache

--- a/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h
@@ -1,0 +1,28 @@
+#ifndef HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+#define HeterogeneousCore_CUDAUtilities_ScopedSetDevice_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  class ScopedSetDevice {
+  public:
+    explicit ScopedSetDevice(int newDevice) {
+      cudaCheck(cudaGetDevice(&prevDevice_));
+      cudaCheck(cudaSetDevice(newDevice));
+    }
+
+    ~ScopedSetDevice() {
+      // Intentionally don't check the return value to avoid
+      // exceptions to be thrown. If this call fails, the process is
+      // doomed anyway.
+      cudaSetDevice(prevDevice_);
+    }
+
+  private:
+    int prevDevice_;
+  };
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/SharedEventPtr.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedEventPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  // cudaEvent_t itself is a typedef for a pointer, for the use with
+  // edm::ReusableObjectHolder the pointed-to type is more interesting
+  // to avoid extra layer of indirection
+  using SharedEventPtr = std::shared_ptr<std::remove_pointer_t<cudaEvent_t>>;
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+#define HeterogeneousCore_CUDAUtilities_SharedStreamPtr_h
+
+#include <memory>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  // cudaStream_t itself is a typedef for a pointer, for the use with
+  // edm::ReusableObjectHolder the pointed-to type is more interesting
+  // to avoid extra layer of indirection
+  using SharedStreamPtr = std::shared_ptr<std::remove_pointer_t<cudaStream_t>>;
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -4,6 +4,7 @@
 // C++ standard headers
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 // CUDA headers
 #include <cuda.h>
@@ -18,8 +19,7 @@ namespace {
     out << file << ", line " << line << ":\n";
     out << "cudaCheck(" << cmd << ");\n";
     out << error << ": " << message << "\n";
-    std::cerr << out.str() << std::flush;
-    abort();
+    throw std::runtime_error(out.str());
   }
 
 }  // namespace

--- a/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/currentDevice.h
@@ -1,0 +1,16 @@
+#ifndef HeterogenousCore_CUDAUtilities_currentDevice_h
+#define HeterogenousCore_CUDAUtilities_currentDevice_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include <cuda_runtime.h>
+
+namespace cudautils {
+  inline int currentDevice() {
+    int dev;
+    cudaCheck(cudaGetDevice(&dev));
+    return dev;
+  }
+}  // namespace cudautils
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/src/CUDAStreamCache.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/CUDAStreamCache.cc
@@ -21,7 +21,7 @@ namespace cudautils {
     const auto dev = cudautils::currentDevice();
     return cache_[dev].makeOrGet([dev]() {
       cudaStream_t stream;
-      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamDefault));
+      cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
       return std::unique_ptr<BareStream, Deleter>(stream, Deleter{dev});
     });
   }

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
@@ -1,5 +1,6 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/allocate_device.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
 #include "getCachingDeviceAllocator.h"
@@ -23,7 +24,7 @@ namespace cudautils {
       }
       cuda::throw_if_error(cudautils::allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
     } else {
-      cuda::device::current::scoped_override_t<> setDeviceForThisScope(dev);
+      ScopedSetDevice setDeviceForThisScope(dev);
       cuda::throw_if_error(cudaMalloc(&ptr, nbytes));
     }
     return ptr;
@@ -33,7 +34,7 @@ namespace cudautils {
     if constexpr (cudautils::allocator::useCaching) {
       cuda::throw_if_error(cudautils::allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
     } else {
-      cuda::device::current::scoped_override_t<> setDeviceForThisScope(device);
+      ScopedSetDevice setDeviceForThisScope(device);
       cuda::throw_if_error(cudaFree(ptr));
     }
   }

--- a/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
@@ -18,7 +18,7 @@ namespace cudautils {
     // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator
     constexpr unsigned int minBin = 1;
     // Largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
-    constexpr unsigned int maxBin = 9;
+    constexpr unsigned int maxBin = 10;
     // Total storage for the allocator. 0 means no limit.
     constexpr size_t maxCachedBytes = 0;
     // Fraction of total device memory taken for the allocator. In case there are multiple devices with different amounts of memory, the smallest of them is taken. If maxCachedBytes is non-zero, the smallest of them is taken.

--- a/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
@@ -10,7 +10,7 @@ TEST_CASE("copyAsync", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Host to device") {
     SECTION("Single element") {

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -8,7 +8,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cudautils::make_device_unique<int>(stream);

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -30,7 +30,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   }
 
   SECTION("Allocating too much") {
-    constexpr size_t maxSize = 1 << 27;  // 8**9
+    constexpr size_t maxSize = 1 << 30;  // 8**10
     auto ptr = cudautils::make_device_unique<char[]>(maxSize, stream);
     ptr.reset();
     REQUIRE_THROWS(ptr = cudautils::make_device_unique<char[]>(maxSize + 1, stream));

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -8,7 +8,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto ptr = cudautils::make_host_unique<int>(stream);

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -29,7 +29,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   }
 
   SECTION("Allocating too much") {
-    constexpr size_t maxSize = 1 << 27;  // 8**9
+    constexpr size_t maxSize = 1 << 30;  // 8**10
     auto ptr = cudautils::make_host_unique<char[]>(maxSize, stream);
     ptr.reset();
     REQUIRE_THROWS(ptr = cudautils::make_host_unique<char[]>(maxSize + 1, stream));

--- a/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
@@ -11,7 +11,7 @@ TEST_CASE("memsetAsync", "[cudaMemTools]") {
   exitSansCUDADevices();
 
   cudaStream_t stream;
-  cudaCheck(cudaStreamCreate(&stream));
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   SECTION("Single element") {
     auto host_orig = cudautils::make_host_unique<int>(stream);

--- a/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUHelpers.cu
+++ b/HeterogeneousCore/Producer/test/TestHeterogeneousEDProducerGPUHelpers.cu
@@ -64,7 +64,7 @@ int TestAcceleratorServiceProducerGPUHelpers_simple_kernel(int input) {
   constexpr int NUM_VALUES = 10000;
 
   auto current_device = cuda::device::current::get();
-  auto stream = current_device.create_stream(cuda::stream::implicitly_synchronizes_with_default_stream);
+  auto stream = current_device.create_stream(cuda::stream::no_implicit_synchronization_with_default_stream);
 
   auto h_a = cudautils::make_host_unique<int[]>(NUM_VALUES, nullptr);
   auto h_b = cudautils::make_host_unique<int[]>(NUM_VALUES, nullptr);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -15,10 +15,14 @@
 namespace CAConstants {
 
   // constants
+#ifndef ONLY_PHICUT
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
   constexpr uint32_t maxNumberOfTuples() { return 24 * 1024; }
+#endif
+#else
+  constexpr uint32_t maxNumberOfTuples() { return 48 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
@@ -30,8 +34,8 @@ namespace CAConstants {
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 448 * 1024; }
-  constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
+  constexpr uint32_t maxNumberOfDoublets() { return 2*1024 * 1024; }
+  constexpr uint32_t maxCellsPerHit() { return 8 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
 
@@ -43,8 +47,13 @@ namespace CAConstants {
   using hindex_type = uint16_t;  // FIXME from siPixelRecHitsHeterogeneousProduct
   using tindex_type = uint16_t;  //  for tuples
 
+#ifndef ONLY_PHICUT
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
   using CellTracks = GPU::VecArray<tindex_type, 42>;
+#else
+  using CellNeighbors = GPU::VecArray<uint32_t, 64>;
+  using CellTracks = GPU::VecArray<tindex_type, 64>;
+#endif
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -54,8 +54,8 @@ void CAHitNtupletGeneratorKernelsCPU::buildDoublets(HitsOnCPU const &hh, cudaStr
                                          nActualPairs,
                                          m_params.idealConditions_,
                                          m_params.doClusterCut_,
-                                         m_params.doZCut_,
-                                         m_params.doPhiCut_,
+                                         m_params.doZ0Cut_,
+                                         m_params.doPtCut_,
                                          m_params.maxNumberOfDoublets_);
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -208,8 +208,8 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
                                                                     nActualPairs,
                                                                     m_params.idealConditions_,
                                                                     m_params.doClusterCut_,
-                                                                    m_params.doZCut_,
-                                                                    m_params.doPhiCut_,
+                                                                    m_params.doZ0Cut_,
+                                                                    m_params.doPtCut_,
                                                                     m_params.maxNumberOfDoublets_);
   cudaCheck(cudaGetLastError());
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -194,9 +194,9 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   }
 
   assert(nActualPairs <= gpuPixelDoublets::nPairs);
-  int stride = 1;
+  int stride = 4;
   int threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
-  int blocks = (2 * nhits + threadsPerBlock - 1) / threadsPerBlock;
+  int blocks = (4 * nhits + threadsPerBlock - 1) / threadsPerBlock;
   dim3 blks(1, blocks, 1);
   dim3 thrs(stride, threadsPerBlock, 1);
   gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0, stream>>>(device_theCells_.get(),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -62,8 +62,8 @@ namespace cAHitNtupletGenerator {
            bool idealConditions,
            bool doStats,
            bool doClusterCut,
-           bool doZCut,
-           bool doPhiCut,
+           bool doZ0Cut,
+           bool doPtCut,
            float ptmin,
            float CAThetaCutBarrel,
            float CAThetaCutForward,
@@ -82,8 +82,8 @@ namespace cAHitNtupletGenerator {
           idealConditions_(idealConditions),
           doStats_(doStats),
           doClusterCut_(doClusterCut),
-          doZCut_(doZCut),
-          doPhiCut_(doPhiCut),
+          doZ0Cut_(doZ0Cut),
+          doPtCut_(doPtCut),
           ptmin_(ptmin),
           CAThetaCutBarrel_(CAThetaCutBarrel),
           CAThetaCutForward_(CAThetaCutForward),
@@ -103,8 +103,8 @@ namespace cAHitNtupletGenerator {
     const bool idealConditions_;
     const bool doStats_;
     const bool doClusterCut_;
-    const bool doZCut_;
-    const bool doPhiCut_;
+    const bool doZ0Cut_;
+    const bool doPtCut_;
     const float ptmin_;
     const float CAThetaCutBarrel_;
     const float CAThetaCutForward_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -63,8 +63,8 @@ CAHitNtupletGeneratorOnGPU::CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& 
                cfg.getParameter<bool>("idealConditions"),
                cfg.getParameter<bool>("fillStatistics"),
                cfg.getParameter<bool>("doClusterCut"),
-               cfg.getParameter<bool>("doZCut"),
-               cfg.getParameter<bool>("doPhiCut"),
+               cfg.getParameter<bool>("doZ0Cut"),
+               cfg.getParameter<bool>("doPtCut"),
                cfg.getParameter<double>("ptmin"),
                cfg.getParameter<double>("CAThetaCutBarrel"),
                cfg.getParameter<double>("CAThetaCutForward"),
@@ -135,8 +135,8 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   desc.add<bool>("includeJumpingForwardDoublets", false);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
-  desc.add<bool>("doZCut", true);
-  desc.add<bool>("doPhiCut", true);
+  desc.add<bool>("doZ0Cut", true);
+  desc.add<bool>("doPtCut", true);
   desc.add<bool>("useRiemannFit", false)->setComment("true for Riemann, false for BrokenLine");
 
   edm::ParameterSetDescription trackQualityCuts;

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -93,8 +93,8 @@ namespace gpuPixelDoublets {
                                 int nActualPairs,
                                 bool ideal_cond,
                                 bool doClusterCut,
-                                bool doZCut,
-                                bool doPhiCut,
+                                bool doZ0Cut,
+                                bool doPtCut,
                                 uint32_t maxNumOfDoublets) {
     auto const& __restrict__ hh = *hhp;
     doubletsFromHisto(layerPairs,
@@ -111,8 +111,8 @@ namespace gpuPixelDoublets {
                       maxr,
                       ideal_cond,
                       doClusterCut,
-                      doZCut,
-                      doPhiCut,
+                      doZ0Cut,
+                      doPtCut,
                       maxNumOfDoublets);
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -36,8 +36,8 @@ namespace gpuPixelDoubletsAlgos {
                                                     float const* __restrict__ maxr,
                                                     bool ideal_cond,
                                                     bool doClusterCut,
-                                                    bool doZCut,
-                                                    bool doPhiCut,
+                                                    bool doZ0Cut,
+                                                    bool doPtCut,
                                                     uint32_t maxNumOfDoublets) {
     // ysize cuts (z in the barrel)  times 8
     // these are used if doClusterCut is true
@@ -115,10 +115,9 @@ namespace gpuPixelDoubletsAlgos {
       */
 
       auto mez = hh.zGlobal(i);
-      
-      if (doZCut && (mez < minz[pairLayerId] || mez > maxz[pairLayerId]))
+
+      if (mez < minz[pairLayerId] || mez > maxz[pairLayerId])
         continue;
-      
 
       int16_t mes = -1;  // make compiler happy
       if (doClusterCut) {
@@ -204,20 +203,16 @@ namespace gpuPixelDoubletsAlgos {
           auto mo = hh.detectorIndex(oi);
           if (mo > 2000)
             continue;  //    invalid
-
-
-          if (z0cutoff(oi)) continue;
+          
+          if (doZ0Cut && z0cutoff(oi)) continue;
 
           auto mop = hh.iphi(oi);
           uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
           if (idphi > iphicut)  continue;
 
-          if (doPhiCut) {
-            if (doClusterCut && zsizeCut(oi))
-              continue;
-            if (ptcut(oi, idphi))
-              continue;
-          }
+         if (doClusterCut && zsizeCut(oi)) continue;
+         if (doPtCut && ptcut(oi, idphi)) continue;
+      
           auto ind = atomicAdd(nCells, 1);
           if (ind >= maxNumOfDoublets) {
             atomicSub(nCells, 1);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -108,10 +108,17 @@ namespace gpuPixelDoubletsAlgos {
       if (mi > 2000)
         continue;  // invalid
 
-      auto mez = hh.zGlobal(i);
+      /* maybe clever, not effective when zoCut is on
+      auto bpos = (mi%8)/4;  // if barrel is 1 for z>0
+      auto fpos = (outer>3) & (outer<7);
+      if ( ((inner<3) & (outer>3)) && bpos!=fpos) continue;
+      */
 
+      auto mez = hh.zGlobal(i);
+      
       if (doZCut && (mez < minz[pairLayerId] || mez > maxz[pairLayerId]))
         continue;
+      
 
       int16_t mes = -1;  // make compiler happy
       if (doClusterCut) {
@@ -139,12 +146,11 @@ namespace gpuPixelDoubletsAlgos {
       constexpr float minRadius =
           hardPtCut * 87.78f;  // cm (1 GeV track has 1 GeV/c / (e * 3.8T) ~ 87 cm radius in a 3.8T field)
       constexpr float minRadius2T4 = 4.f * minRadius * minRadius;
-      auto ptcut = [&](int j, int16_t mop) {
+      auto ptcut = [&](int j, int16_t idphi) {
         auto r2t4 = minRadius2T4;
         auto ri = mer;
         auto ro = hh.rGlobal(j);
-        // auto mop = hh.iphi(j);
-        auto dphi = short2phi(std::min(std::abs(int16_t(mep - mop)), std::abs(int16_t(mop - mep))));
+        auto dphi = short2phi(idphi);
         return dphi * dphi * (r2t4 - ri * ro) > (ro - ri) * (ro - ri);
       };
       auto z0cutoff = [&](int j) {
@@ -173,6 +179,7 @@ namespace gpuPixelDoubletsAlgos {
       auto kl = Hist::bin(int16_t(mep - iphicut));
       auto kh = Hist::bin(int16_t(mep + iphicut));
       auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
+      // bool piWrap = std::abs(kh-kl) > Hist::nbins()/2;
 
 #ifdef GPU_DEBUG
       int tot = 0;
@@ -197,13 +204,18 @@ namespace gpuPixelDoubletsAlgos {
           auto mo = hh.detectorIndex(oi);
           if (mo > 2000)
             continue;  //    invalid
+
+
+          if (z0cutoff(oi)) continue;
+
           auto mop = hh.iphi(oi);
-          if (std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop))) > iphicut)
-            continue;
+          uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
+          if (idphi > iphicut)  continue;
+
           if (doPhiCut) {
             if (doClusterCut && zsizeCut(oi))
               continue;
-            if (z0cutoff(oi) || ptcut(oi, mop))
+            if (ptcut(oi, idphi))
               continue;
           }
           auto ind = atomicAdd(nCells, 1);


### PR DESCRIPTION
reordering of cuts and some factorization that speed up doublets a bit.
I also redimensioned the various buffers not to overflow in case of very relaxed cuts.
I alos renamed some configurable to better reflect their actual action in code

With this version on Patatrack02's T4 I measured a throughput in excess of 1KHz for Quadruplets
(and of ~540Hz for Triplets) for a single job