### PR TITLE
Increase the size of the ECAL GPU buffers

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -48,7 +48,7 @@ void EcalRawToDigiGPU::fillDescriptions(edm::ConfigurationDescriptions& confDesc
   for (uint32_t i = 0; i < 54; ++i)
     feds[i] = i + 601;
   desc.add<std::vector<int>>("FEDs", feds);
-  desc.add<uint32_t>("maxChannels", 20000);
+  desc.add<uint32_t>("maxChannels", 40000);
   desc.add<std::string>("digisLabelEB", "ebDigisGPU");
   desc.add<std::string>("digisLabelEE", "eeDigisGPU");
 

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -338,7 +338,7 @@ def customise_gpu_ecal(process):
         ),
         digisLabelEB = cms.string("ebDigis"),
         digisLabelEE = cms.string("eeDigis"),
-        maxChannels = cms.uint32(20000)
+        maxChannels = cms.uint32(40000)
     )
 
     process.hltEcalDigis = cms.EDProducer("EcalCPUDigisProducer",
@@ -352,7 +352,8 @@ def customise_gpu_ecal(process):
     from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitProducerGPU_cfi import ecalUncalibRecHitProducerGPU as _ecalUncalibRecHitProducerGPU
     process.hltEcalUncalibRecHitGPU = _ecalUncalibRecHitProducerGPU.clone(
         digisLabelEB = cms.InputTag("hltEcalDigisGPU", "ebDigis"),
-        digisLabelEE = cms.InputTag("hltEcalDigisGPU", "eeDigis")
+        digisLabelEE = cms.InputTag("hltEcalDigisGPU", "eeDigis"),
+        maxNumberHits = 40000
     )
 
     process.hltEcalUncalibRecHitSoA = cms.EDProducer("EcalCPUUncalibRecHitProducer",
@@ -378,7 +379,7 @@ def customise_gpu_ecal(process):
         uncalibrecHitsInLabelEE = cms.InputTag("hltEcalUncalibRecHitGPU","EcalUncalibRecHitsEE"),
         recHitsLabelEB = cms.string("EcalRecHitsEB"),
         recHitsLabelEE = cms.string("EcalRecHitsEE"),
-        maxNumberHits = cms.uint32(20000),
+        maxNumberHits = cms.uint32(40000),
         ChannelStatusToBeExcluded = cms.vstring(
             "kDAC",
             "kNoisy",

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -100,7 +100,7 @@ void EcalRecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptions& con
   desc.add<double>("EBLaserMAX", 30.0);
   desc.add<double>("EELaserMAX", 30.0);
 
-  desc.add<uint32_t>("maxNumberHits", 20000);
+  desc.add<uint32_t>("maxNumberHits", 40000);
 }
 
 EcalRecHitProducerGPU::EcalRecHitProducerGPU(const edm::ParameterSet& ps) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -99,7 +99,7 @@ void EcalUncalibRecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<double>("outOfTimeThresholdGain61mEE", 1000);
   desc.add<double>("amplitudeThresholdEB", 10);
   desc.add<double>("amplitudeThresholdEE", 10);
-  desc.add<uint32_t>("maxNumberHits", 20000);  //---- AM TEST
+  desc.add<uint32_t>("maxNumberHits", 40000);
   desc.add<std::vector<uint32_t>>("kernelMinimizeThreads", {32, 1, 1});
   // ---- default false or true? It was set to true, but at HLT it is false
   desc.add<bool>("shouldRunTimingComputation", false);

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHitGPU_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHitGPU_cfi.py
@@ -1,26 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLocalCalo.EcalRecAlgos.ecalCleaningAlgo import cleaningAlgoConfig 
+from RecoLocalCalo.EcalRecAlgos.ecalCleaningAlgo import cleaningAlgoConfig
 
 # rechit producer
 ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
-                               
+
     uncalibrecHitsInLabelEB = cms.InputTag("ecalUncalibRecHitProducerGPU","EcalUncalibRecHitsEB"),
     uncalibrecHitsInLabelEE = cms.InputTag("ecalUncalibRecHitProducerGPU","EcalUncalibRecHitsEE"),
-          
+
     #recHitsLabelEB = cms.string("EcalRecHitsGPUEB"),
     #recHitsLabelEE = cms.string("EcalRecHitsGPUEE"),
     recHitsLabelEB = cms.string("EcalRecHitsEB"),
     recHitsLabelEE = cms.string("EcalRecHitsEE"),
- 
-    maxNumberHits = cms.uint32(20000),  # FIXME AM
-  
-  
+
+    maxNumberHits = cms.uint32(40000),
+
+
     #EErechitCollection = cms.string('EcalRecHitsEE'),
     #EEuncalibRecHitCollection = cms.InputTag("ecalMultiFitUncalibRecHit","EcalUncalibRecHitsEE"),
     #EBuncalibRecHitCollection = cms.InputTag("ecalMultiFitUncalibRecHit","EcalUncalibRecHitsEB"),
     #EBrechitCollection = cms.string('EcalRecHitsEB'),
-   
+
     ## db statuses to be exluded from reconstruction (some will be recovered)
     ChannelStatusToBeExcluded = cms.vstring(   'kDAC',
                                                'kNoisy',
@@ -42,26 +42,26 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
                                                #'kTPSaturated',
                                                #'kL1SpikeFlag',
                                                ),
-    
+
     ## avoid propagation of dead channels other than after recovery
     killDeadChannels = cms.bool(True),
     #algo = cms.string("EcalRecHitWorkerSimple"),
-    
+
     ## define maximal and minimal values for the laser corrections
-    
+
     EBLaserMIN = cms.double(0.01),                    #    EBLaserMIN = cms.double(0.5),
     EELaserMIN = cms.double(0.01),                    #    EELaserMIN = cms.double(0.5),
-                                                     
+
     EBLaserMAX = cms.double(30.0),                    #    EBLaserMAX = cms.double(3.0),
     EELaserMAX = cms.double(30.0),                    #    EELaserMAX = cms.double(8.0),
 
 
-    ## useful if time is not calculated, as at HLT                        
-    #skipTimeCalib = cms.bool(False),                         
+    ## useful if time is not calculated, as at HLT
+    #skipTimeCalib = cms.bool(False),
 
     ## apply laser corrections
     #laserCorrection = cms.bool(True),
-                            
+
     ## reco flags association to DB flag
     flagsMapDBReco = cms.PSet(
         kGood  = cms.vstring('kOk','kDAC','kNoLaser','kNoisy'),
@@ -71,8 +71,8 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
                                            'kDeadVFE'),
         kTowerRecovered = cms.vstring('kDeadFE'),
         kDead           = cms.vstring('kNoDataNoTP')
-        ), 
-        
+        ),
+
 #//         flagmask_ |= 0x1 << EcalRecHit::kNeighboursRecovered;
 #//         flagmask_ |= 0x1 << EcalRecHit::kTowerRecovered;
 #//         flagmask_ |= 0x1 << EcalRecHit::kDead;
