### PR TITLE
Enable ECAL rechits reconstruction on GPUs at HLT

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -473,8 +473,8 @@ def customise_gpu_ecal(process):
       + process.hltEcalDigis
       + process.hltEcalPreshowerDigis
       + process.hltEcalUncalibRecHitGPU
-      #+ process.hltEcalUncalibRecHitSoA
-      #+ process.hltEcalUncalibRecHit
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
       + process.hltEcalRecHitGPU
       + process.hltEcalRecHitSoA
@@ -485,8 +485,8 @@ def customise_gpu_ecal(process):
         process.hltEcalDigisGPU
       + process.hltEcalDigis
       + process.hltEcalUncalibRecHitGPU
-      #+ process.hltEcalUncalibRecHitSoA
-      #+ process.hltEcalUncalibRecHit
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
       + process.hltEcalRecHitGPU
       + process.hltEcalRecHitSoA
@@ -497,14 +497,18 @@ def customise_gpu_ecal(process):
       + process.hltEcalDigis
       + process.hltEcalPreshowerDigis
       + process.hltEcalUncalibRecHitGPU
-      #+ process.hltEcalUncalibRecHitSoA
-      #+ process.hltEcalUncalibRecHit
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
       + process.hltEcalRecHitGPU
       + process.hltEcalRecHitSoA
       + process.hltEcalRecHit
       + process.hltEcalPreshowerRecHit)
 
+    # 
+    # hltEcalUncalibRecHitSoA + hltEcalUncalibRecHit
+    # Needed by phi-symmetry filter for calibration stream -> ECAL will follow up
+    #
 
     # done
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -308,6 +308,14 @@ def customise_gpu_ecal(process):
     process.load("RecoLocalCalo.EcalRecProducers.ecalTimeBiasCorrectionsGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalTimeCalibConstantsGPUESProducer_cfi")
 
+    process.load("RecoLocalCalo.EcalRecProducers.ecalRechitADCToGeVConstantGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalRechitChannelStatusGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalIntercalibConstantsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosRefGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalLaserAlphasGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalLinearCorrectionsGPUESProducer_cfi")
+    
 
     # Modules and EDAliases
 
@@ -387,6 +395,77 @@ def customise_gpu_ecal(process):
     )
 
 
