### PR TITLE
Replace cuda::throw_if_error() with cudaCheck()

### DIFF
--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -25,8 +25,7 @@ end
 #include <iostream>
 #include <memory>
 #include <random>
-
-#include "cuda/api_wrappers.h"
+#include <stdexcept>
 
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
@@ -104,8 +103,8 @@ int main() {
     go<5>();
     go<7>();
     go<9>();
-  } catch (cuda::runtime_error &ex) {
-    std::cerr << "CUDA error: " << ex.what() << std::endl;
+  } catch (std::runtime_error &ex) {
+    std::cerr << "CUDA or std runtime error: " << ex.what() << std::endl;
     exit(EXIT_FAILURE);
   } catch (...) {
     std::cerr << "A non-CUDA error occurred" << std::endl;

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -25,8 +25,7 @@ end
 #include <iostream>
 #include <memory>
 #include <random>
-
-#include "cuda/api_wrappers.h"
+#include <stdexcept>
 
 #ifdef __CUDACC__
 #define inline __host__ __device__ inline
@@ -189,8 +188,8 @@ int main() {
     go<USESIN>();
     go<USELOG>();
     go<USELOG, true>();
-  } catch (cuda::runtime_error &ex) {
-    std::cerr << "CUDA error: " << ex.what() << std::endl;
+  } catch (std::runtime_error &ex) {
+    std::cerr << "CUDA or std runtime error: " << ex.what() << std::endl;
     exit(EXIT_FAILURE);
   } catch (...) {
     std::cerr << "A non-CUDA error occurred" << std::endl;

--- a/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
@@ -61,7 +61,7 @@ public:
           // wait on the CUDA stream and return the value. Subsequent
           // work queued on the stream will wait for the event to
           // occur (i.e. transfer to finish).
-          cudaCheckVerbose(cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0), "Failed to make a stream to wait for an event");
+          cudaCheck(cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0), "Failed to make a stream to wait for an event");
         }
         // else: filling is still going on. But for the same CUDA
         // stream (which would be a bit strange but fine), we can just

--- a/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
@@ -61,7 +61,8 @@ public:
           // wait on the CUDA stream and return the value. Subsequent
           // work queued on the stream will wait for the event to
           // occur (i.e. transfer to finish).
-          cudaCheck(cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0), "Failed to make a stream to wait for an event");
+          cudaCheck(cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0),
+                    "Failed to make a stream to wait for an event");
         }
         // else: filling is still going on. But for the same CUDA
         // stream (which would be a bit strange but fine), we can just

--- a/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
+++ b/HeterogeneousCore/CUDACore/interface/CUDAESProduct.h
@@ -9,6 +9,7 @@
 
 #include "FWCore/Concurrency/interface/hardware_pause.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/currentDevice.h"
@@ -60,8 +61,7 @@ public:
           // wait on the CUDA stream and return the value. Subsequent
           // work queued on the stream will wait for the event to
           // occur (i.e. transfer to finish).
-          auto ret = cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0);
-          cuda::throw_if_error(ret, "Failed to make a stream to wait for an event");
+          cudaCheckVerbose(cudaStreamWaitEvent(cudaStream, data.m_event.get(), 0), "Failed to make a stream to wait for an event");
         }
         // else: filling is still going on. But for the same CUDA
         // stream (which would be a bit strange but fine), we can just

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -78,8 +78,7 @@ namespace impl {
         // wait for an event, so all subsequent work in the stream
         // will run only after the event has "occurred" (i.e. data
         // product became available).
-        auto ret = cudaStreamWaitEvent(stream(), dataEvent, 0);
-        cuda::throw_if_error(ret, "Failed to make a stream to wait for an event");
+        cudaCheckVerbose(cudaStreamWaitEvent(stream(), dataEvent, 0), "Failed to make a stream to wait for an event");
       }
     }
   }

