### PR TITLE
Update HCAL local reconstruction on GPUs

### DIFF
--- a/CUDADataFormats/HcalDigi/src/classes.h
+++ b/CUDADataFormats/HcalDigi/src/classes.h
@@ -1,38 +1,3 @@
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "CUDADataFormats/HcalDigi/interface/DigiCollection.h"
-
-namespace hcal {
-
-  // instantiate what we know will be used
-  template struct DigiCollection<Flavor01, common::ViewStoragePolicy>;
-
-  template struct DigiCollection<Flavor2, common::ViewStoragePolicy>;
-
-  template struct DigiCollection<Flavor3, common::ViewStoragePolicy>;
-
-  template struct DigiCollection<Flavor4, common::ViewStoragePolicy>;
-
-  template struct DigiCollection<Flavor5, common::ViewStoragePolicy>;
-
-  template struct DigiCollection<Flavor01, common::VecStoragePolicy<std::allocator>>;
-
-  template struct DigiCollection<Flavor2, common::VecStoragePolicy<std::allocator>>;
-
-  template struct DigiCollection<Flavor3, common::VecStoragePolicy<std::allocator>>;
-
-  template struct DigiCollection<Flavor4, common::VecStoragePolicy<std::allocator>>;
-
-  template struct DigiCollection<Flavor5, common::VecStoragePolicy<std::allocator>>;
-
-  template struct DigiCollection<Flavor01, common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-  template struct DigiCollection<Flavor2, common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-  template struct DigiCollection<Flavor3, common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-  template struct DigiCollection<Flavor4, common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-  template struct DigiCollection<Flavor5, common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-}  // namespace hcal
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/CUDADataFormats/HcalDigi/src/classes_def.xml
+++ b/CUDADataFormats/HcalDigi/src/classes_def.xml
@@ -1,19 +1,7 @@
 <lcgdict>
-    <class name="std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t, 0>>" />
-    <class name="std::vector<uint16_t, cms::cuda::HostAllocator<uint16_t, 0>>" />
-    <class name="std::vector<uint8_t, cms::cuda::HostAllocator<uint8_t, 0>>" />
-            
     <class name="hcal::DigiCollectionBase<hcal::common::VecStoragePolicy<std::allocator>>" />
     <class name="hcal::DigiCollectionBase<hcal::common::VecStoragePolicy<hcal::CUDAHostAllocatorAlias>>" />
 
-    <!--
-    <class name="hcal::DigiCollectionBase<hcal::Flavor01, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollectionBase<hcal::Flavor2, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollectionBase<hcal::Flavor3, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollectionBase<hcal::Flavor4, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollectionBase<hcal::Flavor5, hcal::common::ViewStoragePolicy>" />
-    -->
-        
     <class name="hcal::DigiCollection<hcal::Flavor01, hcal::common::VecStoragePolicy<std::allocator>>" />
     <class name="hcal::DigiCollection<hcal::Flavor2, hcal::common::VecStoragePolicy<std::allocator>>" />
     <class name="hcal::DigiCollection<hcal::Flavor3, hcal::common::VecStoragePolicy<std::allocator>>" />
@@ -25,14 +13,6 @@
     <class name="hcal::DigiCollection<hcal::Flavor3, hcal::common::VecStoragePolicy<hcal::CUDAHostAllocatorAlias>>" />
     <class name="hcal::DigiCollection<hcal::Flavor4, hcal::common::VecStoragePolicy<hcal::CUDAHostAllocatorAlias>>" />
     <class name="hcal::DigiCollection<hcal::Flavor5, hcal::common::VecStoragePolicy<hcal::CUDAHostAllocatorAlias>>" />
-
-    <!--
-    <class name="hcal::DigiCollection<hcal::Flavor01, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollection<hcal::Flavor2, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollection<hcal::Flavor3, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollection<hcal::Flavor4, hcal::common::ViewStoragePolicy>" />
-    <class name="hcal::DigiCollection<hcal::Flavor5, hcal::common::ViewStoragePolicy>" />
-    -->
 
     <class name="cms::cuda::Product<hcal::DigiCollection<hcal::Flavor01, hcal::common::ViewStoragePolicy>>" persistent="false" />
     <class name="cms::cuda::Product<hcal::DigiCollection<hcal::Flavor2, hcal::common::ViewStoragePolicy>>" persistent="false" />

