### PR TITLE
use a dynamic buffer for CA cells components, adjust allocator growing factor to reduce memory used

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h
@@ -28,6 +28,13 @@ namespace cms {
     extern thread_local dim3 gridDim;
 
     template <typename T1, typename T2>
+    T1 atomicCAS(T1* address, T1 compare, T2 val) {
+      T1 old = *address;
+      *address = old == compare ? val : old;
+      return old;
+    }
+
+    template <typename T1, typename T2>
     T1 atomicInc(T1* a, T2 b) {
       auto ret = *a;
       if ((*a) < T1(b))

--- a/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
@@ -139,9 +139,9 @@ namespace cms {
     // in principle not limited....
     template <typename T>
     __global__ void multiBlockPrefixScan(T const* ici, T* ico, int32_t size, int32_t* pc) {
-      volatile T const * ci = ici;
-      volatile T * co = ico;
-      __shared__  T ws[32];
+      volatile T const* ci = ici;
+      volatile T* co = ico;
+      __shared__ T ws[32];
 #ifdef __CUDA_ARCH__
       assert(sizeof(T) * gridDim.x <= dynamic_smem_size());  // size of psum below
 #endif

--- a/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
@@ -41,9 +41,9 @@ namespace cms {
   namespace cuda {
 
     // limited to 32*32 elements....
-    template <typename T>
-    __host__ __device__ __forceinline__ void blockPrefixScan(T const* __restrict__ ci,
-                                                             T* __restrict__ co,
+    template <typename VT, typename T>
+    __host__ __device__ __forceinline__ void blockPrefixScan(VT const* ci,
+                                                             VT* co,
                                                              uint32_t size,
                                                              T* ws
 #ifndef __CUDA_ARCH__
@@ -138,8 +138,10 @@ namespace cms {
 
     // in principle not limited....
     template <typename T>
-    __global__ void multiBlockPrefixScan(T const* ci, T* co, int32_t size, int32_t* pc) {
-      __shared__ T ws[32];
+    __global__ void multiBlockPrefixScan(T const* ici, T* ico, int32_t size, int32_t* pc) {
+      volatile T const * ci = ici;
+      volatile T * co = ico;
+      __shared__  T ws[32];
 #ifdef __CUDA_ARCH__
       assert(sizeof(T) * gridDim.x <= dynamic_smem_size());  // size of psum below
 #endif
@@ -152,6 +154,7 @@ namespace cms {
       // count blocks that finished
       __shared__ bool isLastBlockDone;
       if (0 == threadIdx.x) {
+        __threadfence();
         auto value = atomicAdd(pc, 1);  // block counter
         isLastBlockDone = (value == (int(gridDim.x) - 1));
       }

--- a/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
+++ b/HeterogeneousCore/CUDAUtilities/src/getCachingDeviceAllocator.h
@@ -13,11 +13,11 @@ namespace cms::cuda::allocator {
   // Use caching or not
   constexpr bool useCaching = true;
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
-  constexpr unsigned int binGrowth = 8;
+  constexpr unsigned int binGrowth = 2;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator
-  constexpr unsigned int minBin = 1;
+  constexpr unsigned int minBin = 8;
   // Largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
-  constexpr unsigned int maxBin = 10;
+  constexpr unsigned int maxBin = 30;
   // Total storage for the allocator. 0 means no limit.
   constexpr size_t maxCachedBytes = 0;
   // Fraction of total device memory taken for the allocator. In case there are multiple devices with different amounts of memory, the smallest of them is taken. If maxCachedBytes is non-zero, the smallest of them is taken.

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -27,7 +27,7 @@ namespace CAConstants {
   constexpr uint32_t maxNumberOfQuadruplets() { return maxNumberOfTuples(); }
 #ifndef ONLY_PHICUT
 #ifndef GPU_SMALL_EVENTS
-  constexpr uint32_t maxNumberOfDoublets() { return 448 * 1024; }
+  constexpr uint32_t maxNumberOfDoublets() { return 512 * 1024; }
   constexpr uint32_t maxCellsPerHit() { return 128; }
 #else
   constexpr uint32_t maxNumberOfDoublets() { return 128 * 1024; }
@@ -37,7 +37,7 @@ namespace CAConstants {
   constexpr uint32_t maxNumberOfDoublets() { return 2 * 1024 * 1024; }
   constexpr uint32_t maxCellsPerHit() { return 8 * 128; }
 #endif
-  constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 4; }
+  constexpr uint32_t maxNumOfActiveDoublets() { return maxNumberOfDoublets() / 8; }
 
   constexpr uint32_t maxNumberOfLayerPairs() { return 20; }
   constexpr uint32_t maxNumberOfLayers() { return 10; }
@@ -49,7 +49,7 @@ namespace CAConstants {
 
 #ifndef ONLY_PHICUT
   using CellNeighbors = cms::cuda::VecArray<uint32_t, 36>;
-  using CellTracks = cms::cuda::VecArray<tindex_type, 42>;
+  using CellTracks = cms::cuda::VecArray<tindex_type, 48>;
 #else
   using CellNeighbors = cms::cuda::VecArray<uint32_t, 64>;
   using CellTracks = cms::cuda::VecArray<tindex_type, 64>;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -24,17 +24,20 @@ void CAHitNtupletGeneratorKernelsCPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   device_isOuterHitOfCell_.reset(
       (GPUCACell::OuterHitOfCell *)malloc(std::max(1U, nhits) * sizeof(GPUCACell::OuterHitOfCell)));
   assert(device_isOuterHitOfCell_.get());
-  device_theCellNeighborsContainer_.reset(
-      (GPUCACell::CellNeighbors *)malloc(CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors)));
-  device_theCellTracksContainer_.reset(
-      (GPUCACell::CellTracks *)malloc(CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellTracks)));
+
+  cellStorage_.reset((unsigned char *)malloc(CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors) +
+                                             CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellTracks)));
+  device_theCellNeighborsContainer_ = (GPUCACell::CellNeighbors *)cellStorage_.get();
+  device_theCellTracksContainer_ =
+      (GPUCACell::CellTracks *)(cellStorage_.get() +
+                                CAConstants::maxNumOfActiveDoublets() * sizeof(GPUCACell::CellNeighbors));
 
   gpuPixelDoublets::initDoublets(device_isOuterHitOfCell_.get(),
                                  nhits,
                                  device_theCellNeighbors_.get(),
-                                 device_theCellNeighborsContainer_.get(),
+                                 device_theCellNeighborsContainer_,
                                  device_theCellTracks_.get(),
-                                 device_theCellTracksContainer_.get());
+                                 device_theCellTracksContainer_);
 
   // device_theCells_ = Traits:: template make_unique<GPUCACell[]>(cs, m_params.maxNumberOfDoublets_, stream);
   device_theCells_.reset((GPUCACell *)malloc(sizeof(GPUCACell) * m_params.maxNumberOfDoublets_));

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -144,6 +144,10 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   cudaDeviceSynchronize();
   cudaCheck(cudaGetLastError());
 #endif
+
+  // free space asap
+  // device_isOuterHitOfCell_.reset();
+
 }
 
 template <>
@@ -228,6 +232,7 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   cudaCheck(cudaGetLastError());
 #endif
 }
+
 
 template <>
 void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA *tracks_d, cudaStream_t cudaStream) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -147,7 +147,6 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 
   // free space asap
   // device_isOuterHitOfCell_.reset();
-
 }
 
 template <>
@@ -232,7 +231,6 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   cudaCheck(cudaGetLastError());
 #endif
 }
-
 
 template <>
 void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA *tracks_d, cudaStream_t cudaStream) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -51,7 +51,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
       hh.view(),
       device_theCells_.get(),
       device_nCells_,
-      device_theCellNeighbors_,
+      device_theCellNeighbors_.get(),
       device_isOuterHitOfCell_.get(),
       m_params.hardCurvCut_,
       m_params.ptmin_,
@@ -78,7 +78,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   kernel_find_ntuplets<<<numberOfBlocks, blockSize, 0, cudaStream>>>(hh.view(),
                                                                      device_theCells_.get(),
                                                                      device_nCells_,
-                                                                     device_theCellTracks_,
+                                                                     device_theCellTracks_.get(),
                                                                      tuples_d,
                                                                      device_hitTuple_apc_,
                                                                      quality_d,
@@ -132,8 +132,8 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
                                                                         device_hitTuple_apc_,
                                                                         device_theCells_.get(),
                                                                         device_nCells_,
-                                                                        device_theCellNeighbors_,
-                                                                        device_theCellTracks_,
+                                                                        device_theCellNeighbors_.get(),
+                                                                        device_theCellTracks_.get(),
                                                                         device_isOuterHitOfCell_.get(),
                                                                         nhits,
                                                                         m_params.maxNumberOfDoublets_,
@@ -162,15 +162,19 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   // in principle we can use "nhits" to heuristically dimension the workspace...
   device_isOuterHitOfCell_ = cms::cuda::make_device_unique<GPUCACell::OuterHitOfCell[]>(std::max(1U, nhits), stream);
   assert(device_isOuterHitOfCell_.get());
+  device_theCellNeighborsContainer_ =
+      cms::cuda::make_device_unique<GPUCACell::CellNeighbors[]>(CAConstants::maxNumOfActiveDoublets(), stream);
+  device_theCellTracksContainer_ =
+      cms::cuda::make_device_unique<GPUCACell::CellTracks[]>(CAConstants::maxNumOfActiveDoublets(), stream);
   {
     int threadsPerBlock = 128;
     // at least one block!
     int blocks = (std::max(1U, nhits) + threadsPerBlock - 1) / threadsPerBlock;
     gpuPixelDoublets::initDoublets<<<blocks, threadsPerBlock, 0, stream>>>(device_isOuterHitOfCell_.get(),
                                                                            nhits,
-                                                                           device_theCellNeighbors_,
+                                                                           device_theCellNeighbors_.get(),
                                                                            device_theCellNeighborsContainer_.get(),
-                                                                           device_theCellTracks_,
+                                                                           device_theCellTracks_.get(),
                                                                            device_theCellTracksContainer_.get());
     cudaCheck(cudaGetLastError());
   }
@@ -201,8 +205,8 @@ void CAHitNtupletGeneratorKernelsGPU::buildDoublets(HitsOnCPU const &hh, cudaStr
   dim3 thrs(stride, threadsPerBlock, 1);
   gpuPixelDoublets::getDoubletsFromHisto<<<blks, thrs, 0, stream>>>(device_theCells_.get(),
                                                                     device_nCells_,
-                                                                    device_theCellNeighbors_,
-                                                                    device_theCellTracks_,
+                                                                    device_theCellNeighbors_.get(),
+                                                                    device_theCellTracks_.get(),
                                                                     hh.view(),
                                                                     device_isOuterHitOfCell_.get(),
                                                                     nActualPairs,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -179,9 +179,9 @@ public:
 
 private:
   // workspace
-  CAConstants::CellNeighborsVector* device_theCellNeighbors_ = nullptr;
+  unique_ptr<CAConstants::CellNeighborsVector> device_theCellNeighbors_;
   unique_ptr<CAConstants::CellNeighbors[]> device_theCellNeighborsContainer_;
-  CAConstants::CellTracksVector* device_theCellTracks_ = nullptr;
+  unique_ptr<CAConstants::CellTracksVector> device_theCellTracks_;
   unique_ptr<CAConstants::CellTracks[]> device_theCellTracksContainer_;
 
   unique_ptr<GPUCACell[]> device_theCells_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -179,10 +179,11 @@ public:
 
 private:
   // workspace
+  unique_ptr<unsigned char[]> cellStorage_;
   unique_ptr<CAConstants::CellNeighborsVector> device_theCellNeighbors_;
-  unique_ptr<CAConstants::CellNeighbors[]> device_theCellNeighborsContainer_;
+  CAConstants::CellNeighbors* device_theCellNeighborsContainer_;
   unique_ptr<CAConstants::CellTracksVector> device_theCellTracks_;
-  unique_ptr<CAConstants::CellTracks[]> device_theCellTracksContainer_;
+  CAConstants::CellTracks* device_theCellTracksContainer_;
 
   unique_ptr<GPUCACell[]> device_theCells_;
   unique_ptr<GPUCACell::OuterHitOfCell[]> device_isOuterHitOfCell_;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -12,12 +12,8 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)
   //////////////////////////////////////////////////////////
 
-  /* not used at the moment 
-  cudaCheck(cudaMalloc(&device_theCellNeighbors_, sizeof(CAConstants::CellNeighborsVector)));
-  cudaCheck(cudaMemset(device_theCellNeighbors_, 0, sizeof(CAConstants::CellNeighborsVector)));
-  cudaCheck(cudaMalloc(&device_theCellTracks_, sizeof(CAConstants::CellTracksVector)));
-  cudaCheck(cudaMemset(device_theCellTracks_, 0, sizeof(CAConstants::CellTracksVector)));
-  */
+  device_theCellNeighbors_ = Traits::template make_unique<CAConstants::CellNeighborsVector>(stream);
+  device_theCellTracks_ = Traits::template make_unique<CAConstants::CellTracksVector>(stream);
 
   device_hitToTuple_ = Traits::template make_unique<HitToTuple>(stream);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -79,6 +79,10 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
       printf("Tuples overflow\n");
     if (*nCells >= maxNumberOfDoublets)
       printf("Cells overflow\n");
+    if (cellNeighbors && cellNeighbors->full())
+      printf("cellNeighbors overflow\n");
+    if (cellTracks && cellTracks->full())
+      printf("cellTracks overflow\n");
   }
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -168,14 +168,15 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
 
   CAHitNtupletGeneratorKernelsGPU kernels(m_params);
   kernels.counters_ = m_counters;
-  HelixFitOnGPU fitter(bfield, m_params.fit5as4_);
 
   kernels.allocateOnGPU(stream);
-  fitter.allocateOnGPU(&(soa->hitIndices), kernels.tupleMultiplicity(), soa);
 
   kernels.buildDoublets(hits_d, stream);
   kernels.launchKernels(hits_d, soa, stream);
   kernels.fillHitDetIndices(hits_d.view(), soa, stream);  // in principle needed only if Hits not "available"
+
+  HelixFitOnGPU fitter(bfield, m_params.fit5as4_);
+  fitter.allocateOnGPU(&(soa->hitIndices), kernels.tupleMultiplicity(), soa);
   if (m_params.useRiemannFit_) {
     fitter.launchRiemannKernels(hits_d.view(), hits_d.nHits(), CAConstants::maxNumberOfQuadruplets(), stream);
   } else {

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -69,10 +69,14 @@ public:
       auto i = cellNeighbors.extend();  // maybe waisted....
       if (i > 0) {
         cellNeighbors[i].reset();
+#ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellNeighbors[0]);
         atomicCAS((ptrAsInt*)(&theOuterNeighbors),
                   zero,
                   (ptrAsInt)(&cellNeighbors[i]));  // if fails we cannot give "i" back...
+#else
+        theOuterNeighbors = &cellNeighbors[i];
+#endif
       } else
         return -1;
     }
@@ -85,8 +89,12 @@ public:
       auto i = cellTracks.extend();  // maybe waisted....
       if (i > 0) {
         cellTracks[i].reset();
+#ifdef __CUDACC__
         auto zero = (ptrAsInt)(&cellTracks[0]);
         atomicCAS((ptrAsInt*)(&theTracks), zero, (ptrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...
+#else
+        theTracks = &cellTracks[i];
+#endif
       } else
         return -1;
     }

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -56,24 +56,46 @@ public:
     theInnerZ = hh.zGlobal(innerHitId);
     theInnerR = hh.rGlobal(innerHitId);
 
-    outerNeighbors().reset();
-    tracks().reset();
+    // link to default empty
+    theOuterNeighbors = &cellNeighbors[0];
+    theTracks = &cellTracks[0];
     assert(outerNeighbors().empty());
     assert(tracks().empty());
   }
 
   __device__ __forceinline__ int addOuterNeighbor(CellNeighbors::value_t t, CellNeighborsVector& cellNeighbors) {
+    // use smart cache
+    if (outerNeighbors().empty()) {
+      auto i = cellNeighbors.extend();  // maybe waisted....
+      if (i > 0) {
+        cellNeighbors[i].reset();
+        auto zero = (ptrAsInt)(&cellNeighbors[0]);
+        atomicCAS((ptrAsInt*)(&theOuterNeighbors),
+                  zero,
+                  (ptrAsInt)(&cellNeighbors[i]));  // if fails we cannot give "i" back...
+      } else
+        return -1;
+    }
     return outerNeighbors().push_back(t);
   }
 
   __device__ __forceinline__ int addTrack(CellTracks::value_t t, CellTracksVector& cellTracks) {
+    if (tracks().empty()) {
+      auto i = cellTracks.extend();  // maybe waisted....
+      if (i > 0) {
+        cellTracks[i].reset();
+        auto zero = (ptrAsInt)(&cellTracks[0]);
+        atomicCAS((ptrAsInt*)(&theTracks), zero, (ptrAsInt)(&cellTracks[i]));  // if fails we cannot give "i" back...
+      } else
+        return -1;
+    }
     return tracks().push_back(t);
   }
 
-  __device__ __forceinline__ CellTracks& tracks() { return theTracks; }
-  __device__ __forceinline__ CellTracks const& tracks() const { return theTracks; }
-  __device__ __forceinline__ CellNeighbors& outerNeighbors() { return theOuterNeighbors; }
-  __device__ __forceinline__ CellNeighbors const& outerNeighbors() const { return theOuterNeighbors; }
+  __device__ __forceinline__ CellTracks& tracks() { return *theTracks; }
+  __device__ __forceinline__ CellTracks const& tracks() const { return *theTracks; }
+  __device__ __forceinline__ CellNeighbors& outerNeighbors() { return *theOuterNeighbors; }
+  __device__ __forceinline__ CellNeighbors const& outerNeighbors() const { return *theOuterNeighbors; }
   __device__ __forceinline__ float get_inner_x(Hits const& hh) const { return hh.xGlobal(theInnerHitId); }
   __device__ __forceinline__ float get_outer_x(Hits const& hh) const { return hh.xGlobal(theOuterHitId); }
   __device__ __forceinline__ float get_inner_y(Hits const& hh) const { return hh.yGlobal(theInnerHitId); }
@@ -297,8 +319,8 @@ public:
   }
 
 private:
-  CellNeighbors theOuterNeighbors;
-  CellTracks theTracks;
+  CellNeighbors* theOuterNeighbors;
+  CellTracks* theTracks;
 
 public:
   int32_t theDoubletId;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -76,6 +76,7 @@ public:
       } else
         return -1;
     }
+    __threadfence();
     return outerNeighbors().push_back(t);
   }
 
@@ -89,6 +90,7 @@ public:
       } else
         return -1;
     }