@@ -81,7 +81,7 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
 #//         flagmask_ |= 0x1 << EcalRecHit::kL1SpikeFlag;
 
 
-                            
+
     ## for channel recovery
     #algoRecover = cms.string("EcalRecHitWorkerRecover"),
     recoverEBIsolatedChannels = cms.bool(False),
@@ -91,18 +91,18 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
     recoverEBFE = cms.bool(True),
     recoverEEFE = cms.bool(True),
 
-    ##db statuses for which recovery in EE/EB should not be attempted           
+    ##db statuses for which recovery in EE/EB should not be attempted
     #dbStatusToBeExcludedEE = cms.vint32(
                                         #14,  # dead, no TP
                                         #78,  # dead, HV off
                                         #142, # dead,LV off
-                                        #), 
+                                        #),
     #dbStatusToBeExcludedEB = cms.vint32(
                                         #14,  # dead, no TP
                                         #78,  # dead, HV off
                                         #142, # dead,LV off
-                                        #), 
-    
+                                        #),
+
     ## --- logWarnings for saturated DeadFEs
     ## if the logWarningThreshold is negative the Algo will not try recovery (in EE is not tested we may need negative threshold e.g. -1.e+9)
     ## if you want to enable recovery but you don't wish to throw logWarnings put the logWarningThresholds very high e.g +1.e+9
@@ -124,9 +124,7 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
 
 #from Configuration.Eras.Modifier_fastSim_cff import fastSim
 ## no flags for bad channels in FastSim
-#fastSim.toModify(ecalRecHit, 
+#fastSim.toModify(ecalRecHit,
                  #killDeadChannels = False,
                  #recoverEBFE = False,
                  #recoverEEFE = False)
-
-


### PR DESCRIPTION
Configure the ECAL modules to reserve space for 40'000 channels in each of EB and EE.