### PR TITLE
Load CUDAService from Services_cff, and only if gpu modifier is active

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -921,8 +921,6 @@ class ConfigBuilder(object):
                 self.loadAndRemember('SimGeneral.HepPDTESSource.'+self._options.particleTable+'_cfi')
 
         self.loadAndRemember('FWCore/MessageService/MessageLogger_cfi')
-        # Eventually replace with some more generic file to load
-        self.loadAndRemember('HeterogeneousCore/CUDAServices/CUDAService_cfi')
 
         self.ALCADefaultCFF="Configuration/StandardSequences/AlCaRecoStreams_cff"
         self.GENDefaultCFF="Configuration/StandardSequences/Generator_cff"

--- a/Configuration/StandardSequences/python/Services_cff.py
+++ b/Configuration/StandardSequences/python/Services_cff.py
@@ -11,3 +11,8 @@ from IOMC.RandomEngine.IOMC_cff import *
 #an "intermediate layer" remains, just in case somebody is using it...
 # from Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff import *
 from DQMServices.Core.DQMStore_cfg import *
+
+from Configuration.ProcessModifiers.gpu_cff import gpu
+def loadCUDAService(process):
+    process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
+modifyConfigurationStandardSequencesServicesCUDAService = gpu.makeProcessModifier(loadCUDAService)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
@@ -3,9 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
 from RecoVertex.BeamSpotProducer.beamSpotToCUDA_cfi import beamSpotToCUDA as _beamSpotToCUDA
 
-offlineBeamSpotCUDA = _beamSpotToCUDA.clone()
+offlineBeamSpotTask = cms.Task(offlineBeamSpot)
 
-offlineBeamSpotTask = cms.Task(
-    offlineBeamSpot,
-    offlineBeamSpotCUDA
-)
+from Configuration.ProcessModifiers.gpu_cff import gpu
+offlineBeamSpotCUDA = _beamSpotToCUDA.clone()
+_offlineBeamSpotTask_gpu = offlineBeamSpotTask.copy()
+_offlineBeamSpotTask_gpu.add(offlineBeamSpotCUDA)
+gpu.toReplaceWith(offlineBeamSpotTask, _offlineBeamSpotTask_gpu)


### PR DESCRIPTION
#### PR description:

Addresses https://github.com/cms-sw/cmssw/issues/28575.

#### PR validation:

Unit tests run, profiling workflow runs (without explicit load of `CUDAService`).