### PR TITLE
Small Optimization in doublet code

### DIFF
--- a/DataFormats/Math/test/testAtan2.cpp
+++ b/DataFormats/Math/test/testAtan2.cpp
@@ -195,6 +195,12 @@ void testIntPhi() {
 }
 
 int main() {
+
+  constexpr float p2i = ((int)(std::numeric_limits<short>::max()) + 1) / M_PI;
+  constexpr float i2p = M_PI / ((int)(std::numeric_limits<short>::max()) + 1);
+  std::cout << std::hexfloat << "p2i i2p " << p2i <<" "<< i2p << std::defaultfloat << std::endl;
+
+
   std::cout << unsafe_atan2f<5>(0.f, 0.f) << " " << std::atan2(0., 0.) << std::endl;
   std::cout << unsafe_atan2f<5>(0.5f, 0.5f) << " " << std::atan2(0.5, 0.5) << std::endl;
   std::cout << unsafe_atan2f<5>(0.5f, -0.5f) << " " << std::atan2(0.5, -0.5) << std::endl;

--- a/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
@@ -18,7 +18,7 @@ namespace cudautils {
     // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator
     constexpr unsigned int minBin = 1;
     // Largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
-    constexpr unsigned int maxBin = 9;
+    constexpr unsigned int maxBin = 10;
     // Total storage for the allocator. 0 means no limit.
     constexpr size_t maxCachedBytes = 0;
     // Fraction of total device memory taken for the allocator. In case there are multiple devices with different amounts of memory, the smallest of them is taken. If maxCachedBytes is non-zero, the smallest of them is taken.

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -30,7 +30,7 @@ TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
   }
 
   SECTION("Allocating too much") {
-    constexpr size_t maxSize = 1 << 27;  // 8**9
+    constexpr size_t maxSize = 1 << 30;  // 8**10
     auto ptr = cudautils::make_device_unique<char[]>(maxSize, stream);
     ptr.reset();
     REQUIRE_THROWS(ptr = cudautils::make_device_unique<char[]>(maxSize + 1, stream));

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -29,7 +29,7 @@ TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
   }
 
   SECTION("Allocating too much") {
-    constexpr size_t maxSize = 1 << 27;  // 8**9
+    constexpr size_t maxSize = 1 << 30;  // 8**10
     auto ptr = cudautils::make_host_unique<char[]>(maxSize, stream);
     ptr.reset();
     REQUIRE_THROWS(ptr = cudautils::make_host_unique<char[]>(maxSize + 1, stream));

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -10,7 +10,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
 
-#define ONLY_PHICUT
+// #define ONLY_PHICUT
 
 namespace CAConstants {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -10,15 +10,19 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUVecArray.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
 
-// #define ONLY_PHICUT
+#define ONLY_PHICUT
 
 namespace CAConstants {
 
   // constants
+#ifndef ONLY_PHICUT
 #ifdef GPU_SMALL_EVENTS
   constexpr uint32_t maxNumberOfTuples() { return 3 * 1024; }
 #else
   constexpr uint32_t maxNumberOfTuples() { return 24 * 1024; }
+#endif
+#else
+  constexpr uint32_t maxNumberOfTuples() { return 48 * 1024; }
 #endif
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
@@ -30,8 +34,8 @@ namespace CAConstants {
   constexpr uint32_t maxCellsPerHit() { return 128 / 2; }
 #endif
 #else
-  constexpr uint32_t maxNumberOfDoublets() { return 448 * 1024; }
-  constexpr uint32_t maxCellsPerHit() { return 4 * 128; }
+  constexpr uint32_t maxNumberOfDoublets() { return 2*1024 * 1024; }
+  constexpr uint32_t maxCellsPerHit() { return 8 * 128; }
 #endif
   constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
 
@@ -43,8 +47,13 @@ namespace CAConstants {
   using hindex_type = uint16_t;  // FIXME from siPixelRecHitsHeterogeneousProduct
   using tindex_type = uint16_t;  //  for tuples
 
+#ifndef ONLY_PHICUT
   using CellNeighbors = GPU::VecArray<uint32_t, 36>;
   using CellTracks = GPU::VecArray<tindex_type, 42>;
+#else
+  using CellNeighbors = GPU::VecArray<uint32_t, 64>;
+  using CellTracks = GPU::VecArray<tindex_type, 64>;
+#endif
 
   using CellNeighborsVector = GPU::SimpleVector<CellNeighbors>;
   using CellTracksVector = GPU::SimpleVector<CellTracks>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -54,8 +54,8 @@ void CAHitNtupletGeneratorKernelsCPU::buildDoublets(HitsOnCPU const &hh, cudaStr
                                          nActualPairs,
                                          m_params.idealConditions_,
                                          m_params.doClusterCut_,
-                                         m_params.doZCut_,
-                                         m_params.doPhiCut_,
+                                         m_params.doZ0Cut_,
+                                         m_params.doPtCut_,
                                          m_params.maxNumberOfDoublets_);
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -208,8 +208,8 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
                                                                     nActualPairs,
                                                                     m_params.idealConditions_,
                                                                     m_params.doClusterCut_,
-                                                                    m_params.doZCut_,
-                                                                    m_params.doPhiCut_,
+                                                                    m_params.doZ0Cut_,
+                                                                    m_params.doPtCut_,
                                                                     m_params.maxNumberOfDoublets_);
   cudaCheck(cudaGetLastError());
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -194,9 +194,9 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   }
 
   assert(nActualPairs <= gpuPixelDoublets::nPairs);
-  int stride = 1;
+  int stride = 4;
   int threadsPerBlock = gpuPixelDoublets::getDoubletsFromHistoMaxBlockSize / stride;
-  int blocks = (2 * nhits + threadsPerBlock - 1) / threadsPerBlock;
+  int blocks = (4 * nhits + threadsPerBlock - 1) / threadsPerBlock;
   dim3 blks(1, blocks, 1);
   dim3 thrs(stride, threadsPerBlock, 1);
   gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0, stream>>>(device_theCells_.get(),

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -62,8 +62,8 @@ namespace cAHitNtupletGenerator {
            bool idealConditions,
            bool doStats,
            bool doClusterCut,
-           bool doZCut,
-           bool doPhiCut,
+           bool doZ0Cut,
+           bool doPtCut,
            float ptmin,
            float CAThetaCutBarrel,
            float CAThetaCutForward,
@@ -82,8 +82,8 @@ namespace cAHitNtupletGenerator {
           idealConditions_(idealConditions),
           doStats_(doStats),
           doClusterCut_(doClusterCut),
-          doZCut_(doZCut),
-          doPhiCut_(doPhiCut),
+          doZ0Cut_(doZ0Cut),
+          doPtCut_(doPtCut),
           ptmin_(ptmin),
           CAThetaCutBarrel_(CAThetaCutBarrel),
           CAThetaCutForward_(CAThetaCutForward),
@@ -103,8 +103,8 @@ namespace cAHitNtupletGenerator {
     const bool idealConditions_;
     const bool doStats_;
     const bool doClusterCut_;
-    const bool doZCut_;
-    const bool doPhiCut_;
+    const bool doZ0Cut_;
+    const bool doPtCut_;
     const float ptmin_;
     const float CAThetaCutBarrel_;
     const float CAThetaCutForward_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -63,8 +63,8 @@ CAHitNtupletGeneratorOnGPU::CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& 
                cfg.getParameter<bool>("idealConditions"),
                cfg.getParameter<bool>("fillStatistics"),
                cfg.getParameter<bool>("doClusterCut"),
-               cfg.getParameter<bool>("doZCut"),
-               cfg.getParameter<bool>("doPhiCut"),
+               cfg.getParameter<bool>("doZ0Cut"),
+               cfg.getParameter<bool>("doPtCut"),
                cfg.getParameter<double>("ptmin"),
                cfg.getParameter<double>("CAThetaCutBarrel"),
                cfg.getParameter<double>("CAThetaCutForward"),
@@ -135,8 +135,8 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   desc.add<bool>("includeJumpingForwardDoublets", false);
   desc.add<bool>("fit5as4", true);
   desc.add<bool>("doClusterCut", true);
-  desc.add<bool>("doZCut", true);
-  desc.add<bool>("doPhiCut", true);
+  desc.add<bool>("doZ0Cut", true);
+  desc.add<bool>("doPtCut", true);
   desc.add<bool>("useRiemannFit", false)->setComment("true for Riemann, false for BrokenLine");
 
   edm::ParameterSetDescription trackQualityCuts;

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -93,8 +93,8 @@ namespace gpuPixelDoublets {
                                 int nActualPairs,
                                 bool ideal_cond,
                                 bool doClusterCut,
-                                bool doZCut,
-                                bool doPhiCut,
+                                bool doZ0Cut,
+                                bool doPtCut,
                                 uint32_t maxNumOfDoublets) {
     auto const& __restrict__ hh = *hhp;
     doubletsFromHisto(layerPairs,
@@ -111,8 +111,8 @@ namespace gpuPixelDoublets {
                       maxr,
                       ideal_cond,
                       doClusterCut,
-                      doZCut,
-                      doPhiCut,
+                      doZ0Cut,
+                      doPtCut,
                       maxNumOfDoublets);
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -108,10 +108,17 @@ namespace gpuPixelDoubletsAlgos {
       if (mi > 2000)
         continue;  // invalid
 
-      auto mez = hh.zGlobal(i);
+      /* maybe clever, not effective when zoCut is on
+      auto bpos = (mi%8)/4;  // if barrel is 1 for z>0
+      auto fpos = (outer>3) & (outer<7);
+      if ( ((inner<3) & (outer>3)) && bpos!=fpos) continue;
+      */
 
+      auto mez = hh.zGlobal(i);
+      
       if (doZCut && (mez < minz[pairLayerId] || mez > maxz[pairLayerId]))
         continue;
+      
 
       int16_t mes = -1;  // make compiler happy
       if (doClusterCut) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -36,8 +36,8 @@ namespace gpuPixelDoubletsAlgos {
                                                     float const* __restrict__ maxr,
                                                     bool ideal_cond,
                                                     bool doClusterCut,
-                                                    bool doZCut,
-                                                    bool doPhiCut,
+                                                    bool doZ0Cut,
+                                                    bool doPtCut,
                                                     uint32_t maxNumOfDoublets) {
     // ysize cuts (z in the barrel)  times 8
     // these are used if doClusterCut is true
@@ -115,10 +115,9 @@ namespace gpuPixelDoubletsAlgos {
       */
 
       auto mez = hh.zGlobal(i);
-      
-      if (doZCut && (mez < minz[pairLayerId] || mez > maxz[pairLayerId]))
+
+      if (mez < minz[pairLayerId] || mez > maxz[pairLayerId])
         continue;
-      
 
       int16_t mes = -1;  // make compiler happy
       if (doClusterCut) {
@@ -204,20 +203,16 @@ namespace gpuPixelDoubletsAlgos {
           auto mo = hh.detectorIndex(oi);
           if (mo > 2000)
             continue;  //    invalid
-
-
-          if (z0cutoff(oi)) continue;
+          
+          if (doZ0Cut && z0cutoff(oi)) continue;
 
           auto mop = hh.iphi(oi);
           uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
           if (idphi > iphicut)  continue;
 
-          if (doPhiCut) {
-            if (doClusterCut && zsizeCut(oi))
-              continue;
-            if (ptcut(oi, idphi))
-              continue;
-          }
+         if (doClusterCut && zsizeCut(oi)) continue;
+         if (doPtCut && ptcut(oi, idphi)) continue;
+      
           auto ind = atomicAdd(nCells, 1);
           if (ind >= maxNumOfDoublets) {
             atomicSub(nCells, 1);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -197,6 +197,10 @@ namespace gpuPixelDoubletsAlgos {
           auto mo = hh.detectorIndex(oi);
           if (mo > 2000)
             continue;  //    invalid
+
+
+          if (z0cutoff(oi)) continue;
+
           auto mop = hh.iphi(oi);
           uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
           if (idphi > iphicut)  continue;
@@ -204,7 +208,7 @@ namespace gpuPixelDoubletsAlgos {
           if (doPhiCut) {
             if (doClusterCut && zsizeCut(oi))
               continue;
-            if (z0cutoff(oi) || ptcut(oi, idphi))
+            if (ptcut(oi, idphi))
               continue;
           }
           auto ind = atomicAdd(nCells, 1);

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoubletsAlgos.h
@@ -139,12 +139,11 @@ namespace gpuPixelDoubletsAlgos {
       constexpr float minRadius =
           hardPtCut * 87.78f;  // cm (1 GeV track has 1 GeV/c / (e * 3.8T) ~ 87 cm radius in a 3.8T field)
       constexpr float minRadius2T4 = 4.f * minRadius * minRadius;
-      auto ptcut = [&](int j, int16_t mop) {
+      auto ptcut = [&](int j, int16_t idphi) {
         auto r2t4 = minRadius2T4;
         auto ri = mer;
         auto ro = hh.rGlobal(j);
-        // auto mop = hh.iphi(j);
-        auto dphi = short2phi(std::min(std::abs(int16_t(mep - mop)), std::abs(int16_t(mop - mep))));
+        auto dphi = short2phi(idphi);
         return dphi * dphi * (r2t4 - ri * ro) > (ro - ri) * (ro - ri);
       };
       auto z0cutoff = [&](int j) {
@@ -173,6 +172,7 @@ namespace gpuPixelDoubletsAlgos {
       auto kl = Hist::bin(int16_t(mep - iphicut));
       auto kh = Hist::bin(int16_t(mep + iphicut));
       auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
+      // bool piWrap = std::abs(kh-kl) > Hist::nbins()/2;
 
 #ifdef GPU_DEBUG
       int tot = 0;
@@ -198,12 +198,13 @@ namespace gpuPixelDoubletsAlgos {
           if (mo > 2000)
             continue;  //    invalid
           auto mop = hh.iphi(oi);
-          if (std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop))) > iphicut)
-            continue;
+          uint16_t idphi = std::min(std::abs(int16_t(mop - mep)), std::abs(int16_t(mep - mop)));
+          if (idphi > iphicut)  continue;
+
           if (doPhiCut) {
             if (doClusterCut && zsizeCut(oi))
               continue;
-            if (z0cutoff(oi) || ptcut(oi, mop))
+            if (z0cutoff(oi) || ptcut(oi, idphi))
               continue;
           }
           auto ind = atomicAdd(nCells, 1);


### PR DESCRIPTION
Reordering of cuts and some factorization that speed up doublets a bit.
I also redimensioned the various buffers not to overflow in case of very relaxed cuts.
I alos renamed some configurable to better reflect their actual action in code

With this version on Patatrack02's T4 I measured a throughput in excess of 1KHz for Quadruplets
(and of ~540Hz for Triplets) for a single job