--- a/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/CUDAScopedContext.cc
@@ -78,7 +78,7 @@ namespace impl {
         // wait for an event, so all subsequent work in the stream
         // will run only after the event has "occurred" (i.e. data
         // product became available).
-        cudaCheckVerbose(cudaStreamWaitEvent(stream(), dataEvent, 0), "Failed to make a stream to wait for an event");
+        cudaCheck(cudaStreamWaitEvent(stream(), dataEvent, 0), "Failed to make a stream to wait for an event");
       }
     }
   }

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -51,7 +51,6 @@ namespace cudautils {
 
 }  // namespace cudautils
 
-#define cudaCheck(ARG) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG)))
-#define cudaCheckVerbose(ARG, DESC) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), DESC))
+#define cudaCheck(ARG, ...) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), ## __VA_ARGS__))
 
 #endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -15,8 +15,12 @@
 
 namespace cudautils {
 
-  [[noreturn]] inline void abortOnCudaError(
-      const char* file, int line, const char* cmd, const char* error, const char* message, const char* description = nullptr) {
+  [[noreturn]] inline void abortOnCudaError(const char* file,
+                                            int line,
+                                            const char* cmd,
+                                            const char* error,
+                                            const char* message,
+                                            const char* description = nullptr) {
     std::ostringstream out;
     out << "\n";
     out << file << ", line " << line << ":\n";
@@ -27,7 +31,8 @@ namespace cudautils {
     throw std::runtime_error(out.str());
   }
 
-  inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult result, const char* description = nullptr) {
+  inline bool cudaCheck_(
+      const char* file, int line, const char* cmd, CUresult result, const char* description = nullptr) {
     if (LIKELY(result == CUDA_SUCCESS))
       return true;
 
@@ -39,7 +44,8 @@ namespace cudautils {
     return false;
   }
 
-  inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
+  inline bool cudaCheck_(
+      const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
     if (LIKELY(result == cudaSuccess))
       return true;
 
@@ -51,6 +57,6 @@ namespace cudautils {
 
 }  // namespace cudautils
 
-#define cudaCheck(ARG, ...) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), ## __VA_ARGS__))
+#define cudaCheck(ARG, ...) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), ##__VA_ARGS__))
 
 #endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -16,81 +16,42 @@
 namespace cudautils {
 
   [[noreturn]] inline void abortOnCudaError(
-      const char* file, int line, const char* cmd, const char* error, const char* message) {
+      const char* file, int line, const char* cmd, const char* error, const char* message, const char* description = nullptr) {
     std::ostringstream out;
     out << "\n";
     out << file << ", line " << line << ":\n";
     out << "cudaCheck(" << cmd << ");\n";
     out << error << ": " << message << "\n";
+    if (description)
+      out << description << "\n";
     throw std::runtime_error(out.str());
+  }
+
+  inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult result, const char* description = nullptr) {
+    if (LIKELY(result == CUDA_SUCCESS))
+      return true;
+
+    const char* error;
+    const char* message;
+    cuGetErrorName(result, &error);
+    cuGetErrorString(result, &message);
+    abortOnCudaError(file, line, cmd, error, message, description);
+    return false;
+  }
+
+  inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t result, const char* description = nullptr) {
+    if (LIKELY(result == cudaSuccess))
+      return true;
+
+    const char* error = cudaGetErrorName(result);
+    const char* message = cudaGetErrorString(result);
+    abortOnCudaError(file, line, cmd, error, message, description);
+    return false;
   }
 
 }  // namespace cudautils
 
-inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult result) {
-  if (LIKELY(result == CUDA_SUCCESS))
-    return true;
-
-  const char* error;
-  const char* message;
-  cuGetErrorName(result, &error);
-  cuGetErrorString(result, &message);
-  cudautils::abortOnCudaError(file, line, cmd, error, message);
-  return false;
-}
-
-inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t result) {
-  if (LIKELY(result == cudaSuccess))
-    return true;
-
-  const char* error = cudaGetErrorName(result);
-  const char* message = cudaGetErrorString(result);
-  cudautils::abortOnCudaError(file, line, cmd, error, message);
-  return false;
-}
-
-#define cudaCheck(ARG) (cudaCheck_(__FILE__, __LINE__, #ARG, (ARG)))
-
-namespace cudautils {
-
-  template <typename T>
-  [[noreturn]] inline void abortOnCudaErrorVerbose(
-      const char* file, int line, const char* cmd, const char* error, const char* message, T const& description) {
-    std::ostringstream out;
-    out << "\n";
-    out << file << ", line " << line << ":\n";
-    out << "cudaCheck(" << cmd << ");\n";
-    out << error << ": " << message << "\n";
-    out << description << "\n";
-    throw std::runtime_error(out.str());
-  }
-
-}  // namespace cudautils
-
-template <typename T>
-inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUresult result, T const& description) {
-  if (LIKELY(result == CUDA_SUCCESS))
-    return true;
-
-  const char* error;
-  const char* message;
-  cuGetErrorName(result, &error);
-  cuGetErrorString(result, &message);
-  cudautils::abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
-  return false;
-}
-
-template <typename T>
-inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, cudaError_t result, T const& description) {
-  if (LIKELY(result == cudaSuccess))
-    return true;
-
-  const char* error = cudaGetErrorName(result);
-  const char* message = cudaGetErrorString(result);
-  cudautils::abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
-  return false;
-}
-
-#define cudaCheckVerbose(ARG, DESC) (cudaCheckVerbose_(__FILE__, __LINE__, #ARG, (ARG), DESC))
+#define cudaCheck(ARG) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG)))
+#define cudaCheckVerbose(ARG, DESC) (cudautils::cudaCheck_(__FILE__, __LINE__, #ARG, (ARG), DESC))
 
 #endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -48,4 +48,47 @@ inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t 
 
 #define cudaCheck(ARG) (cudaCheck_(__FILE__, __LINE__, #ARG, (ARG)))
 
