### PR TITLE
Implement the ECAL-only gpu workflows

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 # This object is used to selectively make changes for different running
 # scenarios. In this case it makes changes for Run 2.
@@ -72,7 +73,7 @@ RawToDigi_ecalOnly = cms.Sequence(RawToDigiTask_ecalOnly)
 scalersRawToDigi.scalersInputTag = 'rawDataCollector'
 siPixelDigis.cpu.InputLabel = 'rawDataCollector'
 #false by default anyways ecalDigis.DoRegional = False
-ecalDigis.InputLabel = 'rawDataCollector'
+(~gpu).toModify(ecalDigis, InputLabel='rawDataCollector')
 ecalPreshowerDigis.sourceTag = 'rawDataCollector'
 hcalDigis.InputLabel = 'rawDataCollector'
 muonCSCDigis.InputObjects = 'rawDataCollector'

--- a/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
+++ b/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
@@ -5,3 +5,24 @@ from EventFilter.EcalRawToDigi.EcalUnpackerData_cfi import ecalEBunpacker as _ec
 ecalDigis = _ecalEBunpacker.clone()
 
 ecalDigisTask = cms.Task(ecalDigis)
+
+# process modifier to run on GPUs
+from Configuration.ProcessModifiers.gpu_cff import gpu
+
+# GPU-friendly EventSetup modules
+from EventFilter.EcalRawToDigi.ecalElectronicsMappingGPUESProducer_cfi import ecalElectronicsMappingGPUESProducer
+
+# raw to digi on GPUs
+from EventFilter.EcalRawToDigi.ecalRawToDigiGPU_cfi import ecalRawToDigiGPU as _ecalRawToDigiGPU
+ecalDigisGPU = _ecalRawToDigiGPU.clone()
+
+# copy the digi from the GPU to the CPU and convert to legacy format
+from EventFilter.EcalRawToDigi.ecalCPUDigisProducer_cfi import ecalCPUDigisProducer as _ecalCPUDigisProducer
+_gpu_ecalDigis = _ecalCPUDigisProducer.clone(
+  digisInLabelEB = 'ecalDigisGPU:ebDigisGPU',
+  digisInLabelEE = 'ecalDigisGPU:eeDigisGPU',
+  produceDummyIntegrityCollections = True,
+)
+gpu.toReplaceWith(ecalDigis, _gpu_ecalDigis)
+
+gpu.toReplaceWith(ecalDigisTask, cms.Task(ecalElectronicsMappingGPUESProducer, ecalDigisGPU, ecalDigis))

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -1,6 +1,40 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 # ECAL multifit running on CPU
 from RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHit_cfi import ecalMultiFitUncalibRecHit
 
 ecalMultiFitUncalibRecHitTask = cms.Task(ecalMultiFitUncalibRecHit)
+
+# ECAL conditions used by the multifit running on GPU
+from RecoLocalCalo.EcalRecProducers.ecalPedestalsGPUESProducer_cfi import ecalPedestalsGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalGainRatiosGPUESProducer_cfi import ecalGainRatiosGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalPulseShapesGPUESProducer_cfi import ecalPulseShapesGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalPulseCovariancesGPUESProducer_cfi import ecalPulseCovariancesGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalSamplesCorrelationGPUESProducer_cfi import ecalSamplesCorrelationGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalTimeBiasCorrectionsGPUESProducer_cfi import ecalTimeBiasCorrectionsGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalTimeCalibConstantsGPUESProducer_cfi import ecalTimeCalibConstantsGPUESProducer
+
+# ECAL multifit running on GPU
+from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitProducerGPU_cfi import ecalUncalibRecHitProducerGPU as _ecalUncalibRecHitProducerGPU
+ecalMultiFitUncalibRecHitGPU = _ecalUncalibRecHitProducerGPU.clone(
+  digisLabelEB = cms.InputTag('ecalDigisGPU', 'ebDigisGPU'),
+  digisLabelEE = cms.InputTag('ecalDigisGPU', 'eeDigisGPU'),
+)
+
+# copy the uncalibrated rechits from GPU to CPU
+from RecoLocalCalo.EcalRecProducers.ecalCPUUncalibRecHitProducer_cfi import ecalCPUUncalibRecHitProducer as _ecalCPUUncalibRecHitProducer
+ecalMultiFitUncalibRecHitSoA = _ecalCPUUncalibRecHitProducer.clone(
+  recHitsInLabelEB = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEB'),
+  recHitsInLabelEE = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEE'),
+)
+
+# convert the uncalibrated rechits legacy format
+from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitConvertGPU2CPUFormat_cfi import ecalUncalibRecHitConvertGPU2CPUFormat as _ecalUncalibRecHitConvertGPU2CPUFormat
+_gpu_ecalMultiFitUncalibRecHit = _ecalUncalibRecHitConvertGPU2CPUFormat.clone(
+  recHitsLabelGPUEB = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
+  recHitsLabelGPUEE = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEE'),
+)
+gpu.toReplaceWith(ecalMultiFitUncalibRecHit, _gpu_ecalMultiFitUncalibRecHit)
+
+gpu.toReplaceWith(ecalMultiFitUncalibRecHitTask, cms.Task(ecalMultiFitUncalibRecHitGPU, ecalMultiFitUncalibRecHitSoA, ecalMultiFitUncalibRecHit))


### PR DESCRIPTION
Let EcalCPUDigisProducer optionally produce dummy ECAL integrity collections.

Implement the use of the "gpu" process modifier for ECAL-only reconstruction workflows:
  - 10824.512: TTbar, 2018 realistic conditions, no pileup;
  - 11634.512: TTbar, 2021 realistic conditions, no pileup.