### PR TITLE
protect for too many pixels

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -91,15 +91,15 @@ namespace gpuClustering {
     assert((msize == numElements) or ((msize < numElements) and (id[msize] != thisModuleId)));
 
     // limit to maxPixInModule  (FIXME if recurrent (and not limited to simulation with low threshold) one will need to implement something cleverer)
-   if (0==threadIdx.x) {
-     if (msize - firstPixel > maxPixInModule) {
-       printf("too many pixels in module %d: %d > %d\n",thisModuleId,msize - firstPixel,maxPixInModule);
-       msize = maxPixInModule+firstPixel;
-     }
-   }
+    if (0 == threadIdx.x) {
+      if (msize - firstPixel > maxPixInModule) {
+        printf("too many pixels in module %d: %d > %d\n", thisModuleId, msize - firstPixel, maxPixInModule);
+        msize = maxPixInModule + firstPixel;
+      }
+    }
 
-   __syncthreads();
-   assert(msize - firstPixel <= maxPixInModule);
+    __syncthreads();
+    assert(msize - firstPixel <= maxPixInModule);
 
 #ifdef GPU_DEBUG
     __shared__ uint32_t totGood;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClustering.h
@@ -89,7 +89,17 @@ namespace gpuClustering {
     __syncthreads();
 
     assert((msize == numElements) or ((msize < numElements) and (id[msize] != thisModuleId)));
-    assert(msize - firstPixel < maxPixInModule);
+
+    // limit to maxPixInModule  (FIXME if recurrent (and not limited to simulation with low threshold) one will need to implement something cleverer)
+   if (0==threadIdx.x) {
+     if (msize - firstPixel > maxPixInModule) {
+       printf("too many pixels in module %d: %d > %d\n",thisModuleId,msize - firstPixel,maxPixInModule);
+       msize = maxPixInModule+firstPixel;
+     }
+   }
+
+   __syncthreads();
+   assert(msize - firstPixel <= maxPixInModule);
 
 #ifdef GPU_DEBUG
     __shared__ uint32_t totGood;
@@ -125,7 +135,7 @@ namespace gpuClustering {
     }
 
 #ifdef __CUDA_ARCH__
-    // assume that we can cover the whole module with up to 10 blockDim.x-wide iterations
+    // assume that we can cover the whole module with up to 16 blockDim.x-wide iterations
     constexpr int maxiter = 16;
 #else
     auto maxiter = hist.size();


### PR DESCRIPTION
add a protection to avoid overflow in case there are more pixels in a Module than the allowed maximum

It should never trigger (unless simulation has a unrealistic low charge threshold)
(
see
https://hypernews.cern.ch/HyperNews/CMS/get/pixelOfflineSW/1502/1/1/1/2/1/1/1/2/1/1/1/1/1/1/1/1/1.html
)