+
+namespace {
+
+  template <typename T>
+  [[noreturn]] inline void abortOnCudaErrorVerbose(
+      const char* file, int line, const char* cmd, const char* error, const char* message, T const& description) {
+    std::ostringstream out;
+    out << "\n";
+    out << file << ", line " << line << ":\n";
+    out << "cudaCheck(" << cmd << ");\n";
+    out << error << ": " << message << "\n";
+    out << description << "\n";
+    throw std::runtime_error(out.str());
+  }
+
+}  // namespace
+
+template <typename T>
+inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUresult result, T const& description) {
+  if (__builtin_expect(result == CUDA_SUCCESS, true))
+    return true;
+
+  const char* error;
+  const char* message;
+  cuGetErrorName(result, &error);
+  cuGetErrorString(result, &message);
+  abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
+  return false;
+}
+
+template <typename T>
+inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, cudaError_t result, T const& description) {
+  if (__builtin_expect(result == cudaSuccess, true))
+    return true;
+
+  const char* error = cudaGetErrorName(result);
+  const char* message = cudaGetErrorString(result);
+  abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
+  return false;
+}
+
+#define cudaCheckVerbose(ARG, DESC) (cudaCheckVerbose_(__FILE__, __LINE__, #ARG, (ARG), DESC))
+
 #endif  // HeterogeneousCore_CUDAUtilities_cudaCheck_h

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -10,6 +10,9 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// CMSSW headers
+#include "FWCore/Utilities/interface/Likely.h"
+
 namespace cudautils {
 
   [[noreturn]] inline void abortOnCudaError(
@@ -25,7 +28,7 @@ namespace cudautils {
 }  // namespace cudautils
 
 inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult result) {
-  if (__builtin_expect(result == CUDA_SUCCESS, true))
+  if (LIKELY(result == CUDA_SUCCESS))
     return true;
 
   const char* error;
@@ -37,7 +40,7 @@ inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult res
 }
 
 inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t result) {
-  if (__builtin_expect(result == cudaSuccess, true))
+  if (LIKELY(result == cudaSuccess))
     return true;
 
   const char* error = cudaGetErrorName(result);
@@ -66,7 +69,7 @@ namespace cudautils {
 
 template <typename T>
 inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUresult result, T const& description) {
-  if (__builtin_expect(result == CUDA_SUCCESS, true))
+  if (LIKELY(result == CUDA_SUCCESS))
     return true;
 
   const char* error;
@@ -79,7 +82,7 @@ inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUres
 
 template <typename T>
 inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, cudaError_t result, T const& description) {
-  if (__builtin_expect(result == cudaSuccess, true))
+  if (LIKELY(result == cudaSuccess))
     return true;
 
   const char* error = cudaGetErrorName(result);

--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -10,7 +10,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-namespace {
+namespace cudautils {
 
   [[noreturn]] inline void abortOnCudaError(
       const char* file, int line, const char* cmd, const char* error, const char* message) {
@@ -22,7 +22,7 @@ namespace {
     throw std::runtime_error(out.str());
   }
 
-}  // namespace
+}  // namespace cudautils
 
 inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult result) {
   if (__builtin_expect(result == CUDA_SUCCESS, true))
@@ -32,7 +32,7 @@ inline bool cudaCheck_(const char* file, int line, const char* cmd, CUresult res
   const char* message;
   cuGetErrorName(result, &error);
   cuGetErrorString(result, &message);
-  abortOnCudaError(file, line, cmd, error, message);
+  cudautils::abortOnCudaError(file, line, cmd, error, message);
   return false;
 }
 
@@ -42,14 +42,13 @@ inline bool cudaCheck_(const char* file, int line, const char* cmd, cudaError_t 
 
   const char* error = cudaGetErrorName(result);
   const char* message = cudaGetErrorString(result);
-  abortOnCudaError(file, line, cmd, error, message);
+  cudautils::abortOnCudaError(file, line, cmd, error, message);
   return false;
 }
 
 #define cudaCheck(ARG) (cudaCheck_(__FILE__, __LINE__, #ARG, (ARG)))
 
-
-namespace {
+namespace cudautils {
 
   template <typename T>
   [[noreturn]] inline void abortOnCudaErrorVerbose(
@@ -63,7 +62,7 @@ namespace {
     throw std::runtime_error(out.str());
   }
 
-}  // namespace
+}  // namespace cudautils
 
 template <typename T>
 inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUresult result, T const& description) {
@@ -74,7 +73,7 @@ inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, CUres
   const char* message;
   cuGetErrorName(result, &error);
   cuGetErrorString(result, &message);
-  abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
+  cudautils::abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
   return false;
 }
 
@@ -85,7 +84,7 @@ inline bool cudaCheckVerbose_(const char* file, int line, const char* cmd, cudaE
 
   const char* error = cudaGetErrorName(result);
   const char* message = cudaGetErrorString(result);
-  abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
+  cudautils::abortOnCudaErrorVerbose(file, line, cmd, error, message, description);
   return false;
 }
 

--- a/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h
@@ -3,8 +3,9 @@
 
 #include <memory>
 
-#include <cuda/api_wrappers.h>
 #include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 namespace cudautils {
   namespace host {
@@ -13,7 +14,7 @@ namespace cudautils {
         // Additional layer of types to distinguish from host::unique_ptr
         class HostDeleter {
         public:
-          void operator()(void *ptr) { cuda::throw_if_error(cudaFreeHost(ptr)); }
+          void operator()(void *ptr) { cudaCheck(cudaFreeHost(ptr)); }
         };
       }  // namespace impl
 
@@ -47,7 +48,7 @@ namespace cudautils {
     static_assert(std::is_trivially_constructible<T>::value,
                   "Allocating with non-trivial constructor on the pinned host memory is not supported");
     void *mem;
-    cuda::throw_if_error(cudaHostAlloc(&mem, sizeof(T), flags));
+    cudaCheck(cudaHostAlloc(&mem, sizeof(T), flags));
     return
         typename cudautils::host::noncached::impl::make_host_unique_selector<T>::non_array(reinterpret_cast<T *>(mem));
   }
@@ -59,7 +60,7 @@ namespace cudautils {
     static_assert(std::is_trivially_constructible<element_type>::value,
                   "Allocating with non-trivial constructor on the pinned host memory is not supported");
     void *mem;
-    cuda::throw_if_error(cudaHostAlloc(&mem, n * sizeof(element_type), flags));
+    cudaCheck(cudaHostAlloc(&mem, n * sizeof(element_type), flags));
     return typename cudautils::host::noncached::impl::make_host_unique_selector<T>::unbounded_array(
         reinterpret_cast<element_type *>(mem));
   }

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_device.cc
@@ -1,13 +1,11 @@
+#include <limits>
+
+#include "FWCore/Utilities/interface/Likely.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/allocate_device.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/ScopedSetDevice.h"
-#include "FWCore/Utilities/interface/Likely.h"
 
 #include "getCachingDeviceAllocator.h"
-
-#include <cuda/api_wrappers.h>
-
-#include <limits>
 
 namespace {
   const size_t maxAllocationSize =
@@ -22,20 +20,20 @@ namespace cudautils {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cuda::throw_if_error(cudautils::allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
+      cudaCheck(cudautils::allocator::getCachingDeviceAllocator().DeviceAllocate(dev, &ptr, nbytes, stream));
     } else {
       ScopedSetDevice setDeviceForThisScope(dev);
-      cuda::throw_if_error(cudaMalloc(&ptr, nbytes));
+      cudaCheck(cudaMalloc(&ptr, nbytes));
     }
     return ptr;
   }
 
   void free_device(int device, void *ptr) {
     if constexpr (cudautils::allocator::useCaching) {
-      cuda::throw_if_error(cudautils::allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
+      cudaCheck(cudautils::allocator::getCachingDeviceAllocator().DeviceFree(device, ptr));
     } else {
       ScopedSetDevice setDeviceForThisScope(device);
-      cuda::throw_if_error(cudaFree(ptr));
+      cudaCheck(cudaFree(ptr));
     }
   }
 

--- a/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/allocate_host.cc
@@ -1,11 +1,10 @@
+#include <limits>
+
+#include "FWCore/Utilities/interface/Likely.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/allocate_host.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "FWCore/Utilities/interface/Likely.h"
 
 #include "getCachingHostAllocator.h"
-#include <cuda/api_wrappers.h>
-
-#include <limits>
 
 namespace {
   const size_t maxAllocationSize =
@@ -20,18 +19,18 @@ namespace cudautils {
         throw std::runtime_error("Tried to allocate " + std::to_string(nbytes) +
                                  " bytes, but the allocator maximum is " + std::to_string(maxAllocationSize));
       }
-      cuda::throw_if_error(cudautils::allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream));
+      cudaCheck(cudautils::allocator::getCachingHostAllocator().HostAllocate(&ptr, nbytes, stream));
     } else {
-      cuda::throw_if_error(cudaMallocHost(&ptr, nbytes));
+      cudaCheck(cudaMallocHost(&ptr, nbytes));
     }
     return ptr;
   }
 
   void free_host(void *ptr) {
     if constexpr (cudautils::allocator::useCaching) {
-      cuda::throw_if_error(cudautils::allocator::getCachingHostAllocator().HostFree(ptr));
+      cudaCheck(cudautils::allocator::getCachingHostAllocator().HostFree(ptr));
     } else {
-      cuda::throw_if_error(cudaFreeHost(ptr));
+      cudaCheck(cudaFreeHost(ptr));
     }
   }
 


### PR DESCRIPTION
Add a verbose version of `cudaCheck()`.
Replace `cuda::throw_if_error()` with `cudaCheck()` or `cudaCheckVerbose()`.