--- a/CUDADataFormats/HcalRecHitSoA/src/classes.h
+++ b/CUDADataFormats/HcalRecHitSoA/src/classes.h
@@ -1,14 +1,3 @@
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "CUDADataFormats/HcalRecHitSoA/interface/RecHitCollection.h"
-
-namespace hcal {
-
-  // explicit template instantiations
-  template struct RecHitCollection<common::ViewStoragePolicy>;
-
-  template struct RecHitCollection<common::VecStoragePolicy<std::allocator>>;
-
-  template struct RecHitCollection<common::VecStoragePolicy<CUDAHostAllocatorAlias>>;
-
-}  // namespace hcal
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/CUDADataFormats/StdDictionaries/BuildFile.xml
+++ b/CUDADataFormats/StdDictionaries/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="rootcore"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/CUDADataFormats/StdDictionaries/src/classes.h
+++ b/CUDADataFormats/StdDictionaries/src/classes.h
@@ -1,0 +1,4 @@
+#include <cstddef>
+#include <vector>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"

--- a/CUDADataFormats/StdDictionaries/src/classes_def.xml
+++ b/CUDADataFormats/StdDictionaries/src/classes_def.xml
@@ -1,0 +1,14 @@
+<lcgdict>
+    <class name="std::vector<std::byte, cms::cuda::HostAllocator<std::byte, 0>>" />
+
+    <class name="std::vector<uint8_t, cms::cuda::HostAllocator<uint8_t, 0>>" />
+    <class name="std::vector<uint16_t, cms::cuda::HostAllocator<uint16_t, 0>>" />
+    <class name="std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t, 0>>" />
+
+    <class name="std::vector<int8_t, cms::cuda::HostAllocator<int8_t, 0>>" />
+    <class name="std::vector<int16_t, cms::cuda::HostAllocator<int16_t, 0>>" />
+    <class name="std::vector<int32_t, cms::cuda::HostAllocator<int32_t, 0>>" />
+
+    <class name="std::vector<float, cms::cuda::HostAllocator<float, 0>>" />
+    <class name="std::vector<double, cms::cuda::HostAllocator<double, 0>>" />
+</lcgdict>

--- a/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
@@ -22,5 +22,6 @@
   <use name="CUDADataFormats/HcalCommon"/>
   <use name="CUDADataFormats/HcalDigi" />
   <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </library>

--- a/EventFilter/HcalRawToDigi/plugins/ElectronicsMappingGPU.h
+++ b/EventFilter/HcalRawToDigi/plugins/ElectronicsMappingGPU.h
@@ -4,8 +4,8 @@
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 
 #ifndef __CUDACC__
