### PR TITLE
Update the HLT customisation

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -66,10 +66,18 @@ def customise_cpu_pixel(process):
     )
 
     from RecoPixelVertexing.PixelTriplets.caHitNtupletCUDA_cfi import caHitNtupletCUDA as _caHitNtupletCUDA
-    process.hltPixelTracksSoA = _caHitNtupletCUDA.clone(
+    process.hltPixelTracksHitQuadruplets = _caHitNtupletCUDA.clone(
         idealConditions = False,
         pixelRecHitSrc = "hltSiPixelRecHitSoA",
         onGPU = False
+    )
+
+    process.hltPixelTracksSoA = cms.EDAlias(
+        hltPixelTracksHitQuadruplets = cms.VPSet(
+            cms.PSet(
+                type = cms.string("32768TrackSoATHeterogeneousSoA")
+            )
+        )
     )
 
     from RecoPixelVertexing.PixelTrackFitting.pixelTrackProducerFromSoA_cfi import pixelTrackProducerFromSoA as _pixelTrackProducerFromSoA
@@ -103,7 +111,8 @@ def customise_cpu_pixel(process):
         + process.hltPixelTracksFilter                      # not used here, kept for compatibility with legacy sequences
         + process.hltPixelTracksTrackingRegions             # from the original sequence
         + process.hltSiPixelRecHitSoA                       # pixel rechits on cpu, converted to SoA
-        + process.hltPixelTracksSoA                         # pixel ntuplets on cpu, in SoA format
+        + process.hltPixelTracksHitQuadruplets              # pixel ntuplets on cpu, in SoA format
+        # process.hltPixelTracksSoA                         # alias for hltPixelTracksHitQuadruplets
         + process.hltPixelTracks)                           # pixel tracks on cpu, with conversion to legacy
 
     process.HLTRecopixelvertexingSequence = cms.Sequence(

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -1,15 +1,29 @@
 import FWCore.ParameterSet.Config as cms
 
+# customisation for running on CPUs, common parts
+def customise_cpu_common(process):
+
+    # Services
+
+    process.CUDAService = cms.Service("CUDAService",
+        enabled = cms.untracked.bool(False)
+    )
+
+
+    # done
+    return process
+
+
 # customisation for offloading to GPUs, common parts
 def customise_gpu_common(process):
 
     # Services
 
     process.CUDAService = cms.Service("CUDAService",
+        enabled = cms.untracked.bool(True),
         allocator = cms.untracked.PSet(
             devicePreallocate = cms.untracked.vuint32(),
         ),
-        enabled = cms.untracked.bool(True),
         limits = cms.untracked.PSet(
             cudaLimitDevRuntimePendingLaunchCount = cms.untracked.int32(-1),
             cudaLimitDevRuntimeSyncDepth = cms.untracked.int32(-1),
@@ -362,6 +376,7 @@ def customise_gpu_ecal(process):
 
 # customisation for running on CPUs
 def customise_for_Patatrack_on_cpu(process):
+    process = customise_cpu_common(process)
     process = customise_cpu_pixel(process)
     return process
 


### PR DESCRIPTION
Load a skeleton CUDAService when running on the CPU.
Make the label for the quadruplets consistent on CPU and GPU.
Enable offloading ECAL unpacking and multifit.