### PR TITLE
Remove use of boost::mpl::vector for dependent records

### DIFF
--- a/CalibTracker/Records/interface/SiPixelGainCalibrationForHLTGPURcd.h
+++ b/CalibTracker/Records/interface/SiPixelGainCalibrationForHLTGPURcd.h
@@ -1,17 +1,14 @@
 #ifndef CalibTracker_Records_SiPixelGainCalibrationForHLTGPURcd_h
 #define CalibTracker_Records_SiPixelGainCalibrationForHLTGPURcd_h
 
-#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
-#include "FWCore/Framework/interface/DependentRecordImplementation.h"
-
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTRcd.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-
-#include "boost/mpl/vector.hpp"
 
 class SiPixelGainCalibrationForHLTGPURcd
     : public edm::eventsetup::DependentRecordImplementation<
           SiPixelGainCalibrationForHLTGPURcd,
-          boost::mpl::vector<SiPixelGainCalibrationForHLTRcd, TrackerDigiGeometryRecord> > {};
+          edm::mpl::Vector<SiPixelGainCalibrationForHLTRcd, TrackerDigiGeometryRecord>> {};
 
-#endif
+#endif  // CalibTracker_Records_SiPixelGainCalibrationForHLTGPURcd_h

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecord.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalCombinedRecord.h
@@ -5,7 +5,7 @@
 
 template <typename... Sources>
 class HcalCombinedRecord : public edm::eventsetup::DependentRecordImplementation<HcalCombinedRecord<Sources...>,
-                                                                                 boost::mpl::vector<Sources...>> {
+                                                                                 edm::mpl::Vector<Sources...>> {
 public:
   using DependencyRecords = std::tuple<Sources...>;
 };


### PR DESCRIPTION
Update dependent records declarations to use `edm::mpl::Vector` instead of `boost::mpl::vector`, following #30874.