### PR TITLE
fix max track size in vertex soa

### DIFF
--- a/CUDADataFormats/Vertex/interface/ZVertexSoA.h
+++ b/CUDADataFormats/Vertex/interface/ZVertexSoA.h
@@ -8,7 +8,7 @@
 // These vertices are clusterized and fitted only along the beam line (z)
 // to obtain their global coordinate the beam spot position shall be added (eventually correcting for the beam angle as well)
 struct ZVertexSoA {
-  static constexpr uint32_t MAXTRACKS = 16 * 1024;
+  static constexpr uint32_t MAXTRACKS = 32 * 1024;
   static constexpr uint32_t MAXVTX = 1024;
 
   int16_t idv[MAXTRACKS];    // vertex index for each associated (original) track  (-1 == not associate)


### PR DESCRIPTION
makes it consistent with the buffer in track soa

the message
```
%MSG-w PixelVertexProducer:  PixelVertexProducerFromSoA:pixelVertices  05-Jul-2020 17:43:34 CEST Run: 323775 Event: 33111938
oops track 16452 does not exists on CPU 65535
%MSG
```
should not appear any more (and does not in my test)