### PR TITLE
Implement Vertex finder with one kernel instead of 5

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducerCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducerCUDA.cc
@@ -44,7 +44,8 @@ private:
 
 PixelVertexProducerCUDA::PixelVertexProducerCUDA(const edm::ParameterSet& conf)
     : m_OnGPU(conf.getParameter<bool>("onGPU")),
-      m_gpuAlgo(conf.getParameter<bool>("useDensity"),
+      m_gpuAlgo(conf.getParameter<bool>("oneKernel"),
+                conf.getParameter<bool>("useDensity"),
                 conf.getParameter<bool>("useDBSCAN"),
                 conf.getParameter<bool>("useIterative"),
                 conf.getParameter<int>("minT"),
@@ -68,6 +69,7 @@ void PixelVertexProducerCUDA::fillDescriptions(edm::ConfigurationDescriptions& d
   // Only one of these three algos can be used at once.
   // Maybe this should become a Plugin Factory
   desc.add<bool>("onGPU", true);
+  desc.add<bool>("oneKernel", true);
   desc.add<bool>("useDensity", true);
   desc.add<bool>("useDBSCAN", false);
   desc.add<bool>("useIterative", false);

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuClusterTracksByDensity.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuClusterTracksByDensity.h
@@ -17,7 +17,7 @@ namespace gpuVertexFinder {
   //
   // based on Rodrighez&Laio algo
   //
-  __global__ void clusterTracksByDensity(gpuVertexFinder::ZVertices* pdata,
+  __device__ __forceinline__ void clusterTracksByDensity(gpuVertexFinder::ZVertices* pdata,
                                          gpuVertexFinder::WorkSpace* pws,
                                          int minT,      // min number of neighbours to be "seed"
                                          float eps,     // max absolute distance to cluster
@@ -218,6 +218,16 @@ namespace gpuVertexFinder {
     if (verbose && 0 == threadIdx.x)
       printf("found %d proto vertices\n", foundClusters);
   }
+
+  __global__ void clusterTracksByDensityKernel(gpuVertexFinder::ZVertices* pdata,
+                                         gpuVertexFinder::WorkSpace* pws,
+                                         int minT,    // min number of neighbours to be "seed"
+                                         float eps,     // max absolute distance to cluster
+                                         float errmax,  // max error to be "seed"
+                                         float chi2max  // max normalized distance to cluster
+  ) {
+   clusterTracksByDensity(pdata,pws,minT,eps,errmax,chi2max);
+ }
 
 }  // namespace gpuVertexFinder
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuFitVertices.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuFitVertices.h
@@ -12,7 +12,7 @@
 
 namespace gpuVertexFinder {
 
-  __global__ void fitVertices(ZVertices* pdata,
+  __device__ __forceinline__ void fitVertices(ZVertices* pdata,
                               WorkSpace* pws,
                               float chi2Max  // for outlier rejection
   ) {
@@ -100,6 +100,14 @@ namespace gpuVertexFinder {
     if (verbose && 0 == threadIdx.x)
       printf("and %d noise\n", noise);
   }
+
+  __global__ void fitVerticesKernel(ZVertices* pdata,
+                              WorkSpace* pws,
+                              float chi2Max  // for outlier rejection
+  ) {
+
+   fitVertices(pdata,pws,chi2Max);
+ }
 
 }  // namespace gpuVertexFinder
 

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuSortByPt2.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuSortByPt2.h
@@ -15,7 +15,8 @@
 
 namespace gpuVertexFinder {
 
-  __global__ void sortByPt2(ZVertices* pdata, WorkSpace* pws) {
+  __device__ __forceinline__ 
+  void sortByPt2(ZVertices* pdata, WorkSpace* pws) {
     auto& __restrict__ data = *pdata;
     auto& __restrict__ ws = *pws;
     auto nt = ws.ntrks;
@@ -64,6 +65,11 @@ namespace gpuVertexFinder {
       sortInd[i] = i;
     std::sort(sortInd, sortInd + nvFinal, [&](auto i, auto j) { return ptv2[i] < ptv2[j]; });
 #endif
+  }
+
+
+  __global__ void sortByPt2Kernel(ZVertices* pdata, WorkSpace* pws) {
+     sortByPt2(pdata,pws);
   }
 
 }  // namespace gpuVertexFinder

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
@@ -32,20 +32,20 @@ namespace gpuVertexFinder {
     assert(zt);
 
     // one vertex per block
-    auto kv = blockIdx.x;
+    for ( auto kv = blockIdx.x; kv<nvFinal; kv += gridDim.x) {
 
-    if (kv >= nvFinal)
-      return;
     if (nn[kv] < 4)
-      return;
+      continue;
     if (chi2[kv] < maxChi2 * float(nn[kv]))
-      return;
+      continue;
 
-    assert(nn[kv] < 1023);
-    __shared__ uint32_t it[1024];   // track index
-    __shared__ float zz[1024];      // z pos
-    __shared__ uint8_t newV[1024];  // 0 or 1
-    __shared__ float ww[1024];      // z weight
+    constexpr int MAXTK = 256;
+    assert(nn[kv] < MAXTK);
+    if (nn[kv] >= MAXTK) continue; // too bad FIXME
+    __shared__ uint32_t it[MAXTK];   // track index
+    __shared__ float zz[MAXTK];      // z pos
+    __shared__ uint8_t newV[MAXTK];  // 0 or 1
+    __shared__ float ww[MAXTK];      // z weight
 
     __shared__ uint32_t nq;  // number of track for this vertex
     nq = 0;
@@ -54,7 +54,7 @@ namespace gpuVertexFinder {
     // copy to local
     for (auto k = threadIdx.x; k < nt; k += blockDim.x) {
       if (iv[k] == int(kv)) {
-        auto old = atomicInc(&nq, 1024);
+        auto old = atomicInc(&nq, MAXTK);
         zz[old] = zt[k] - zv[kv];
         newV[old] = zz[old] < 0 ? 0 : 1;
         ww[old] = 1.f / ezt2[k];
@@ -104,7 +104,7 @@ namespace gpuVertexFinder {
 
     // avoid empty vertices
     if (0 == wnew[0] || 0 == wnew[1])
-      return;
+      continue;
 
     // quality cut
     auto dist2 = (znew[0] - znew[1]) * (znew[0] - znew[1]);
@@ -115,7 +115,7 @@ namespace gpuVertexFinder {
       printf("inter %d %f %f\n", 20 - maxiter, chi2Dist, dist2 * wv[kv]);
 
     if (chi2Dist < 4)
-      return;
+      continue;
 
     // get a new global vertex
     __shared__ uint32_t igv;
@@ -126,6 +126,8 @@ namespace gpuVertexFinder {
       if (1 == newV[k])
         iv[it[k]] = igv;
     }
+
+  } // loop on vertices
   }
 
   __global__ void splitVerticesKernel(ZVertices* pdata, WorkSpace* pws, float maxChi2) {

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
@@ -39,7 +39,7 @@ namespace gpuVertexFinder {
     if (chi2[kv] < maxChi2 * float(nn[kv]))
       continue;
 
-    constexpr int MAXTK = 256;
+    constexpr int MAXTK = 512;
     assert(nn[kv] < MAXTK);
     if (nn[kv] >= MAXTK) continue; // too bad FIXME
     __shared__ uint32_t it[MAXTK];   // track index

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h
@@ -12,7 +12,7 @@
 
 namespace gpuVertexFinder {
 
-  __global__ void splitVertices(ZVertices* pdata, WorkSpace* pws, float maxChi2) {
+  __device__ __forceinline__ void splitVertices(ZVertices* pdata, WorkSpace* pws, float maxChi2) {
     constexpr bool verbose = false;  // in principle the compiler should optmize out if false
 
     auto& __restrict__ data = *pdata;
@@ -126,6 +126,10 @@ namespace gpuVertexFinder {
       if (1 == newV[k])
         iv[it[k]] = igv;
     }
+  }
+
+  __global__ void splitVerticesKernel(ZVertices* pdata, WorkSpace* pws, float maxChi2) {
+     splitVertices(pdata, pws, maxChi2);
   }
 
 }  // namespace gpuVertexFinder

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinder.h
@@ -43,7 +43,8 @@ namespace gpuVertexFinder {
     using WorkSpace = gpuVertexFinder::WorkSpace;
     using TkSoA = pixelTrack::TrackSoA;
 
-    Producer(bool useDensity,
+    Producer(bool oneKernel,
+             bool useDensity,
              bool useDBSCAN,
              bool useIterative,
              int iminT,      // min number of neighbours to be "core"
@@ -51,13 +52,15 @@ namespace gpuVertexFinder {
              float ierrmax,  // max error to be "seed"
              float ichi2max  // max normalized distance to cluster
              )
-        : useDensity_(useDensity),
+        : oneKernel_(oneKernel && !(useDBSCAN||useIterative)),
+          useDensity_(useDensity),
           useDBSCAN_(useDBSCAN),
           useIterative_(useIterative),
           minT(iminT),
           eps(ieps),
           errmax(ierrmax),
-          chi2max(ichi2max) {}
+          chi2max(ichi2max) {
+          }
 
     ~Producer() = default;
 
@@ -65,6 +68,7 @@ namespace gpuVertexFinder {
     ZVertexHeterogeneous make(TkSoA const* tksoa, float ptMin) const;
 
   private:
+    const bool oneKernel_;
     const bool useDensity_;
     const bool useDBSCAN_;
     const bool useIterative_;

--- a/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinderImpl.h
+++ b/RecoPixelVertexing/PixelVertexFinding/src/gpuVertexFinderImpl.h
@@ -46,7 +46,7 @@ namespace gpuVertexFinder {
   }
 
 #ifdef __CUDACC__
-// #define ONE_KERNEL
+#define ONE_KERNEL
 #ifdef ONE_KERNEL
   __global__ void vertexFinderOneKernel(gpuVertexFinder::ZVertices* pdata,
                                         gpuVertexFinder::WorkSpace* pws,

--- a/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
@@ -19,6 +19,14 @@
 <use name="SimDataFormats/Track"/>
 <use name="TrackingTools/TransientTrack"/>
 
+
+<bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderOneKernel_t">
+  <use name="cuda"/>
+  <flags CUDA_FLAGS="-g -DGPU_DEBUG -DONE_KERNEL"/>
+  <flags CXXFLAGS="-g"/>
+</bin>
+
+
 <bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderByDensity_t">
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>

--- a/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
@@ -19,13 +19,11 @@
 <use name="SimDataFormats/Track"/>
 <use name="TrackingTools/TransientTrack"/>
 
-
 <bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderOneKernel_t">
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG -DONE_KERNEL"/>
   <flags CXXFLAGS="-g"/>
 </bin>
-
 
 <bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderByDensity_t">
   <use name="cuda"/>
@@ -52,4 +50,3 @@
 <bin file="cpuVertexFinder_t.cpp" name="cpuVertexFinderIterative_t">
   <flags CXXFLAGS="-g -DGPU_DEBUG -DUSE_ITERATIVE"/>
 </bin>
-

--- a/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
+++ b/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
@@ -15,11 +15,43 @@
 #define CLUSTERIZE clusterTracksIterative
 #else
 #include "RecoPixelVertexing/PixelVertexFinding/src/gpuClusterTracksByDensity.h"
-#define CLUSTERIZE clusterTracksByDensity
+#define CLUSTERIZE clusterTracksByDensityKernel
 #endif
 #include "RecoPixelVertexing/PixelVertexFinding/src/gpuFitVertices.h"
 #include "RecoPixelVertexing/PixelVertexFinding/src/gpuSortByPt2.h"
 #include "RecoPixelVertexing/PixelVertexFinding/src/gpuSplitVertices.h"
+
+#ifdef ONE_KERNEL
+#ifdef __CUDACC__
+  __global__ void vertexFinderOneKernel(gpuVertexFinder::ZVertices* pdata,
+                                           gpuVertexFinder::WorkSpace* pws,
+                                           int minT,    // min number of neighbours to be "seed"
+                                           float eps,     // max absolute distance to cluster
+                                        float errmax,  // max error to be "seed"
+                                           float chi2max  // max normalized distance to cluster,
+  ) {
+    clusterTracksByDensity(pdata,pws,minT,eps,errmax,chi2max);
+    __syncthreads();
+    fitVertices(pdata,pws, 50.);
+    __syncthreads();
+
+    
+    // one block per vertex...
+    if (0==threadIdx.x) {
+      cudaStream_t stream = 0;
+      cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+      splitVerticesKernel<<<1024, 128, 0, stream>>>(pdata,pws, 9.f);
+      cudaStreamDestroy(stream);
+      cudaDeviceSynchronize();
+    }
+    
+    __syncthreads();
+    fitVertices(pdata,pws, 5000.);
+    __syncthreads();
+    sortByPt2(pdata,pws);
+  }
+#endif
+#endif
 
 using namespace gpuVertexFinder;
 
@@ -151,13 +183,17 @@ int main() {
       cudaCheck(cudaGetLastError());
       cudaDeviceSynchronize();
 
+#ifdef ONE_KERNEL
+      cudautils::launch(vertexFinderOneKernel, {1, 512 + 256}, onGPU_d.get(), ws_d.get(), kk, par[0], par[1], par[2]);
+#else
       cudautils::launch(CLUSTERIZE, {1, 512 + 256}, onGPU_d.get(), ws_d.get(), kk, par[0], par[1], par[2]);
+#endif
       print<<<1, 1, 0, 0>>>(onGPU_d.get(), ws_d.get());
 
       cudaCheck(cudaGetLastError());
       cudaDeviceSynchronize();
 
-      cudautils::launch(fitVertices, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 50.f);
+      cudautils::launch(fitVerticesKernel, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 50.f);
       cudaCheck(cudaGetLastError());
       cudaCheck(cudaMemcpy(&nv, LOC_ONGPU(nvFinal), sizeof(uint32_t), cudaMemcpyDeviceToHost));
 
@@ -219,7 +255,7 @@ int main() {
       }
 
 #ifdef __CUDACC__
-      cudautils::launch(fitVertices, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 50.f);
+      cudautils::launch(fitVerticesKernel, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 50.f);
       cudaCheck(cudaMemcpy(&nv, LOC_ONGPU(nvFinal), sizeof(uint32_t), cudaMemcpyDeviceToHost));
       cudaCheck(cudaMemcpy(nn, LOC_ONGPU(ndof), nv * sizeof(int32_t), cudaMemcpyDeviceToHost));
       cudaCheck(cudaMemcpy(chi2, LOC_ONGPU(chi2), nv * sizeof(float), cudaMemcpyDeviceToHost));
@@ -239,7 +275,7 @@ int main() {
 
 #ifdef __CUDACC__
       // one vertex per block!!!
-      cudautils::launch(splitVertices, {1024, 64}, onGPU_d.get(), ws_d.get(), 9.f);
+      cudautils::launch(splitVerticesKernel, {1024, 64}, onGPU_d.get(), ws_d.get(), 9.f);
       cudaCheck(cudaMemcpy(&nv, LOC_WS(nvIntermediate), sizeof(uint32_t), cudaMemcpyDeviceToHost));
 #else
       gridDim.x = 1024;  // nv ????
@@ -252,10 +288,10 @@ int main() {
       std::cout << "after split " << nv << std::endl;
 
 #ifdef __CUDACC__
-      cudautils::launch(fitVertices, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 5000.f);
+      cudautils::launch(fitVerticesKernel, {1, 1024 - 256}, onGPU_d.get(), ws_d.get(), 5000.f);
       cudaCheck(cudaGetLastError());
 
-      cudautils::launch(sortByPt2, {1, 256}, onGPU_d.get(), ws_d.get());
+      cudautils::launch(sortByPt2Kernel, {1, 256}, onGPU_d.get(), ws_d.get());
       cudaCheck(cudaGetLastError());
       cudaCheck(cudaMemcpy(&nv, LOC_ONGPU(nvFinal), sizeof(uint32_t), cudaMemcpyDeviceToHost));
 #else


### PR DESCRIPTION
After realizing that the number of vertex to split is small I implemented the whole sequence
finder, fitter,split,fitter,ptsort as a single kernel of ONE block.
to make things simple only for the Density clustering.
Other options are still available using configurable (or conditional compilation).

The quadruplet workflow is a couple of percent (one...) faster on T4.
```
                    5.75%  564.21ms      5000  112.84us  4.8640us  741.69us  gpuVertexFinder::vertexFinderOneKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)
      API calls:   25.46%  4.66845s    175000  26.676us  6.3150us  61.718ms  cudaLaunchKernel
                   18.76%  3.43955s     13678  251.47us  1.6050us  5.9472ms  cudaEventSynchronize

   965.6 ±   2.4 ev/s

------
                    2.81%  265.91ms      5000  53.181us  3.0080us  786.65us  gpuVertexFinder::clusterTracksByDensityKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, int, float, float, float)
                    1.90%  180.09ms      5000  36.017us     992ns  131.74us  gpuVertexFinder::sortByPt2Kernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*)
                    0.63%  59.975ms     10000  5.9970us  1.2800us  120.26us  gpuVertexFinder::fitVerticesKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, float)
                    0.29%  27.200ms      5000  5.4400us  1.5680us  215.36us  gpuVertexFinder::splitVerticesKernel(ZVertexSoA*, gpuVertexFinder::WorkSpace*, float)
      API calls:   29.07%  5.72791s    195000  29.373us  6.0080us  68.871ms  cudaLaunchKernel
                   18.05%  3.55706s    211228  16.839us     586ns  68.982ms  cudaEventRecord

   952.6 ±   2.1 ev/s
```