+    __threadfence();
     return tracks().push_back(t);
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -74,14 +74,16 @@ namespace gpuPixelDoublets {
     for (int i = first; i < nHits; i += gridDim.x * blockDim.x)
       isOuterHitOfCell[i].reset();
 
-    cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
-    cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
-    auto i = cellNeighbors->extend();
-    assert(0 == i);
-    (*cellNeighbors)[0].reset();
-    i = cellTracks->extend();
-    assert(0 == i);
-    (*cellTracks)[0].reset();
+    if (0==first) {
+      cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
+      cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
+      auto i = cellNeighbors->extend();
+      assert(0 == i);
+      (*cellNeighbors)[0].reset();
+      i = cellTracks->extend();
+      assert(0 == i);
+      (*cellTracks)[0].reset();
+    }
   }
 
   constexpr auto getDoubletsFromHistoMaxBlockSize = 64;  // for both x and y

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -74,7 +74,7 @@ namespace gpuPixelDoublets {
     for (int i = first; i < nHits; i += gridDim.x * blockDim.x)
       isOuterHitOfCell[i].reset();
 
-    if (0==first) {
+    if (0 == first) {
       cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
       cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
       auto i = cellNeighbors->extend();

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuPixelDoublets.h
@@ -73,6 +73,15 @@ namespace gpuPixelDoublets {
     int first = blockIdx.x * blockDim.x + threadIdx.x;
     for (int i = first; i < nHits; i += gridDim.x * blockDim.x)
       isOuterHitOfCell[i].reset();
+
+    cellNeighbors->construct(CAConstants::maxNumOfActiveDoublets(), cellNeighborsContainer);
+    cellTracks->construct(CAConstants::maxNumOfActiveDoublets(), cellTracksContainer);
+    auto i = cellNeighbors->extend();
+    assert(0 == i);
+    (*cellNeighbors)[0].reset();
+    i = cellTracks->extend();
+    assert(0 == i);
+    (*cellTracks)[0].reset();
   }
 
   constexpr auto getDoubletsFromHistoMaxBlockSize = 64;  // for both x and y

--- a/RecoPixelVertexing/PixelTriplets/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/test/BuildFile.xml
@@ -27,3 +27,8 @@
 
 <bin file="CircleEq_t.cpp">
 </bin>
+
+<bin file="CAsizes_t.cpp">
+  <use name="cuda"/>
+  <use name="eigen"/>
+</bin>

--- a/RecoPixelVertexing/PixelTriplets/test/CAsizes_t.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/CAsizes_t.cpp
@@ -1,0 +1,32 @@
+#include "RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h"
+
+#include <typeinfo>
+#include <iostream>
+
+template<typename T>
+void print() {
+
+  std::cout << "size of " << typeid(T).name() << ' ' << sizeof(T) << std::endl;
+
+
+}
+
+
+
+int main() {
+
+  using namespace CAConstants;
+
+  print<GPUCACell>();
+  print<CellNeighbors>();
+  print<CellTracks>();
+  print<OuterHitOfCell>();
+  print<TuplesContainer>();
+  print<HitToTuple>();
+  print<TupleMultiplicity>();
+
+  print<CellNeighborsVector>();
+
+  return 0;
+
+}

--- a/RecoPixelVertexing/PixelTriplets/test/CAsizes_t.cpp
+++ b/RecoPixelVertexing/PixelTriplets/test/CAsizes_t.cpp
@@ -3,18 +3,12 @@
 #include <typeinfo>
 #include <iostream>
 
-template<typename T>
+template <typename T>
 void print() {
-
   std::cout << "size of " << typeid(T).name() << ' ' << sizeof(T) << std::endl;
-
-
 }
 
-
-
 int main() {
-
   using namespace CAConstants;
 
   print<GPUCACell>();
@@ -28,5 +22,4 @@ int main() {
   print<CellNeighborsVector>();
 
   return 0;
-
 }


### PR DESCRIPTION
This PR main objective is to revive the dynamic buffer for CA cells components that was left out of the main merge of last year because of crashes....  (see https://github.com/cms-patatrack/cmssw/pull/312/commits/6ec0bc7170dbbd397401c031e8e4b0bec0b182f1#diff-80b2ae8844f1bd61dff8c97dda310263R78-L70 )

took the opportunity to enlarge a bit the buffers to reduce overflows in large events.

I took the opportunity to fix a possible data race that was left unresolved in prefixScan.
I used the code pattern in https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memory-fence-functions
on V100 one can trigger the crash pretty easily and after the fix no more crashes were observed...

Finally (after much struggle) the growing factor in the allocator has been reduced to the minimum (2) that seems to fit all kind of data allocation pattern and reduce the actual memory used by a factor 2

with 16threads on 5K events of the usual lumi section
this PR tops at 1.4GB of memory  while current release (with growing factor 2 as well) tops at 2.4GB

benchmark for quadruplets on T4 8 threads is at 1050 Hz while current release barely reach 900 Hz 
(with mps)
running multiple jobs on T4 for triplets
Running 4 times over 5000 events with 4 jobs, each with 5 threads, 5 streams and 1 GPUs
this PR:  707.8 ±   7.2 ev/s
reference: 543.5 ±   1.4 ev/s
and on V100:
this PR:  1547.1 ±   1.6 ev/s
reference:  1380.1 ±   1.0 ev/s
V100 and hyperthreads
Running 4 times over 5000 events with 8 jobs, each with 5 threads, 5 streams and 1 GPUs
this PR:  1616.6 ±   1.0 ev/s
reference:  1429.2 ±   1.1 ev/s

purely technical. No regression expected besides minor one due to reduced overflows .