-#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #endif
 
 namespace hcal {
@@ -31,9 +31,6 @@ namespace hcal {
 
       // get device pointers
       Product const &getProduct(cudaStream_t) const;
-
-      //
-      static std::string name() { return std::string{"hcalElectronicsMappingGPU"}; }
 
     private:
       // in the future, we need to arrange so to avoid this copy on the host

--- a/EventFilter/HcalRawToDigi/plugins/HcalCPUDigisProducer.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCPUDigisProducer.cc
@@ -1,22 +1,16 @@
 #include <iostream>
 
-// framework
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CUDADataFormats/HcalDigi/interface/DigiCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
-
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
-#include "CUDADataFormats/HcalDigi/interface/DigiCollection.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 class HcalCPUDigisProducer : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
@@ -62,8 +56,7 @@ void HcalCPUDigisProducer::fillDescriptions(edm::ConfigurationDescriptions& conf
   desc.add<std::string>("digisLabelF5HBOut", "f5HBDigis");
   desc.add<std::string>("digisLabelF3HBOut", "f3HBDigis");
 
-  std::string label = "hcalCPUDigisProducer";
-  confDesc.add(label, desc);
+  confDesc.addWithDefaultLabel(desc);
 }
 
 HcalCPUDigisProducer::HcalCPUDigisProducer(const edm::ParameterSet& ps)
@@ -153,13 +146,9 @@ void HcalCPUDigisProducer::acquire(edm::Event const& event,
 }
 
 void HcalCPUDigisProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
-  auto outf01 = std::make_unique<OProductTypef01>(std::move(digisf01HE_));
-  auto outf5 = std::make_unique<OProductTypef5>(std::move(digisf5HB_));
-  auto outf3 = std::make_unique<OProductTypef3>(std::move(digisf3HB_));
-
-  event.put(digisF01HETokenOut_, std::move(outf01));
-  event.put(digisF5HBTokenOut_, std::move(outf5));
-  event.put(digisF3HBTokenOut_, std::move(outf3));
+  event.emplace(digisF01HETokenOut_, std::move(digisf01HE_));
+  event.emplace(digisF5HBTokenOut_, std::move(digisf5HB_));
+  event.emplace(digisF3HBTokenOut_, std::move(digisf3HB_));
 
   // output collections
   /*

--- a/EventFilter/HcalRawToDigi/plugins/HcalESProducerGPUDefs.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalESProducerGPUDefs.cc
@@ -1,10 +1,8 @@
-#include "HcalRawESProducerGPU.h"
+#include <iostream>
 
 #include "CondFormats/DataRecord/interface/HcalElectronicsMapRcd.h"
-
 #include "EventFilter/HcalRawToDigi/plugins/ElectronicsMappingGPU.h"
-
-#include <iostream>
+#include "HcalRawESProducerGPU.h"
 
 using HcalElectronicsMappingGPUESProducer =
     HcalRawESProducerGPU<hcal::raw::ElectronicsMappingGPU, HcalElectronicsMap, HcalElectronicsMapRcd>;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawESProducerGPU.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawESProducerGPU.h
@@ -1,15 +1,15 @@
 #ifndef RecoLocalCalo_HcalRecProducers_src_HcalRawESProducerGPU_h
 #define RecoLocalCalo_HcalRecProducers_src_HcalRawESProducerGPU_h
 
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include <iostream>
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/typelookup.h"
 
 template <typename Target, typename Source, typename Record>
 class HcalRawESProducerGPU : public edm::ESProducer {
@@ -31,10 +31,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& confDesc) {
     edm::ParameterSetDescription desc;
 
-    std::string label = Target::name() + "ESProducer";
     desc.add<std::string>("ComponentName", "");
     desc.add<std::string>("label", "")->setComment("Product Label");
-    confDesc.add(label, desc);
+    confDesc.addWithDefaultLabel(desc);
   }
 
 private:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecord.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalCalo_HcalRecProducers_src_HcalCombinedRecord_h
-#define RecoLocalCalo_HcalRecProducers_src_HcalCombinedRecord_h
+#ifndef RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecord_h
+#define RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecord_h
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
@@ -10,4 +10,4 @@ public:
   using DependencyRecords = std::tuple<Sources...>;
 };
 
-#endif  // RecoLocalCalo_HcalRecProducers_interface_HcalCombinedRecord_h
+#endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecord_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecordsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecordsGPU.h
@@ -1,12 +1,11 @@
-#ifndef RecoLocalCalo_HcalRecProducers_src_HcalCombinedRecordsGPU_h
-#define RecoLocalCalo_HcalRecProducers_src_HcalCombinedRecordsGPU_h
+#ifndef RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecordsGPU_h
+#define RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecordsGPU_h
 
-#include "CondFormats/DataRecord/interface/HcalPedestalsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalPedestalWidthsRcd.h"
+#include "CondFormats/DataRecord/interface/HcalPedestalsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalQIEDataRcd.h"
 #include "CondFormats/DataRecord/interface/HcalQIETypesRcd.h"
-
-#include "RecoLocalCalo/HcalRecProducers/src/HcalCombinedRecord.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecord.h"
 
 using HcalConvertedPedestalsRcd = HcalCombinedRecord<HcalPedestalsRcd, HcalQIEDataRcd, HcalQIETypesRcd>;
 
@@ -18,4 +17,4 @@ using HcalConvertedPedestalWidthsRcd =
 using HcalConvertedEffectivePedestalWidthsRcd =
     HcalCombinedRecord<HcalPedestalsRcd, HcalPedestalWidthsRcd, HcalQIEDataRcd, HcalQIETypesRcd>;
 
-#endif  // RecoLocalCalo_HcalRecProducers_src_HcalCombinedRecordsGPU_h
+#endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalCombinedRecordsGPU_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h
@@ -7,10 +7,6 @@
 class HcalConvertedEffectivePedestalWidthsGPU final : public HcalConvertedPedestalWidthsGPU {
 public:
   using HcalConvertedPedestalWidthsGPU::HcalConvertedPedestalWidthsGPU;
-
-#ifndef __CUDACC__
-  static std::string name() { return std::string{"hcalConvertedEffectivePedestalWidthsGPU"}; }
-#endif
 };
 
 #endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalConvertedEffectivePedestalWidthsGPU_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h
@@ -9,10 +9,6 @@
 class HcalConvertedEffectivePedestalsGPU final : public HcalConvertedPedestalsGPU {
 public:
   using HcalConvertedPedestalsGPU::HcalConvertedPedestalsGPU;
-
-#ifndef __CUDACC__
-  static std::string name() { return std::string{"hcalConvertedEffectivePedestalsGPU"}; }
-#endif
 };
 
 #endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalConvertedEffectivePedestalsGPU_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h
@@ -31,9 +31,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalConvertedPedestalWidthsGPU"}; }
-
 private:
   uint64_t totalChannels_;
   std::vector<float, cms::cuda::HostAllocator<float>> values_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalsGPU.h
@@ -27,9 +27,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalConvertedPedestalsGPU"}; }
-
   uint32_t offsetForHashes() const { return offsetForHashes_; }
 
 protected:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalGainWidthsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalGainWidthsGPU.h
@@ -28,9 +28,6 @@ public:
   // get device pointers
   Product const &getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalGainWidthsGPU"}; }
-
 private:
   uint64_t totalChannels_;
   std::vector<float, cms::cuda::HostAllocator<float>> value0_, value1_, value2_, value3_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalGainsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalGainsGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalGainsGPU"}; }
-
 private:
   uint64_t totalChannels_;
   std::vector<float, cms::cuda::HostAllocator<float>> values_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalLUTCorrsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalLUTCorrsGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalLUTCorrsGPU"}; }
-
 private:
   std::vector<float, cms::cuda::HostAllocator<float>> value_;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalPedestalWidthsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalPedestalWidthsGPU.h
@@ -29,9 +29,6 @@ public:
   // as in cpu version
   bool unitIsADC() const { return unitIsADC_; }
 
-  //
-  static std::string name() { return std::string{"hcalPedestalWidthsGPU"}; }
-
 private:
   bool unitIsADC_;
   uint64_t totalChannels_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalPedestalsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalPedestalsGPU.h
@@ -39,9 +39,6 @@ public:
   // as in cpu version
   bool unitIsADC() const { return unitIsADC_; }
 
-  //
-  static std::string name() { return std::string{"hcalPedestalsGPU"}; }
-
   uint32_t offsetForHashes() const { return offsetForHashes_; }
 
 private:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalQIECodersGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalQIECodersGPU.h
@@ -28,9 +28,6 @@ public:
   // get device pointers
   Product const &getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalQIECodersGPU"}; }
-
 private:
   uint64_t totalChannels_;
   std::vector<float, cms::cuda::HostAllocator<float>> offsets_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalQIETypesGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalQIETypesGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalQIETypesGPU"}; }
-
 private:
   std::vector<int, cms::cuda::HostAllocator<int>> values_;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalRecoParamsGPU"}; }
-
 private:
   uint64_t totalChannels_;  // hb + he
   std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t>> param1_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsWithPulseShapesGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsWithPulseShapesGPU.h
@@ -34,9 +34,6 @@ public:
   // get device pointers
   Product const &getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalRecoParamsWithPulseShapesGPU"}; }
-
 private:
   uint64_t totalChannels_;  // hb + he
   std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t>> param1_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalRespCorrsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalRespCorrsGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalRespCorrsGPU"}; }
-
 private:
   std::vector<float, cms::cuda::HostAllocator<float>> values_;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMCharacteristicsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMCharacteristicsGPU.h
@@ -29,9 +29,6 @@ public:
   // get device pointers
   Product const &getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalSiPMCharacteristicsGPU"}; }
-
 private:
   std::vector<int, cms::cuda::HostAllocator<int>> pixels_, auxi1_;
   std::vector<float, cms::cuda::HostAllocator<float>> parLin1_, parLin2_, parLin3_, crossTalk_, auxi2_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMParametersGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMParametersGPU.h
@@ -26,20 +26,16 @@ public:
   // get device pointers
   Product const &getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalSiPMParametersGPU"}; }
-
 private:
   uint64_t totalChannels_;
   std::vector<int, cms::cuda::HostAllocator<int>> type_, auxi1_;
   std::vector<float, cms::cuda::HostAllocator<float>> fcByPE_, darkCurrent_, auxi2_;
   /*
-    std::vector<float, cms::cuda::HostAllocator<float>> value0_, value1_, value2_, value3_,
-                                                 width0_, width1_, width2_, width3_;
-                                                 */
+  std::vector<float, cms::cuda::HostAllocator<float>> value0_, value1_, value2_, value3_, width0_, width1_, width2_, width3_;
+  */
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_HcalRecAlgos_interface_HcalSiPMParametersGPU_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalTimeCorrsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalTimeCorrsGPU.h
@@ -25,9 +25,6 @@ public:
   // get device pointers
   Product const& getProduct(cudaStream_t) const;
 
-  //
-  static std::string name() { return std::string{"hcalTimeCorrsGPU"}; }
-
 private:
   std::vector<float, cms::cuda::HostAllocator<float>> value_;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalCombinedRecordsGPU.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalCombinedRecordsGPU.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecordsGPU.h"
+
+EVENTSETUP_RECORD_REG(HcalConvertedPedestalsRcd);
+EVENTSETUP_RECORD_REG(HcalConvertedPedestalWidthsRcd);

--- a/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
@@ -1,51 +1,43 @@
-// framework
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
-#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
-
-#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalGainWidthsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalGainsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalLUTCorrsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalQIEDataRcd.h"
-#include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
-#include "CondFormats/DataRecord/interface/HcalTimeCorrsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalQIETypesRcd.h"
-#include "CondFormats/DataRecord/interface/HcalSiPMParametersRcd.h"
+#include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
+#include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
 #include "CondFormats/DataRecord/interface/HcalSiPMCharacteristicsRcd.h"
-
-//#include "CondFormats/DataRecord/interface/HcalPedestalsRcd.h"
-#include "RecoLocalCalo/HcalRecProducers/src/HcalCombinedRecordsGPU.h"
-
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsWithPulseShapesGPU.h"
+#include "CondFormats/DataRecord/interface/HcalSiPMParametersRcd.h"
+#include "CondFormats/DataRecord/interface/HcalTimeCorrsRcd.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/HcalCommonData/interface/HcalDDDRecConstants.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/DeclsForKernels.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalGainWidthsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalGainsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalLUTCorrsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalPedestalWidthsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalQIECodersGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRespCorrsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalTimeCorrsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalQIETypesGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMParametersGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRecoParamsWithPulseShapesGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalRespCorrsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMCharacteristicsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h"
-#include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h"
-
-#include "RecoLocalCalo/HcalRecAlgos/interface/DeclsForKernels.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMParametersGPU.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalTimeCorrsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/MahiGPU.h"
+#include "RecoLocalCalo/HcalRecProducers/src/HcalCombinedRecordsGPU.h"
 
 class HBHERecHitProducerGPU : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
@@ -109,23 +101,30 @@ HBHERecHitProducerGPU::HBHERecHitProducerGPU(edm::ParameterSet const& ps)
   configParameters_.kernelMinimizeThreads[1] = threadsMinimize[1];
   configParameters_.kernelMinimizeThreads[2] = threadsMinimize[2];
 
-  outputGPU_.allocate(configParameters_);
-  scratchGPU_.allocate(configParameters_);
+  // call CUDA API functions only if CUDA is available
+  edm::Service<CUDAService> cs;
+  if (cs and cs->enabled()) {
+    outputGPU_.allocate(configParameters_);
+    scratchGPU_.allocate(configParameters_);
 
-  // FIXME: use default device and default stream
-  cudaCheck(
-      cudaMalloc((void**)&configParameters_.pulseOffsetsDevice, sizeof(int) * configParameters_.pulseOffsets.size()));
-  cudaCheck(cudaMemcpy(configParameters_.pulseOffsetsDevice,
-                       configParameters_.pulseOffsets.data(),
-                       configParameters_.pulseOffsets.size() * sizeof(int),
-                       cudaMemcpyHostToDevice));
+    // FIXME: use default device and default stream
+    cudaCheck(cudaMalloc((void**)&configParameters_.pulseOffsetsDevice, sizeof(int) * configParameters_.pulseOffsets.size()));
+    cudaCheck(cudaMemcpy(configParameters_.pulseOffsetsDevice,
+                         configParameters_.pulseOffsets.data(),
+                         configParameters_.pulseOffsets.size() * sizeof(int),
+                         cudaMemcpyHostToDevice));
+  }
 }
 
 HBHERecHitProducerGPU::~HBHERecHitProducerGPU() {
-  outputGPU_.deallocate(configParameters_);
-  scratchGPU_.deallocate(configParameters_);
+  // call CUDA API functions only if CUDA is available
+  edm::Service<CUDAService> cs;
+  if (cs and cs->enabled()) {
+    outputGPU_.deallocate(configParameters_);
+    scratchGPU_.deallocate(configParameters_);
 
-  cudaCheck(cudaFree(configParameters_.pulseOffsetsDevice));
+    cudaCheck(cudaFree(configParameters_.pulseOffsetsDevice));
+  }
 }
 
 void HBHERecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptions& cdesc) {
@@ -154,8 +153,7 @@ void HBHERecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptions& cde
   desc.add<std::vector<double>>("tmaxTimeSlewParameters", {16.00, 10.00, 6.25});
   desc.add<std::vector<uint32_t>>("kernelMinimizeThreads", {16, 1, 1});
 
-  std::string label = "hbheRecHitProducerGPU";
-  cdesc.add(label, desc);
+  cdesc.addWithDefaultLabel(desc);
 }
 
 void HBHERecHitProducerGPU::acquire(edm::Event const& event,

--- a/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHERecHitProducerGPU.cc
@@ -20,6 +20,7 @@
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/DeclsForKernels.h"
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecordsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h"
@@ -37,7 +38,6 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSiPMParametersGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalTimeCorrsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/MahiGPU.h"
-#include "RecoLocalCalo/HcalRecProducers/src/HcalCombinedRecordsGPU.h"
 
 class HBHERecHitProducerGPU : public edm::stream::EDProducer<edm::ExternalWork> {
 public:

--- a/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
@@ -1,20 +1,16 @@
 #include <iostream>
+#include <string>
 
-// framework
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CUDADataFormats/HcalRecHitSoA/interface/RecHitCollection.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
-#include "CUDADataFormats/HcalRecHitSoA/interface/RecHitCollection.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 class HcalCPURecHitsProducer : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
@@ -44,8 +40,7 @@ void HcalCPURecHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& co
   desc.add<std::string>("recHitsM0LabelOut", "recHitsM0HBHE");
   desc.add<std::string>("recHitsLegacyLabelOut", "recHitsLegacyHBHE");
 
-  std::string label = "hcalCPURecHitsProducer";
-  confDesc.add(label, desc);
+  confDesc.addWithDefaultLabel(desc);
 }
 
 HcalCPURecHitsProducer::HcalCPURecHitsProducer(const edm::ParameterSet& ps)
@@ -103,7 +98,7 @@ void HcalCPURecHitsProducer::produce(edm::Event& event, edm::EventSetup const& s
   event.put(recHitsLegacyTokenOut_, std::move(recHitsLegacy));
 
   // put a new format
-  event.put(recHitsM0TokenOut_, std::make_unique<OProductType>(std::move(tmpRecHits_)));
+  event.emplace(recHitsM0TokenOut_, std::move(tmpRecHits_));
 }
 
 DEFINE_FWK_MODULE(HcalCPURecHitsProducer);

--- a/RecoLocalCalo/HcalRecProducers/src/HcalESProducerGPU.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalESProducerGPU.h
@@ -1,21 +1,20 @@
 #ifndef RecoLocalCalo_HcalRecProducers_src_HcalESProducerGPU_h
 #define RecoLocalCalo_HcalRecProducers_src_HcalESProducerGPU_h
 
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Framework/interface/ESProductHost.h"
-#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
-
-#include <iostream>
 #include <array>
+#include <iostream>
 #include <tuple>
 #include <utility>
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProductHost.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Utilities/interface/typelookup.h"
 
 template <typename Record, typename Target, typename Source>
 class HcalESProducerGPU : public edm::ESProducer {
@@ -38,10 +37,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& confDesc) {
     edm::ParameterSetDescription desc;
 
-    std::string label = Target::name() + "ESProducer";
     desc.add<std::string>("ComponentName", "");
     desc.add<std::string>("label", "")->setComment("Product Label");
-    confDesc.add(label, desc);
+    confDesc.addWithDefaultLabel(desc);
   }
 
 private:
@@ -104,11 +102,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& confDesc) {
     edm::ParameterSetDescription desc;
 
-    std::string label = Target::name() + "ESProducerWithDependencies";
     desc.add<std::string>("ComponentName", "");
     for (std::size_t i = 0; i < nsources; i++)
       desc.add<std::string>("label" + std::to_string(i), "")->setComment("Product Label");
-    confDesc.add(label, desc);
+    confDesc.addWithDefaultLabel(desc);
   }
 
 private:

