### PR TITLE
Comment unused variable eps_diff in makeEcalRechitValidationPlots.cpp

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/bin/makeEcalRechitValidationPlots.cpp
+++ b/RecoLocalCalo/EcalRecAlgos/bin/makeEcalRechitValidationPlots.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
   rt->SetBranchAddress("EcalRecHitsSorted_ecalRecHit_EcalRecHitsEB_RECO.", &wcpuEB);
   rt->SetBranchAddress("EcalRecHitsSorted_ecalRecHit_EcalRecHitsEE_RECO.", &wcpuEE);
 
-  constexpr float eps_diff = 1e-3;
+  // constexpr float eps_diff = 1e-3;
 
   // accumulate sizes for events and sizes of each event on both GPU and CPU
   //   auto const nentries = rt->GetEntries();


### PR DESCRIPTION
#### PR description:

Comment instead of removing because there is commented code using eps_diff

Fixes compilation warnings reported in https://github.com/cms-sw/cmssw/pull/27983#issuecomment-645695958
https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-c28630/7161/clang-new-warnings.log

#### PR validation:

Code compiles.