### PR TITLE
Update the BeamSpotCUDA class

### DIFF
--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -1,15 +1,14 @@
 #ifndef CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 #define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 
-#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-
 #include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
 class BeamSpotCUDA {
 public:
-  // alignas(128) doesn't really make sense as there is only one
-  // beamspot per event?
-  struct Data {
+  // align to the CUDA L1 cache line size
+  struct alignas(128) Data {
     float x, y, z;  // position
     // TODO: add covariance matrix
 
@@ -20,13 +19,26 @@ public:
     float betaStar;
   };
 
+  // default constructor, required by cms::cuda::Product<BeamSpotCUDA>
   BeamSpotCUDA() = default;
-  BeamSpotCUDA(Data const* data_h, cudaStream_t stream);
 
+  // constructor that allocates cached device memory on the given CUDA stream
+  BeamSpotCUDA(cudaStream_t stream) { data_d_ = cms::cuda::make_device_unique<Data>(stream); }
+
+  // movable, non-copiable
+  BeamSpotCUDA(BeamSpotCUDA const&) = delete;
+  BeamSpotCUDA(BeamSpotCUDA&&) = default;
+  BeamSpotCUDA& operator=(BeamSpotCUDA const&) = delete;
+  BeamSpotCUDA& operator=(BeamSpotCUDA&&) = default;
+
+  Data* data() { return data_d_.get(); }
   Data const* data() const { return data_d_.get(); }
+
+  cms::cuda::device::unique_ptr<Data>& ptr() { return data_d_; }
+  cms::cuda::device::unique_ptr<Data> const& ptr() const { return data_d_; }
 
 private:
   cms::cuda::device::unique_ptr<Data> data_d_;
 };
 
-#endif
+#endif  // CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -1,9 +1,0 @@
-#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-
-BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cudaStream_t stream) {
-  data_d_ = cms::cuda::make_device_unique<Data>(stream);
-  cudaCheck(cudaMemcpyAsync(data_d_.get(), data_h, sizeof(Data), cudaMemcpyHostToDevice, stream));
-}

--- a/CUDADataFormats/BeamSpot/src/classes.h
+++ b/CUDADataFormats/BeamSpot/src/classes.h
@@ -5,4 +5,4 @@
 #include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-#endif
+#endif  // CUDADataFormats_BeamSpot_classes_h


### PR DESCRIPTION
Make the `BeamSpotCUDA` class movable and explicitly non-copiable (as was already the case due to the `device::unique_ptr` data member).

Remove the `cudaMemcpyAsync` from the `BeamSpotCUDA` data format, and make the copy explicitly in the `BeamSpotToCUDA` producer.