### PR TITLE
backport ecalDigis: do not explicitly set default value (#29835)

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Data_cff.py
@@ -2,10 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.StandardSequences.RawToDigi_cff import *
 
-
-ecalDigis.DoRegional = False
-#False by default ecalDigis.DoRegional = False
-
 # RPC Merged Digis 
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 run3_RPC.toModify(muonRPCDigis,

--- a/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
@@ -10,7 +10,6 @@ gtDigis.DaqGtInputTag = 'rawDataRepacker'
 gtEvmDigis.EvmGtInputTag = 'rawDataRepacker'
 siPixelDigis.InputLabel = 'rawDataRepacker'
 siStripDigis.ProductLabel = 'rawDataRepacker'
-#False by default ecalDigis.DoRegional = False
 ecalDigis.InputLabel = 'rawDataRepacker'
 ecalPreshowerDigis.sourceTag = 'rawDataRepacker'
 hcalDigis.InputLabel = 'rawDataRepacker'

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -72,7 +72,6 @@ RawToDigi_ecalOnly = cms.Sequence(RawToDigiTask_ecalOnly)
 
 scalersRawToDigi.scalersInputTag = 'rawDataCollector'
 siPixelDigis.InputLabel = 'rawDataCollector'
-#false by default anyways ecalDigis.DoRegional = False
 ecalDigis.InputLabel = 'rawDataCollector'
 ecalPreshowerDigis.sourceTag = 'rawDataCollector'
 hcalDigis.InputLabel = 'rawDataCollector'


### PR DESCRIPTION
`ecalDigis.DoRegional = False` is the default value, no need to set it explicitly in the cff files.