### PR TITLE
Update lumi ALCARECO configurations for heterogeneous pixel digi and cluster configuration

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
@@ -10,12 +10,14 @@ ALCARECORandomHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 )
 
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
-siPixelDigisForLumiR = siPixelDigis.clone()
-siPixelDigisForLumiR.InputLabel = cms.InputTag("hltFEDSelectorLumiPixels")
+siPixelDigisForLumiR = siPixelDigis.cpu.clone(
+    InputLabel = "hltFEDSelectorLumiPixels"
+)
 
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import siPixelClustersPreSplitting
-siPixelClustersForLumiR = siPixelClustersPreSplitting.clone()
-siPixelClustersForLumiR.src = cms.InputTag("siPixelDigisForLumiR")
+siPixelClustersForLumiR = siPixelClustersPreSplitting.cpu.clone(
+    src = "siPixelDigisForLumiR"
+)
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCProducer_cfi import alcaPCCProducer
 alcaPCCProducerRandom = alcaPCCProducer.clone()

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
@@ -10,12 +10,14 @@ ALCARECOZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 )
 
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
-siPixelDigisForLumiZB = siPixelDigis.clone()
-siPixelDigisForLumiZB.InputLabel = cms.InputTag("hltFEDSelectorLumiPixels")
+siPixelDigisForLumiZB = siPixelDigis.cpu.clone(
+    InputLabel = "hltFEDSelectorLumiPixels"
+)
 
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import siPixelClustersPreSplitting
-siPixelClustersForLumiZB = siPixelClustersPreSplitting.clone()
-siPixelClustersForLumiZB.src = cms.InputTag("siPixelDigisForLumiZB")
+siPixelClustersForLumiZB = siPixelClustersPreSplitting.cpu.clone(
+    src = "siPixelDigisForLumiZB"
+)
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCProducer_cfi import alcaPCCProducer
 alcaPCCProducerZeroBias = alcaPCCProducer.clone()

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOLumiPixels_cff.py
@@ -9,12 +9,14 @@ ALCARECOLumiPixelsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone
 )
 
 from EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi import siPixelDigis
-siPixelDigisForLumi = siPixelDigis.clone()
-siPixelDigisForLumi.InputLabel = cms.InputTag("hltFEDSelectorLumiPixels")
+siPixelDigisForLumi = siPixelDigis.cpu.clone(
+    InputLabel = "hltFEDSelectorLumiPixels"
+)
 
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import siPixelClustersPreSplitting
-siPixelClustersForLumi = siPixelClustersPreSplitting.clone()
-siPixelClustersForLumi.src = cms.InputTag("siPixelDigisForLumi")
+siPixelClustersForLumi = siPixelClustersPreSplitting.cpu.clone(
+    src = "siPixelDigisForLumi"
+)
 
 # Sequence #
 seqALCARECOLumiPixels = cms.Sequence(ALCARECOLumiPixelsHLT + siPixelDigisForLumi + siPixelClustersForLumi)


### PR DESCRIPTION

#### PR description:

For now just use the CPU producer. Fixes some of the workflows reported in https://github.com/cms-sw/cmssw/issues/28850#issuecomment-581149286 .

#### PR validation:

Running these configurations with `python` works now. Tested also previously failing workflow 4.53.
