### PR TITLE
Rename exitSansCUDADevices to requireCUDADevices

### DIFF
--- a/CUDADataFormats/Common/test/test_CUDAProduct.cc
+++ b/CUDADataFormats/Common/test/test_CUDAProduct.cc
@@ -3,7 +3,7 @@
 #include "CUDADataFormats/Common/interface/CUDAProduct.h"
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 
@@ -30,7 +30,7 @@ TEST_CASE("Use of CUDAProduct template", "[CUDACore]") {
     auto bar = std::move(foo);
   }
 
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   constexpr int defaultDevice = 0;
   cudaCheck(cudaSetDevice(defaultDevice));

--- a/CUDADataFormats/Track/test/TrajectoryStateSOA_t.h
+++ b/CUDADataFormats/Track/test/TrajectoryStateSOA_t.h
@@ -51,13 +51,13 @@ __global__ void testTSSoA(TS* pts, int n) {
 }
 
 #ifdef __CUDACC__
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #endif
 
 int main() {
 #ifdef __CUDACC__
-  exitSansCUDADevices();
+  requireCUDADevices();
 #endif
 
   TS ts;

--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -1,6 +1,6 @@
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DCUDA.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 namespace testTrackingRecHit2D {
@@ -10,7 +10,7 @@ namespace testTrackingRecHit2D {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));

--- a/DataFormats/CaloRecHit/test/test_calo_rechit.cu
+++ b/DataFormats/CaloRecHit/test/test_calo_rechit.cu
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void kernel_test_calo_rechit(CaloRecHit* other) {
   CaloRecHit rh{DetId(0), 10, 1, 0, 0};
@@ -43,7 +43,7 @@ void test_calo_rechit() {
 }
 
 int main(int argc, char** argv) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   test_calo_rechit();
 

--- a/DataFormats/DetId/test/test_detid.cu
+++ b/DataFormats/DetId/test/test_detid.cu
@@ -6,7 +6,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void test_gen_detid(DetId* id, uint32_t const rawid) {
   DetId did{rawid};
@@ -29,7 +29,7 @@ void test_detid() {
 }
 
 int main(int argc, char** argv) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   // test det id functionality
   test_detid();

--- a/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
+++ b/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
@@ -13,7 +13,7 @@
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
 #include "DataFormats/GeometrySurface/interface/SOARotation.h"
 #include "DataFormats/GeometrySurface/interface/TkRotation.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 void toGlobalWrapper(SOAFrame<float> const *frame,
                      float const *xl,
@@ -26,7 +26,7 @@ void toGlobalWrapper(SOAFrame<float> const *frame,
                      uint32_t n);
 
 int main(void) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   typedef float T;
   typedef TkRotation<T> Rotation;

--- a/DataFormats/HcalDetId/test/test_hcal_detid.cu
+++ b/DataFormats/HcalDetId/test/test_hcal_detid.cu
@@ -6,7 +6,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void test_gen_detid(DetId *id) {
   DetId did;
@@ -65,7 +65,7 @@ void test_hcal_detid() {
 }
 
 int main(int argc, char **argv) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   // test det id functionality
   test_detid();

--- a/DataFormats/HcalDigi/test/test_hcal_digi.cu
+++ b/DataFormats/HcalDigi/test/test_hcal_digi.cu
@@ -11,7 +11,7 @@
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
 #include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void kernel_test_hcal_qiesample(HcalQIESample *sample, uint16_t value) {
   printf("kernel: testing hcal qie sampel\n");
@@ -163,7 +163,7 @@ void test_hcal_qie8_hbhedf() {
 }
 
 int main(int argc, char **argv) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   // qie8
   test_hcal_qiesample();

--- a/DataFormats/HcalRecHit/test/test_hcal_reco.cu
+++ b/DataFormats/HcalRecHit/test/test_hcal_reco.cu
@@ -10,7 +10,7 @@
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"
 #include "DataFormats/HcalRecHit/interface/HFQIE10Info.h"
 #include "DataFormats/HcalRecHit/interface/HBHEChannelInfo.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 template <typename T>
 __global__ void kernel_test_hcal_rechits(T *other) {
@@ -110,7 +110,7 @@ void test_hcal_hbhechinfo() {
 }
 
 int main(int argc, char **argv) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   test_hcal_rechits<HBHERecHit>();
   test_hcal_rechits<HFRecHit>();

--- a/DataFormats/Math/test/CholeskyInvert_t.cu
+++ b/DataFormats/Math/test/CholeskyInvert_t.cu
@@ -16,7 +16,7 @@
 #include "DataFormats/Math/interface/choleskyInversion.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
 
@@ -197,7 +197,7 @@ void go(bool soa) {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   go<2>(false);
   go<4>(false);

--- a/DataFormats/Math/test/cudaAtan2Test.cu
+++ b/DataFormats/Math/test/cudaAtan2Test.cu
@@ -30,7 +30,7 @@ end
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 
 constexpr float xmin = -100.001;  // avoid 0
@@ -96,7 +96,7 @@ void go() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   try {
     go<3>();

--- a/DataFormats/Math/test/cudaMathTest.cu
+++ b/DataFormats/Math/test/cudaMathTest.cu
@@ -40,7 +40,7 @@ end
 #include "DataFormats/Math/interface/approx_atan2.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 
 std::mt19937 eng;
@@ -181,7 +181,7 @@ void go() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   try {
     go<USEEXP>();

--- a/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
+++ b/HeterogeneousCore/CUDACore/test/testStreamEvent.cu
@@ -13,7 +13,7 @@
 #include <cuda_runtime.h>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 namespace {
   constexpr int ARRAY_SIZE = 20000000;
@@ -31,7 +31,7 @@ __global__ void kernel_looping(float *point, unsigned int num) {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   constexpr bool debug = false;
 

--- a/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/test/test_CUDAScopedContext.cc
@@ -8,7 +8,7 @@
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/eventIsOccurred.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAStreamCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/CUDAEventCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/currentDevice.h"
@@ -39,7 +39,7 @@ namespace {
 }  // namespace
 
 TEST_CASE("Use of CUDAScopedContext", "[CUDACore]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   constexpr int defaultDevice = 0;
   {

--- a/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
+++ b/HeterogeneousCore/CUDATest/test/test_TestCUDAProducerGPUFirst.cc
@@ -5,7 +5,7 @@
 #include "CUDADataFormats/Common/interface/CUDAProduct.h"
 #include "HeterogeneousCore/CUDACore/interface/CUDAScopedContext.h"
 #include "HeterogeneousCore/CUDATest/interface/CUDAThing.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 #include <iostream>
@@ -59,7 +59,7 @@ process.moduleToTest(process.toTest)
 )_"};
   edm::test::TestProcessor::Config config{baseConfig};
 
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   constexpr int defaultDevice = 0;
 

--- a/HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h
@@ -1,6 +1,0 @@
-#ifndef HeterogeneousCore_CUDAUtilities_exitSansCUDADevices_h
-#define HeterogeneousCore_CUDAUtilities_exitSansCUDADevices_h
-
-void exitSansCUDADevices();
-
-#endif  // HeterogeneousCore_CUDAUtilities_exitSansCUDADevices_h

--- a/HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h
@@ -1,0 +1,6 @@
+#ifndef HeterogeneousCore_CUDAUtilities_requireCUDADevices_h
+#define HeterogeneousCore_CUDAUtilities_requireCUDADevices_h
+
+void requireCUDADevices();
+
+#endif  // HeterogeneousCore_CUDAUtilities_requireCUDADevices_h

--- a/HeterogeneousCore/CUDAUtilities/src/exitSansCUDADevices.cc
+++ b/HeterogeneousCore/CUDAUtilities/src/exitSansCUDADevices.cc
@@ -3,9 +3,9 @@
 
 #include <cuda_runtime.h>
 
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
-void exitSansCUDADevices() {
+void requireCUDADevices() {
   int devices = 0;
   auto status = cudaGetDeviceCount(&devices);
   if (status != cudaSuccess) {

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -5,7 +5,7 @@
 #include <random>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 template <typename T, int NBINS = 128, int S = 8 * sizeof(T), int DELTA = 1000>
 void go() {
@@ -136,7 +136,7 @@ void go() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   go<int16_t>();
   go<uint8_t, 128, 8, 4>();

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -7,7 +7,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
 
 template <typename T>
@@ -152,7 +152,7 @@ void go() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   go<int16_t>();
   go<int8_t>();

--- a/HeterogeneousCore/CUDAUtilities/test/OneHistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/OneHistoContainer_t.cu
@@ -7,7 +7,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
 
@@ -137,7 +137,7 @@ void go() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   go<int16_t>();
   go<uint8_t, 128, 8, 4>();

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -9,7 +9,7 @@
 #ifdef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/currentDevice.h"
 
 #endif
@@ -99,7 +99,7 @@ __global__ void verifyBulk(Assoc const* __restrict__ assoc, AtomicPairCounter co
 
 int main() {
 #ifdef __CUDACC__
-  exitSansCUDADevices();
+  requireCUDADevices();
   auto current_device = cudautils::currentDevice();
 #else
   // make sure cuda emulation is working

--- a/HeterogeneousCore/CUDAUtilities/test/assert_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/assert_t.cu
@@ -1,10 +1,10 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void testIt(int one) { assert(one == 1); }
 
 int main(int argc, char* argv[]) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   testIt<<<1, 1>>>(argc);
   cudaDeviceSynchronize();

--- a/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/copyAsync_t.cpp
@@ -4,10 +4,10 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 TEST_CASE("copyAsync", "[cudaMemTools]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));

--- a/HeterogeneousCore/CUDAUtilities/test/cudastdAlgorithm_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/cudastdAlgorithm_t.cu
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudastdAlgorithm.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
 
@@ -33,7 +33,7 @@ void wrapper() {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   wrapper();
 }

--- a/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/device_unique_ptr_t.cpp
@@ -2,10 +2,10 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 TEST_CASE("device_unique_ptr", "[cudaMemTools]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));

--- a/HeterogeneousCore/CUDAUtilities/test/eigenSoA_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/eigenSoA_t.h
@@ -59,13 +59,13 @@ __global__ void testBasicSoA(float* p) {
 #include <random>
 
 #ifdef __CUDACC__
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #endif
 
 int main() {
 #ifdef __CUDACC__
-  exitSansCUDADevices();
+  requireCUDADevices();
 #endif
 
   float p[1024];

--- a/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_noncached_unique_ptr_t.cpp
@@ -1,10 +1,10 @@
 #include "catch.hpp"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 TEST_CASE("host_noncached_unique_ptr", "[cudaMemTools]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   SECTION("Single element") {
     auto ptr1 = cudautils::make_host_noncached_unique<int>();

--- a/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/host_unique_ptr_t.cpp
@@ -2,10 +2,10 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 TEST_CASE("host_unique_ptr", "[cudaMemTools]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));

--- a/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/memsetAsync_t.cpp
@@ -5,10 +5,10 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/memsetAsync.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 TEST_CASE("memsetAsync", "[cudaMemTools]") {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   cudaStream_t stream;
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));

--- a/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/prefixScan_t.cu
@@ -4,7 +4,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/prefixScan.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 template <typename T>
 __global__ void testPrefixScan(uint32_t size) {
@@ -72,7 +72,7 @@ __global__ void verify(uint32_t const *v, uint32_t n) {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   std::cout << "warp level" << std::endl;
   // std::cout << "warp 32" << std::endl;

--- a/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
@@ -10,7 +10,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/radixSort.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
@@ -169,7 +169,7 @@ void go(bool useShared) {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   bool useShared = false;
 

--- a/HeterogeneousCore/CUDAUtilities/test/test_GPUSimpleVector.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/test_GPUSimpleVector.cu
@@ -8,7 +8,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/GPUSimpleVector.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 __global__ void vector_pushback(GPU::SimpleVector<int> *foo) {
   auto index = threadIdx.x + blockIdx.x * blockDim.x;
@@ -23,7 +23,7 @@ __global__ void vector_emplace_back(GPU::SimpleVector<int> *foo) {
 }
 
 int main() {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   auto maxN = 10000;
   GPU::SimpleVector<int> *obj_ptr = nullptr;

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
@@ -13,7 +13,7 @@
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaDeviceCount.h"
 #endif
@@ -23,7 +23,7 @@
 
 int main(void) {
 #ifdef __CUDACC__
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   if (cudautils::cudaDeviceCount() == 0) {
     std::cerr << "No CUDA devices on this system"

--- a/RecoPixelVertexing/PixelTrackFitting/test/testEigenGPU.cu
+++ b/RecoPixelVertexing/PixelTrackFitting/test/testEigenGPU.cu
@@ -4,7 +4,7 @@
 #include <Eigen/Eigenvalues>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 
 #ifdef USE_BL
 #include "RecoPixelVertexing/PixelTrackFitting/interface/BrokenLine.h"
@@ -329,7 +329,7 @@ void testFit() {
 }
 
 int main(int argc, char* argv[]) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   testFit<4>();
   testFit<3>();

--- a/RecoPixelVertexing/PixelTrackFitting/test/testEigenGPUNoFit.cu
+++ b/RecoPixelVertexing/PixelTrackFitting/test/testEigenGPUNoFit.cu
@@ -4,7 +4,7 @@
 #include <Eigen/Eigenvalues>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "test_common.h"
 
 using namespace Eigen;
@@ -215,7 +215,7 @@ void testEigenvalues() {
 }
 
 int main(int argc, char *argv[]) {
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   testEigenvalues();
   testInverse3x3();

--- a/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
+++ b/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/exitSansCUDADevices.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireCUDADevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #ifdef USE_DBSCAN
 #include "RecoPixelVertexing/PixelVertexFinding/src/gpuClusterTracksDBSCAN.h"
@@ -92,7 +92,7 @@ __global__ void print(ZVertices const* pdata, WorkSpace const* pws) {
 
 int main() {
 #ifdef __CUDACC__
-  exitSansCUDADevices();
+  requireCUDADevices();
 
   auto onGPU_d = cudautils::make_device_unique<ZVertices[]>(1, nullptr);
   auto ws_d = cudautils::make_device_unique<WorkSpace[]>(1, nullptr);


### PR DESCRIPTION
Rename `exitSansCUDADevices()` to `requireCUDADevices()`.