+    #
+    # ecal rechit
+    #
+    # run on gpu
+    process.hltEcalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",                            
+        uncalibrecHitsInLabelEB = cms.InputTag("hltEcalUncalibRecHitGPU","EcalUncalibRecHitsEB"),
+        uncalibrecHitsInLabelEE = cms.InputTag("hltEcalUncalibRecHitGPU","EcalUncalibRecHitsEE"),
+        recHitsLabelEB = cms.string("EcalRecHitsEB"),
+        recHitsLabelEE = cms.string("EcalRecHitsEE"),
+        
+        maxNumberHits = cms.uint32(20000),  # FIXME AM
+        
+        ## db statuses to be exluded from reconstruction (some will be recovered)
+        ChannelStatusToBeExcluded = cms.vstring(   'kDAC',
+                                                   'kNoisy',
+                                                   'kNNoisy',
+                                                   'kFixedG6',
+                                                   'kFixedG1',
+                                                   'kFixedG0',
+                                                   'kNonRespondingIsolated',
+                                                   'kDeadVFE',
+                                                   'kDeadFE',
+                                                   'kNoDataNoTP',
+                                                   ),
+        
+        ## avoid propagation of dead channels other than after recovery
+        killDeadChannels = cms.bool(True),
+        ## define maximal and minimal values for the laser corrections      
+        EBLaserMIN = cms.double(0.01),
+        EELaserMIN = cms.double(0.01),                                
+        EBLaserMAX = cms.double(30.0),
+        EELaserMAX = cms.double(30.0),
+                                
+        ## reco flags association to DB flag
+        flagsMapDBReco = cms.PSet(
+            kGood  = cms.vstring('kOk','kDAC','kNoLaser','kNoisy'),
+            kNoisy = cms.vstring('kNNoisy','kFixedG6','kFixedG1'),
+            kNeighboursRecovered = cms.vstring('kFixedG0',
+                                               'kNonRespondingIsolated',
+                                               'kDeadVFE'),
+            kTowerRecovered = cms.vstring('kDeadFE'),
+            kDead           = cms.vstring('kNoDataNoTP')
+            ), 
+        ## for channel recovery
+        recoverEBIsolatedChannels = cms.bool(False),
+        recoverEEIsolatedChannels = cms.bool(False),
+        recoverEBVFE  = cms.bool(False),
+        recoverEEVFE  = cms.bool(False),
+        recoverEBFE = cms.bool(True),
+        recoverEEFE = cms.bool(True),
+    )
+
+    # copy from gpu to cpu
+    process.hltEcalRecHitSoA  = cms.EDProducer('EcalCPURecHitProducer',
+        recHitsInLabelEB = cms.InputTag('hltEcalRecHitGPU', 'EcalRecHitsEB'),
+        recHitsInLabelEE = cms.InputTag('hltEcalRecHitGPU', 'EcalRecHitsEE'),
+        recHitsOutLabelEB = cms.string('EcalRecHitsEB'),
+        recHitsOutLabelEE = cms.string('EcalRecHitsEE'),
+        containsTimingInformation = cms.bool(False),
+    )
+
+    # transform to legacy format
+    process.hltEcalRecHit  = cms.EDProducer('EcalRecHitConvertGPU2CPUFormat',
+        recHitsLabelGPUEB = cms.InputTag('ecalRecHitProducerGPU', 'EcalRecHitsGPUEB'),
+        recHitsLabelGPUEE = cms.InputTag('ecalRecHitProducerGPU', 'EcalRecHitsGPUEE'),
+        recHitsLabelCPUEB = cms.string('EcalRecHitsEB'),
+        recHitsLabelCPUEE = cms.string('EcalRecHitsEE'),
+    )
+
+
+ 
     # Sequences
 
     process.HLTDoFullUnpackingEgammaEcalMFSequence = cms.Sequence(

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -405,7 +405,7 @@ def customise_gpu_ecal(process):
         recHitsLabelEB = cms.string("EcalRecHitsEB"),
         recHitsLabelEE = cms.string("EcalRecHitsEE"),
         
-        maxNumberHits = cms.uint32(20000),  # FIXME AM
+        maxNumberHits = cms.uint32(75000),  # max number
         
         ## db statuses to be exluded from reconstruction (some will be recovered)
         ChannelStatusToBeExcluded = cms.vstring(   'kDAC',

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -473,9 +473,11 @@ def customise_gpu_ecal(process):
       + process.hltEcalDigis
       + process.hltEcalPreshowerDigis
       + process.hltEcalUncalibRecHitGPU
-      + process.hltEcalUncalibRecHitSoA
-      + process.hltEcalUncalibRecHit
+      #+ process.hltEcalUncalibRecHitSoA
+      #+ process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHitGPU
+      + process.hltEcalRecHitSoA
       + process.hltEcalRecHit
       + process.hltEcalPreshowerRecHit)
 
@@ -483,9 +485,11 @@ def customise_gpu_ecal(process):
         process.hltEcalDigisGPU
       + process.hltEcalDigis
       + process.hltEcalUncalibRecHitGPU
-      + process.hltEcalUncalibRecHitSoA
-      + process.hltEcalUncalibRecHit
+      #+ process.hltEcalUncalibRecHitSoA
+      #+ process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHitGPU
+      + process.hltEcalRecHitSoA
       + process.hltEcalRecHit)
 
     process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(
@@ -493,9 +497,11 @@ def customise_gpu_ecal(process):
       + process.hltEcalDigis
       + process.hltEcalPreshowerDigis
       + process.hltEcalUncalibRecHitGPU
-      + process.hltEcalUncalibRecHitSoA
-      + process.hltEcalUncalibRecHit
+      #+ process.hltEcalUncalibRecHitSoA
+      #+ process.hltEcalUncalibRecHit
       + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHitGPU
+      + process.hltEcalRecHitSoA
       + process.hltEcalRecHit
       + process.hltEcalPreshowerRecHit)
 

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -405,7 +405,7 @@ def customise_gpu_ecal(process):
         recHitsLabelEB = cms.string("EcalRecHitsEB"),
         recHitsLabelEE = cms.string("EcalRecHitsEE"),
         
-        maxNumberHits = cms.uint32(75000),  # max number
+        maxNumberHits = cms.uint32(20000),  # max number -> real max 75k
         
         ## db statuses to be exluded from reconstruction (some will be recovered)
         ChannelStatusToBeExcluded = cms.vstring(   'kDAC',

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -304,6 +304,10 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
   nee_ = eeUncalibRecHits.size;
   //   std::cout << " [EcalRecHitProducerGPU::acquire]  neb_:nee_ = " << neb_ << " : " << nee_ << std::endl;
 
+  if ((neb_ + nee_) > maxNumberHits_) {
+    edm::LogError("EcalRecHitProducerGPU") << "max number of channels exceeded. See options 'maxNumberHits' ";
+  }
+  
   int nchannelsEB = ebUncalibRecHits.size;  // --> offsetForInput, first EB and then EE
 
   // conditions

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -287,6 +287,10 @@ void EcalUncalibRecHitProducerGPU::acquire(edm::Event const& event,
   neb_ = ebDigis.ndigis;
   nee_ = eeDigis.ndigis;
 
+  if ((neb_ + nee_) > maxNumberHits_) {
+    edm::LogError("EcalUncalibRecHitProducerGPU") << "max number of channels exceeded. See options 'maxNumberHits' ";
+  }
+  
   // conditions
   setup.get<EcalPedestalsRcd>().get(pedestalsHandle_);
   setup.get<EcalGainRatiosRcd>().get(gainRatiosHandle_);


### PR DESCRIPTION
Modules for ECAL rechit on GPU for HLT.
- test: it runs
TimeReport   0.006559     0.006559     0.000060  hltEcalRecHitGPU
