### PR TITLE
make CPEFast to better reproduce Generic (w/o track angle)

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/SiPixelStatus.h
+++ b/CUDADataFormats/TrackingRecHit/interface/SiPixelStatus.h
@@ -1,12 +1,12 @@
 #ifndef CUDADataFormats_TrackingRecHit_interface_SiPixelStatus_H
 #define CUDADataFormats_TrackingRecHit_interface_SiPixelStatus_H
 
-  struct SiPixelStatus {
-     uint8_t isBigX : 1;
-     uint8_t isOneX : 1;
-     uint8_t isBigY : 1;
-     uint8_t isOneY : 1;
-     uint8_t qBin : 3;
-  };
+struct SiPixelStatus {
+  uint8_t isBigX : 1;
+  uint8_t isOneX : 1;
+  uint8_t isBigY : 1;
+  uint8_t isOneY : 1;
+  uint8_t qBin : 3;
+};
 
 #endif

--- a/CUDADataFormats/TrackingRecHit/interface/SiPixelStatus.h
+++ b/CUDADataFormats/TrackingRecHit/interface/SiPixelStatus.h
@@ -1,0 +1,12 @@
+#ifndef CUDADataFormats_TrackingRecHit_interface_SiPixelStatus_H
+#define CUDADataFormats_TrackingRecHit_interface_SiPixelStatus_H
+
+  struct SiPixelStatus {
+     uint8_t isBigX : 1;
+     uint8_t isOneX : 1;
+     uint8_t isBigY : 1;
+     uint8_t isOneY : 1;
+     uint8_t qBin : 3;
+  };
+
+#endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -1,3 +1,4 @@
+
 #ifndef RecoLocalTracker_SiPixelRecHits_pixelCPEforGPU_h
 #define RecoLocalTracker_SiPixelRecHits_pixelCPEforGPU_h
 
@@ -12,8 +13,11 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_cxx17.h"
 
+#include "CUDADataFormats/TrackingRecHit/interface/SiPixelStatus.h"
+
 namespace pixelCPEforGPU {
 
+  using Status = SiPixelStatus;
   using Frame = SOAFrame<float>;
   using Rotation = SOARotation<float>;
 
@@ -40,7 +44,11 @@ namespace pixelCPEforGPU {
 
     float x0, y0, z0;  // the vertex in the local coord of the detector
 
-    float sx[3], sy[3];  // the errors...
+    // float apeX, apexY;  // ape^2
+    uint8_t sx2, sy1, sy2;
+    uint8_t sigmax[16], sigmax1[16], sigmay[16];  // in micron
+    float xfact[5], yfact[5];
+    int minCh[5];
 
     Frame frame;
   };
@@ -95,8 +103,11 @@ namespace pixelCPEforGPU {
     float xerr[N];
     float yerr[N];
 
-    int16_t xsize[N];  // clipped at 127 if negative is edge....
+    int16_t xsize[N];  // (*8) clipped at 127 if negative is edge....
     int16_t ysize[N];
+
+    Status status;
+
   };
 
   constexpr int32_t MaxHitsInIter = gpuClustering::maxHitsInIter();
@@ -206,8 +217,8 @@ namespace pixelCPEforGPU {
     if (phase1PixelTopology::isBigPixY(cp.maxCol[ic]))
       ++ysize;
 
-    int unbalanceX = 8. * std::abs(float(cp.Q_f_X[ic] - cp.Q_l_X[ic])) / float(cp.Q_f_X[ic] + cp.Q_l_X[ic]);
-    int unbalanceY = 8. * std::abs(float(cp.Q_f_Y[ic] - cp.Q_l_Y[ic])) / float(cp.Q_f_Y[ic] + cp.Q_l_Y[ic]);
+    int unbalanceX = 8.f * std::abs(float(cp.Q_f_X[ic] - cp.Q_l_X[ic])) / float(cp.Q_f_X[ic] + cp.Q_l_X[ic]);
+    int unbalanceY = 8.f * std::abs(float(cp.Q_f_Y[ic] - cp.Q_l_Y[ic])) / float(cp.Q_f_Y[ic] + cp.Q_l_Y[ic]);
     xsize = 8 * xsize - unbalanceX;
     ysize = 8 * ysize - unbalanceY;
 
@@ -285,8 +296,8 @@ namespace pixelCPEforGPU {
     auto sy = cp.maxCol[ic] - cp.minCol[ic];
 
     // is edgy ?
-    bool isEdgeX = cp.minRow[ic] == 0 or cp.maxRow[ic] == phase1PixelTopology::lastRowInModule;
-    bool isEdgeY = cp.minCol[ic] == 0 or cp.maxCol[ic] == phase1PixelTopology::lastColInModule;
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
     // is one and big?
     bool isBig1X = (0 == sx) && phase1PixelTopology::isBigPixX(cp.minRow[ic]);
     bool isBig1Y = (0 == sy) && phase1PixelTopology::isBigPixY(cp.minCol[ic]);
@@ -323,19 +334,43 @@ namespace pixelCPEforGPU {
     auto sx = cp.maxRow[ic] - cp.minRow[ic];
     auto sy = cp.maxCol[ic] - cp.minCol[ic];
 
-    // is edgy ?
-    bool isEdgeX = cp.minRow[ic] == 0 or cp.maxRow[ic] == phase1PixelTopology::lastRowInModule;
-    bool isEdgeY = cp.minCol[ic] == 0 or cp.maxCol[ic] == phase1PixelTopology::lastColInModule;
+    // is edgy ?  (size is set negative: see above)
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
+
     // is one and big?
-    uint32_t ix = (0 == sx);
-    uint32_t iy = (0 == sy);
-    ix += (0 == sx) && phase1PixelTopology::isBigPixX(cp.minRow[ic]);
-    iy += (0 == sy) && phase1PixelTopology::isBigPixY(cp.minCol[ic]);
+    bool isOneX = (0 == sx);
+    bool isOneY = (0 == sy);
+    bool isBigX = phase1PixelTopology::isBigPixX(cp.minRow[ic]);
+    bool isBigY = phase1PixelTopology::isBigPixY(cp.minCol[ic]);
+
+    auto ch = cp.charge[ic];
+    auto bin = 0;
+    for (; bin < 4; ++bin)
+      if (ch < detParams.minCh[bin + 1])
+        break;
+    assert(bin < 5);
+
+    cp.status.qBin = 4-bin;
+    cp.status.isOneX = isOneX;
+    cp.status.isBigX = (isOneX&isBigX) | isEdgeX;
+    cp.status.isOneY = isOneY;
+    cp.status.isBigY = (isOneY&isBigY) | isEdgeY;
+
+
+    auto xoff = 81.f * comParams.thePitchX;
+    int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (162.f * comParams.thePitchX))));
+
+    auto toCM = [](uint8_t x) { return float(x) * 1.e-4; };
 
     if (not isEdgeX)
-      cp.xerr[ic] = detParams.sx[ix];
+      cp.xerr[ic] = isOneX ? toCM(isBigX ? detParams.sx2 : detParams.sigmax1[jx])
+                           : detParams.xfact[bin] * toCM(detParams.sigmax[jx]);
+
+    auto ey = cp.ysize[ic] > 8 ? detParams.sigmay[std::min(cp.ysize[ic] - 9, 15)] : detParams.sy1;
+
     if (not isEdgeY)
-      cp.yerr[ic] = detParams.sy[iy];
+      cp.yerr[ic] = isOneY ? toCM(isBigY ? detParams.sy2 : detParams.sy1) : detParams.yfact[bin] * toCM(ey);
   }
 
 }  // namespace pixelCPEforGPU

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforGPU.h
@@ -107,7 +107,6 @@ namespace pixelCPEforGPU {
     int16_t ysize[N];
 
     Status status;
-
   };
 
   constexpr int32_t MaxHitsInIter = gpuClustering::maxHitsInIter();
