### PR TITLE
Add missing ESProducers for ECAL and HCAL GPU modules

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -307,6 +307,7 @@ def customise_gpu_ecal(process):
     process.load("RecoLocalCalo.EcalRecProducers.ecalSamplesCorrelationGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalTimeBiasCorrectionsGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalTimeCalibConstantsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalMultifitParametersGPUESProducer_cfi")
 
     process.load("RecoLocalCalo.EcalRecProducers.ecalRechitADCToGeVConstantGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalRechitChannelStatusGPUESProducer_cfi")
@@ -315,6 +316,7 @@ def customise_gpu_ecal(process):
     process.load("RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosRefGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalLaserAlphasGPUESProducer_cfi")
     process.load("RecoLocalCalo.EcalRecProducers.ecalLinearCorrectionsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalRecHitParametersGPUESProducer_cfi")
 
 
     # Modules and EDAliases
@@ -505,6 +507,7 @@ def customise_gpu_hcal(process):
     process.load("RecoLocalCalo.HcalRecProducers.hcalQIETypesGPUESProducer_cfi")
     process.load("RecoLocalCalo.HcalRecProducers.hcalSiPMParametersGPUESProducer_cfi")
     process.load("RecoLocalCalo.HcalRecProducers.hcalSiPMCharacteristicsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.HcalRecProducers.hcalMahiPulseOffsetsGPUESProducer_cfi")
 
 
     # Modules and EDAliases

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
@@ -52,6 +52,7 @@ from RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosGPUESProducer_cfi import
 from RecoLocalCalo.EcalRecProducers.ecalLaserAPDPNRatiosRefGPUESProducer_cfi import ecalLaserAPDPNRatiosRefGPUESProducer
 from RecoLocalCalo.EcalRecProducers.ecalLaserAlphasGPUESProducer_cfi import ecalLaserAlphasGPUESProducer
 from RecoLocalCalo.EcalRecProducers.ecalLinearCorrectionsGPUESProducer_cfi import ecalLinearCorrectionsGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalRecHitParametersGPUESProducer_cfi import ecalRecHitParametersGPUESProducer
 
 # ECAL rechits running on GPU
 from RecoLocalCalo.EcalRecProducers.ecalRecHitGPU_cfi import ecalRecHitGPU as _ecalRecHitGPU
@@ -85,6 +86,7 @@ gpu.toReplaceWith(ecalRecHitNoTPTask, cms.Task(
   ecalLaserAPDPNRatiosRefGPUESProducer,
   ecalLaserAlphasGPUESProducer,
   ecalLinearCorrectionsGPUESProducer,
+  ecalRecHitParametersGPUESProducer,
   # ECAL rechits running on GPU
   ecalRecHitGPU,
   # copy the rechits from GPU to CPU

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -14,6 +14,7 @@ from RecoLocalCalo.EcalRecProducers.ecalPulseCovariancesGPUESProducer_cfi import
 from RecoLocalCalo.EcalRecProducers.ecalSamplesCorrelationGPUESProducer_cfi import ecalSamplesCorrelationGPUESProducer
 from RecoLocalCalo.EcalRecProducers.ecalTimeBiasCorrectionsGPUESProducer_cfi import ecalTimeBiasCorrectionsGPUESProducer
 from RecoLocalCalo.EcalRecProducers.ecalTimeCalibConstantsGPUESProducer_cfi import ecalTimeCalibConstantsGPUESProducer
+from RecoLocalCalo.EcalRecProducers.ecalMultifitParametersGPUESProducer_cfi import ecalMultifitParametersGPUESProducer
 
 # ECAL multifit running on GPU
 from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitProducerGPU_cfi import ecalUncalibRecHitProducerGPU as _ecalUncalibRecHitProducerGPU
@@ -46,6 +47,7 @@ gpu.toReplaceWith(ecalMultiFitUncalibRecHitTask, cms.Task(
   ecalSamplesCorrelationGPUESProducer,
   ecalTimeBiasCorrectionsGPUESProducer,
   ecalTimeCalibConstantsGPUESProducer,
+  ecalMultifitParametersGPUESProducer,
   # ECAL multifit running on GP
   ecalMultiFitUncalibRecHitGPU,
   # copy the uncalibrated rechits from GPU to CPU

--- a/RecoLocalCalo/HcalRecProducers/python/hbheRecHitProducerGPUTask_cff.py
+++ b/RecoLocalCalo/HcalRecProducers/python/hbheRecHitProducerGPUTask_cff.py
@@ -22,6 +22,7 @@ from RecoLocalCalo.HcalRecProducers.hcalTimeCorrsGPUESProducer_cfi import hcalTi
 from RecoLocalCalo.HcalRecProducers.hcalQIETypesGPUESProducer_cfi import hcalQIETypesGPUESProducer
 from RecoLocalCalo.HcalRecProducers.hcalSiPMParametersGPUESProducer_cfi import hcalSiPMParametersGPUESProducer
 from RecoLocalCalo.HcalRecProducers.hcalSiPMCharacteristicsGPUESProducer_cfi import hcalSiPMCharacteristicsGPUESProducer
+from RecoLocalCalo.HcalRecProducers.hcalMahiPulseOffsetsGPUESProducer_cfi import hcalMahiPulseOffsetsGPUESProducer
 
 # convert the HBHE digis into SoA format, and copy them from CPU to GPU
 from EventFilter.HcalRawToDigi.hcalDigisProducerGPU_cfi import hcalDigisProducerGPU as _hcalDigisProducerGPU
@@ -56,6 +57,7 @@ hbheRecHitProducerGPUTask = cms.Task(
     hcalQIETypesGPUESProducer,
     hcalSiPMParametersGPUESProducer,
     hcalSiPMCharacteristicsGPUESProducer,
+    hcalMahiPulseOffsetsGPUESProducer,
     hcalDigisGPU,
     hbheRecHitProducerGPU
 )


### PR DESCRIPTION
Add to the offline workflows and to the HLT customisations the ESProducers required to complement the configuration of the ECAL and HCAL GPU modules.