--- a/RecoLocalCalo/HcalRecProducers/src/HcalESProducersGPUDefs.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalESProducersGPUDefs.cc
@@ -86,17 +86,11 @@ DEFINE_FWK_EVENTSETUP_MODULE(HcalQIETypesGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalSiPMParametersGPUESProducer);
 DEFINE_FWK_EVENTSETUP_MODULE(HcalSiPMCharacteristicsGPUESProducer);
 
-#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
-
-#include "RecoLocalCalo/HcalRecProducers/src/HcalCombinedRecordsGPU.h"
-
+#include "RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecordsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedPedestalWidthsGPU.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalConvertedEffectivePedestalWidthsGPU.h"
-
-EVENTSETUP_RECORD_REG(HcalConvertedPedestalsRcd);
-EVENTSETUP_RECORD_REG(HcalConvertedPedestalWidthsRcd);
 
 using HcalConvertedPedestalsGPUESProducer = HcalESProducerGPUWithDependencies<HcalConvertedPedestalsRcd,
                                                                               HcalConvertedPedestalsGPU,


### PR DESCRIPTION
Remove unnecessary dictionary declarations.

Move common ROOT dictionaries to a dedicated new package, `CUDADataFormats/StdDictionaries` .

Determine the default module label automatically for templated and non-templated `EDProducer`s and `ESProducer`s, and remove the `name()` static method previously used to distinguish their template arguments.

Use `Event::emplace` instead of `Event:put` where relevant.

Protect the use of CUDA API calls in module constructors and destructors, checking that the `CUDAService` is available and enabled.