### PR TITLE
Enable ECAL rechits reconstruction on GPUs

### DIFF
--- a/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
+++ b/EventFilter/EcalRawToDigi/python/ecalDigis_cff.py
@@ -18,11 +18,11 @@ ecalDigisGPU = _ecalRawToDigiGPU.clone()
 
 # copy the digi from the GPU to the CPU and convert to legacy format
 from EventFilter.EcalRawToDigi.ecalCPUDigisProducer_cfi import ecalCPUDigisProducer as _ecalCPUDigisProducer
-_gpu_ecalDigis = _ecalCPUDigisProducer.clone(
-  digisInLabelEB = 'ecalDigisGPU:ebDigisGPU',
-  digisInLabelEE = 'ecalDigisGPU:eeDigisGPU',
-  produceDummyIntegrityCollections = True,
+_ecalDigis_gpu = _ecalCPUDigisProducer.clone(
+  digisInLabelEB = cms.InputTag('ecalDigisGPU', 'ebDigisGPU'),
+  digisInLabelEE = cms.InputTag('ecalDigisGPU', 'eeDigisGPU'),
+  produceDummyIntegrityCollections = True
 )
-gpu.toReplaceWith(ecalDigis, _gpu_ecalDigis)
+gpu.toReplaceWith(ecalDigis, _ecalDigis_gpu)
 
 gpu.toReplaceWith(ecalDigisTask, cms.Task(ecalElectronicsMappingGPUESProducer, ecalDigisGPU, ecalDigis))

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.gpu_cff import gpu
 
 # TPG condition needed by ecalRecHit producer if TT recovery is ON
 from RecoLocalCalo.EcalRecProducers.ecalRecHitTPGConditions_cff import *
@@ -42,6 +43,57 @@ ecalOnlyLocalRecoTask = cms.Task(
     ecalRecHitNoTPTask)
 
 ecalOnlyLocalRecoSequence = cms.Sequence(ecalOnlyLocalRecoTask)
+
+# ECAL rechit calibrations on GPU
+from RecoLocalCalo.EcalRecProducers.ecalRechitADCToGeVConstantGPUESProducer_cfi import ecalRechitADCToGeVConstantGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalRechitChannelStatusGPUESProducer_cfi import ecalRechitChannelStatusGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalIntercalibConstantsGPUESProducer_cfi import ecalIntercalibConstantsGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosGPUESProducer_cfi import ecalLaserAPDPNRatiosGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosRefGPUESProducer_cfi import ecalLaserAPDPNRatiosRefGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalLaserAlphasGPUESProducer_cfi import ecalLaserAlphasGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalLinearCorrectionsGPUESProducer_cfi import ecalLinearCorrectionsGPUESProducer
+
+# ECAL rechits running on GPU
+from RecoLocalCalo.EcalRecProducers.ecalRecHitGPU_cfi import ecalRecHitGPU as _ecalRecHitGPU
+ecalRecHitGPU = _ecalRecHitGPU.clone(
+    uncalibrecHitsInLabelEB = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEB'),
+    uncalibrecHitsInLabelEE = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEE')
+)
+
+# copy the rechits from GPU to CPU
+from RecoLocalCalo.EcalRecProducers.ecalCPURecHitProducer_cfi import ecalCPURecHitProducer as _ecalCPURecHitProducer
+ecalRecHitSoA = _ecalCPURecHitProducer.clone(
+    recHitsInLabelEB = cms.InputTag('ecalRecHitGPU', 'EcalRecHitsEB'),
+    recHitsInLabelEE = cms.InputTag('ecalRecHitGPU', 'EcalRecHitsEE')
+)
+
+# convert the rechits from SoA to legacy format
+from RecoLocalCalo.EcalRecProducers.ecalRecHitConvertGPU2CPUFormat_cfi import ecalRecHitConvertGPU2CPUFormat as _ecalRecHitConvertGPU2CPUFormat
+_ecalRecHit_gpu = _ecalRecHitConvertGPU2CPUFormat.clone(
+    recHitsLabelGPUEB = cms.InputTag('ecalRecHitSoA', 'EcalRecHitsEB'),
+    recHitsLabelGPUEE = cms.InputTag('ecalRecHitSoA', 'EcalRecHitsEE')
+)
+gpu.toReplaceWith(ecalRecHit, _ecalRecHit_gpu)
+
+# ECAL reconstruction on GPU
+gpu.toReplaceWith(ecalRecHitNoTPTask, cms.Task(
+  # ECAL rechit calibrations on GPU
+  ecalRechitADCToGeVConstantGPUESProducer,
+  ecalRechitChannelStatusGPUESProducer,
+  ecalIntercalibConstantsGPUESProducer,
+  ecalLaserAPDPNRatiosGPUESProducer,
+  ecalLaserAPDPNRatiosRefGPUESProducer,
+  ecalLaserAlphasGPUESProducer,
+  ecalLinearCorrectionsGPUESProducer,
+  # ECAL rechits running on GPU
+  ecalRecHitGPU,
+  # copy the rechits from GPU to CPU
+  ecalRecHitSoA,
+  # convert the rechits from SoA to legacy format
+  ecalRecHit,
+  # ECAL preshower rechit legacy module
+  ecalPreshowerRecHit
+))
 
 # Phase 2 modifications
 from RecoLocalCalo.EcalRecProducers.ecalDetailedTimeRecHit_cfi import *

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -29,12 +29,27 @@ ecalMultiFitUncalibRecHitSoA = _ecalCPUUncalibRecHitProducer.clone(
   recHitsInLabelEE = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEE'),
 )
 
-# convert the uncalibrated rechits legacy format
+# convert the uncalibrated rechits from SoA to legacy format
 from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitConvertGPU2CPUFormat_cfi import ecalUncalibRecHitConvertGPU2CPUFormat as _ecalUncalibRecHitConvertGPU2CPUFormat
-_gpu_ecalMultiFitUncalibRecHit = _ecalUncalibRecHitConvertGPU2CPUFormat.clone(
+_ecalMultiFitUncalibRecHit_gpu = _ecalUncalibRecHitConvertGPU2CPUFormat.clone(
   recHitsLabelGPUEB = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
   recHitsLabelGPUEE = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEE'),
 )
-gpu.toReplaceWith(ecalMultiFitUncalibRecHit, _gpu_ecalMultiFitUncalibRecHit)
+gpu.toReplaceWith(ecalMultiFitUncalibRecHit, _ecalMultiFitUncalibRecHit_gpu)
 
-gpu.toReplaceWith(ecalMultiFitUncalibRecHitTask, cms.Task(ecalMultiFitUncalibRecHitGPU, ecalMultiFitUncalibRecHitSoA, ecalMultiFitUncalibRecHit))
+gpu.toReplaceWith(ecalMultiFitUncalibRecHitTask, cms.Task(
+  # ECAL conditions used by the multifit running on GPU
+  ecalPedestalsGPUESProducer,
+  ecalGainRatiosGPUESProducer,
+  ecalPulseShapesGPUESProducer,
+  ecalPulseCovariancesGPUESProducer,
+  ecalSamplesCorrelationGPUESProducer,
+  ecalTimeBiasCorrectionsGPUESProducer,
+  ecalTimeCalibConstantsGPUESProducer,
+  # ECAL multifit running on GP
+  ecalMultiFitUncalibRecHitGPU,
+  # copy the uncalibrated rechits from GPU to CPU
+  ecalMultiFitUncalibRecHitSoA,
+  # convert the uncalibrated rechits legacy format
+  ecalMultiFitUncalibRecHit,
+))


### PR DESCRIPTION
Update sequences for ECAL local reconstruction running on GPU:
  - move ESProducers into the relevant cms.Tasks
  - reconstruct ECAL rechits on GPUs