### PR TITLE
Simplify offlineBeamSpotCUDA configuration

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
@@ -54,7 +54,7 @@ BeamSpotToCUDA::BeamSpotToCUDA(const edm::ParameterSet& iConfig)
 void BeamSpotToCUDA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("offlineBeamSpot"));
-  descriptions.addWithDefaultLabel(desc);
+  descriptions.add("offlineBeamSpotCUDA", desc);
 }
 
 void BeamSpotToCUDA::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
@@ -1,12 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
-from RecoVertex.BeamSpotProducer.beamSpotToCUDA_cfi import beamSpotToCUDA as _beamSpotToCUDA
+from RecoVertex.BeamSpotProducer.offlineBeamSpotCUDA_cfi import offlineBeamSpotCUDA
 
 offlineBeamSpotTask = cms.Task(offlineBeamSpot)
 
 from Configuration.ProcessModifiers.gpu_cff import gpu
-offlineBeamSpotCUDA = _beamSpotToCUDA.clone()
 _offlineBeamSpotTask_gpu = offlineBeamSpotTask.copy()
 _offlineBeamSpotTask_gpu.add(offlineBeamSpotCUDA)
 gpu.toReplaceWith(offlineBeamSpotTask, _offlineBeamSpotTask_gpu)


### PR DESCRIPTION
#### PR description:

Just an afterthought to https://github.com/cms-patatrack/cmssw/pull/432#discussion_r367450659: the `offlineBeamSpotCUDA = _beamSpotToCUDA.clone()` can be avoided by generating the `cfi` with the proper name.


#### PR validation:

Code compiles, profiling workflow runs. Should be purely technical.