### PR TITLE
[RFC] Add make_device_unique() functions to ScopedContextBase

### DIFF
--- a/CUDADataFormats/Common/interface/ProductBase.h
+++ b/CUDADataFormats/Common/interface/ProductBase.h
@@ -9,9 +9,7 @@
 
 namespace cms {
   namespace cuda {
-    namespace impl {
-      class ScopedContextBase;
-    }
+    class ScopedContextBase;
 
     /**
      * Base class for all instantiations of CUDA<T> to hold the
@@ -59,7 +57,7 @@ namespace cms {
           : stream_{std::move(stream)}, event_{std::move(event)}, device_{device} {}
 
     private:
-      friend class impl::ScopedContextBase;
+      friend class ScopedContextBase;
       friend class ScopedContextProduce;
 
       // The following function is intended to be used only from ScopedContext

--- a/HeterogeneousCore/CUDACore/interface/ScopedContextBase.h
+++ b/HeterogeneousCore/CUDACore/interface/ScopedContextBase.h
@@ -1,0 +1,62 @@
+#ifndef HeterogeneousCore_CUDACore_ScopedContextBase_h
+#define HeterogeneousCore_CUDACore_ScopedContextBase_h
+
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/SharedStreamPtr.h"
+
+namespace cms {
+  namespace cuda {
+    class ProductBase;
+
+    class ScopedContextBase {
+    public:
+      ScopedContextBase(ScopedContextBase const&) = delete;
+      ScopedContextBase& operator=(ScopedContextBase const&) = delete;
+      ScopedContextBase(ScopedContextBase&&) = delete;
+      ScopedContextBase& operator=(ScopedContextBase&&) = delete;
+
+      int device() const { return currentDevice_; }
+
+      // cudaStream_t is a pointer to a thread-safe object, for which a
+      // mutable access is needed even if the ScopedContext itself
+      // would be const. Therefore it is ok to return a non-const
+      // pointer from a const method here.
+      cudaStream_t stream() const { return stream_.get(); }
+      const SharedStreamPtr& streamPtr() const { return stream_; }
+
+      template <typename T>
+      typename cms::cuda::device::impl::make_device_unique_selector<T>::non_array make_device_unique() {
+        return cms::cuda::make_device_unique<T>(stream());
+      }
+
+      template <typename T>
+      typename cms::cuda::device::impl::make_device_unique_selector<T>::unbounded_array make_device_unique(size_t n) {
+        return cms::cuda::make_device_unique<T>(n, stream());
+      }
+
+      template <typename T, typename... Args>
+      typename cms::cuda::device::impl::make_device_unique_selector<T>::bounded_array make_device_unique(Args&&...) =
+          delete;
+
+    protected:
+      // The constructors set the current device, but the device
+      // is not set back to the previous value at the destructor. This
+      // should be sufficient (and tiny bit faster) as all CUDA API
+      // functions relying on the current device should be called from
+      // the scope where this context is. The current device doesn't
+      // really matter between modules (or across TBB tasks).
+      explicit ScopedContextBase(edm::StreamID streamID);
+
+      explicit ScopedContextBase(const ProductBase& data);
+
+      explicit ScopedContextBase(int device, SharedStreamPtr stream);
+
+    private:
+      int currentDevice_;
+      SharedStreamPtr stream_;
+    };
+  }  // namespace cuda
+}  // namespace cms
+
+#endif

--- a/HeterogeneousCore/CUDACore/src/ScopedContext.cc
+++ b/HeterogeneousCore/CUDACore/src/ScopedContext.cc
@@ -3,10 +3,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/StreamCache.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-
-#include "chooseDevice.h"
 
 namespace {
   struct CallbackData {
@@ -38,27 +35,6 @@ namespace {
 
 namespace cms::cuda {
   namespace impl {
-    ScopedContextBase::ScopedContextBase(edm::StreamID streamID) : currentDevice_(chooseDevice(streamID)) {
-      cudaCheck(cudaSetDevice(currentDevice_));
-      stream_ = getStreamCache().get();
-    }
-
-    ScopedContextBase::ScopedContextBase(const ProductBase& data) : currentDevice_(data.device()) {
-      cudaCheck(cudaSetDevice(currentDevice_));
-      if (data.mayReuseStream()) {
-        stream_ = data.streamPtr();
-      } else {
-        stream_ = getStreamCache().get();
-      }
-    }
-
-    ScopedContextBase::ScopedContextBase(int device, SharedStreamPtr stream)
-        : currentDevice_(device), stream_(std::move(stream)) {
-      cudaCheck(cudaSetDevice(currentDevice_));
-    }
-
-    ////////////////////
-
     void ScopedContextGetterBase::synchronizeStreams(int dataDevice,
                                                      cudaStream_t dataStream,
                                                      bool available,

--- a/HeterogeneousCore/CUDACore/src/ScopedContextBase.cc
+++ b/HeterogeneousCore/CUDACore/src/ScopedContextBase.cc
@@ -1,0 +1,27 @@
+#include "CUDADataFormats/Common/interface/ProductBase.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContextBase.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/StreamCache.h"
+
+#include "chooseDevice.h"
+
+namespace cms::cuda {
+  ScopedContextBase::ScopedContextBase(edm::StreamID streamID) : currentDevice_(chooseDevice(streamID)) {
+    cudaCheck(cudaSetDevice(currentDevice_));
+    stream_ = getStreamCache().get();
+  }
+
+  ScopedContextBase::ScopedContextBase(const ProductBase& data) : currentDevice_(data.device()) {
+    cudaCheck(cudaSetDevice(currentDevice_));
+    if (data.mayReuseStream()) {
+      stream_ = data.streamPtr();
+    } else {
+      stream_ = getStreamCache().get();
+    }
+  }
+
+  ScopedContextBase::ScopedContextBase(int device, SharedStreamPtr stream)
+      : currentDevice_(device), stream_(std::move(stream)) {
+    cudaCheck(cudaSetDevice(currentDevice_));
+  }
+}  // namespace cms::cuda

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPU.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPU.cc
@@ -49,7 +49,7 @@ void TestCUDAProducerGPU::produce(edm::StreamID streamID, edm::Event& iEvent, ed
   cms::cuda::ScopedContextProduce ctx{in};
   cms::cudatest::Thing const& input = ctx.get(in);
 
-  ctx.emplace(iEvent, dstToken_, cms::cudatest::Thing{gpuAlgo_.runAlgo(label_, input.get(), ctx.stream())});
+  ctx.emplace(iEvent, dstToken_, cms::cudatest::Thing{gpuAlgo_.runAlgo(label_, input.get(), ctx)});
 
   edm::LogVerbatim("TestCUDAProducerGPU")
       << label_ << " TestCUDAProducerGPU::produce end event " << iEvent.id().event() << " stream " << iEvent.streamID();

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEW.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEW.cc
@@ -69,7 +69,7 @@ void TestCUDAProducerGPUEW::acquire(edm::Event const& iEvent,
   cms::cuda::ScopedContextAcquire ctx{in, std::move(waitingTaskHolder), ctxState_};
   cms::cudatest::Thing const& input = ctx.get(in);
 
-  devicePtr_ = gpuAlgo_.runAlgo(label_, input.get(), ctx.stream());
+  devicePtr_ = gpuAlgo_.runAlgo(label_, input.get(), ctx);
   // Mimick the need to transfer some of the GPU data back to CPU to
   // be used for something within this module, or to be put in the
   // event.

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEWTask.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUEWTask.cc
@@ -79,7 +79,7 @@ void TestCUDAProducerGPUEWTask::acquire(edm::Event const& iEvent,
 
   cms::cudatest::Thing const& input = ctx.get(in);
 
-  devicePtr_ = gpuAlgo_.runAlgo(label_, input.get(), ctx.stream());
+  devicePtr_ = gpuAlgo_.runAlgo(label_, input.get(), ctx);
   // Mimick the need to transfer some of the GPU data back to CPU to
   // be used for something within this module, or to be put in the
   // event.
@@ -107,7 +107,7 @@ void TestCUDAProducerGPUEWTask::addSimpleWork(edm::EventNumber_t eventID,
 
     ctx.pushNextTask(
         [eventID, streamID, this](cms::cuda::ScopedContextTask ctx) { addSimpleWork(eventID, streamID, ctx); });
-    gpuAlgo_.runSimpleAlgo(devicePtr_.get(), ctx.stream());
+    gpuAlgo_.runSimpleAlgo(devicePtr_.get(), ctx);
     edm::LogVerbatim("TestCUDAProducerGPUEWTask")
         << label_ << " TestCUDAProducerGPUEWTask::addSimpleWork end event " << eventID << " stream " << streamID;
   } else {

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUFirst.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUFirst.cc
@@ -46,7 +46,7 @@ void TestCUDAProducerGPUFirst::produce(edm::StreamID streamID,
 
   cms::cuda::ScopedContextProduce ctx{streamID};
 
-  cms::cuda::device::unique_ptr<float[]> output = gpuAlgo_.runAlgo(label_, ctx.stream());
+  cms::cuda::device::unique_ptr<float[]> output = gpuAlgo_.runAlgo(label_, ctx);
   ctx.emplace(iEvent, dstToken_, std::move(output));
 
   edm::LogVerbatim("TestCUDAProducerGPUFirst") << label_ << " TestCUDAProducerGPUFirst::produce end event "

--- a/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.h
+++ b/HeterogeneousCore/CUDATest/plugins/TestCUDAProducerGPUKernel.h
@@ -5,6 +5,7 @@
 
 #include <cuda_runtime.h>
 
+#include "HeterogeneousCore/CUDACore/interface/ScopedContextBase.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
 /**
@@ -24,14 +25,14 @@ public:
   ~TestCUDAProducerGPUKernel() = default;
 
   // returns (owning) pointer to device memory
-  cms::cuda::device::unique_ptr<float[]> runAlgo(const std::string& label, cudaStream_t stream) const {
-    return runAlgo(label, nullptr, stream);
+  cms::cuda::device::unique_ptr<float[]> runAlgo(const std::string& label, cms::cuda::ScopedContextBase& ctx) const {
+    return runAlgo(label, nullptr, ctx);
   }
   cms::cuda::device::unique_ptr<float[]> runAlgo(const std::string& label,
                                                  const float* d_input,
-                                                 cudaStream_t stream) const;
+                                                 cms::cuda::ScopedContextBase& ctx) const;
 
-  void runSimpleAlgo(float* d_data, cudaStream_t stream) const;
+  void runSimpleAlgo(float* d_data, cms::cuda::ScopedContextBase& ctx) const;
 };
 
 #endif


### PR DESCRIPTION
 #### PR description:

This PR is to demonstrate how the CUDA memory allocation API would change if moved part of `cms::cuda::ScopedContext*`. Such an API change would allow
* moving the caching allocators back to be owned by `CUDAService` instead of being singletons
  * them being singletons adds some complexity in the destructor of `CUDAService`
* reducing the number CUDA events from one per allocation to one per EDModule
  * cost is that the CUDA event for temporary allocations may get recorded later than now (at the end of module instead at the end of enclosing scope), and such memory blocks may thus become available for other CUDA streams later, which may increase the live GPU memory size
  * less CUDA events means less CUDA API calls, which means less locking on the CUDA mutex
* not having to introduce a distinction between temporary and event product memory allocations (as in #412)

The API change implies that `ScopedContextBase` needs to be percolated to anywhere memory needs is allocated.

For ESProducers an `ScopedContextES` would need to be created (I was planning to create one anyway, and might have made a private prototype on top of https://github.com/cms-patatrack/cmssw/pull/412.

#### PR validation:

Code compiles, test configuration `HeterogeneousCore/CUDATest/test/testCUDASwitch_cfg.py` runs.