@@ -351,12 +350,11 @@ namespace pixelCPEforGPU {
         break;
     assert(bin < 5);
 
-    cp.status.qBin = 4-bin;
+    cp.status.qBin = 4 - bin;
     cp.status.isOneX = isOneX;
-    cp.status.isBigX = (isOneX&isBigX) | isEdgeX;
+    cp.status.isBigX = (isOneX & isBigX) | isEdgeX;
     cp.status.isOneY = isOneY;
-    cp.status.isBigY = (isOneY&isBigY) | isEdgeY;
-
+    cp.status.isBigY = (isOneY & isBigY) | isEdgeY;
 
     auto xoff = 81.f * comParams.thePitchX;
     int jx = std::min(15, std::max(0, int(16.f * (cp.xpos[ic] + xoff) / (162.f * comParams.thePitchX))));

--- a/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/gpuPixelRecHits.h
@@ -149,8 +149,9 @@ namespace gpuPixelRecHits {
         assert(cl < MaxHitsInIter);
         auto x = digis.xx(i);
         auto y = digis.yy(i);
-        auto ch = std::min(digis.adc(i), pixmx);
+        auto ch = digis.adc(i);
         atomicAdd(&clusParams.charge[cl], ch);
+        ch = std::min(ch, pixmx);
         if (clusParams.minRow[cl] == x)
           atomicAdd(&clusParams.Q_f_X[cl], ch);
         if (clusParams.maxRow[cl] == x)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -226,7 +226,7 @@ void PixelCPEFast::fillParamsForGpu() {
     g.pixmx = std::max(0, cp.pixmx);
     g.sx2 = toMicronX(cp.sx2);
     g.sy1 = toMicronY(cp.sy1);
-    g.sy2 = std::max(55,toMicronY(cp.sy2));
+    g.sy2 = std::max(55, toMicronY(cp.sy2));
 
     // sample xerr as function of position
     auto xoff = -81.f * m_commonParamsGPU.thePitchX;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -375,16 +375,13 @@ __global__ void kernel_classifyTracks(HitContainer const *__restrict__ tuples,
     }
 
     // compute a pT-dependent chi2 cut
-    // default parameters:
-    //   - chi2MaxPt = 10 GeV
-    //   - chi2Coeff = { 0.68177776, 0.74609577, -0.08035491, 0.00315399 }
-    //   - chi2Scale = 30 for broken line fit, 45 for Riemann fit
+    // at the moment just a flat cut...
     // (see CAHitNtupletGeneratorGPU.cc)
-    float pt = std::min<float>(tracks->pt(it), cuts.chi2MaxPt);
-    float chi2Cut = cuts.chi2Scale *
-                    (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
-    // above number were for Quads not normalized so for the time being just multiple by ndof for Quads  (triplets to be understood)
-    if (3.f * tracks->chi2(it) >= chi2Cut) {
+    // float pt = std::min<float>(tracks->pt(it), cuts.chi2MaxPt);
+    // float chi2Cut = cuts.chi2Scale *
+    //                (cuts.chi2Coeff[0] + pt * (cuts.chi2Coeff[1] + pt * (cuts.chi2Coeff[2] + pt * cuts.chi2Coeff[3])));
+    float chi2Cut = cuts.chi2Scale;
+    if (tracks->chi2(it) >= chi2Cut) {
 #ifdef NTUPLE_DEBUG
       printf("Bad fit %d size %d pt %f eta %f chi2 %f\n",
              it,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -141,11 +141,11 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
-  trackQualityCuts.add<std::vector<double>>("chi2Coeff", {0.68177776, 0.74609577, -0.08035491, 0.00315399})
+  trackQualityCuts.add<std::vector<double>>("chi2Coeff", {1., 0., 0., 0.})
       ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
-  trackQualityCuts.add<double>("chi2Scale", 30.)
+  trackQualityCuts.add<double>("chi2Scale", 16.)
       ->setComment(
-          "Factor to multiply the pT-dependent chi2 cut (currently: 30 for the broken line fit, 45 for the Riemann "
+          "Factor to multiply the pT-dependent chi2 cut (currently: 16 for the broken line fit, ?? for the Riemann "
           "fit)");
   trackQualityCuts.add<double>("tripletMinPt", 0.5)->setComment("Min pT for triplets, in GeV");
   trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -143,7 +143,7 @@ void CAHitNtupletGeneratorOnGPU::fillDescriptions(edm::ParameterSetDescription& 
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
   trackQualityCuts.add<std::vector<double>>("chi2Coeff", {1., 0., 0., 0.})
       ->setComment("Polynomial coefficients to derive the pT-dependent chi2 cut");
-  trackQualityCuts.add<double>("chi2Scale", 16.)
+  trackQualityCuts.add<double>("chi2Scale", 25.)
       ->setComment(
           "Factor to multiply the pT-dependent chi2 cut (currently: 16 for the broken line fit, ?? for the Riemann "
           "fit)");


### PR DESCRIPTION
This PR improves the error estimation in CPEFast used on GPU providing a simple and fast parameterization in terms of charge, position in x and size in y.

The result is very close to what CPEGeneric provides w/o track-angle (actually a bit more accurate thanks to the estimation of the y-error using the cluster size in y (itself improved with information from the charge unbalance).

The main effect is a reduction and flattening of the chi2 and a reduction of the tails of the pulls.
Given this improvements I have (for the the being) simplified the cut in chi2 to a single value.
As side effect there is a small improvement in efficiency at least for single muon.

Single muon (2018 ideal): quadruplets-only and quadruplets+triplets
http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_gpuNewErr25/plots_pixel_Pt09_pixel/effandfakePtEtaPhi.pdf
http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_gpuNewErr25/plots_pixel_Pt09_pixel/tuning.pdf
http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_gpuNewErr25/plots_pixel_Pt09_pixel/pulls.pdf
http://innocent.home.cern.ch/innocent/RelVal/SingleMuFlatIdeal_gpuNewErr25/plots_pixel_Pt09_pixel/resolutionsPt.pdf

ttBar PU50 2021 "realistic"  (ape=3um!)  (here with chi2 cut at 25 and 16)
http://innocent.home.cern.ch/innocent/RelVal/pixOnly2021_gpuNewErr25I/plots_pixel_Pt09_pixel/effandfakePtEtaPhi.pdf
http://innocent.home.cern.ch/innocent/RelVal/pixOnly2021_gpuNewErr25I/plots_pixelFromPVAllTP_pixel/effandfakePtEtaPhi.pdf
http://innocent.home.cern.ch/innocent/RelVal/pixOnly2021_gpuNewErr25I/plots_pixel_Pt09_pixel/tuning.pdf
http://innocent.home.cern.ch/innocent/RelVal/pixOnly2021_gpuNewErr25I/plots_pixel_Pt09_pixel/pulls.pdf
http://innocent.home.cern.ch/innocent/RelVal/pixOnly2021_gpuNewErr25I/plots_pixel_Pt09_pixel/resolutionsPt.pdf

p.s.
I take the opportunity to apologize with the authors and implementors of the fits: clearly the shape of chi2 and pulls seems to depend more on cluster properties and not on the fit itself (as I wrongly assumed for a year or so)





