### PR TITLE
Add MPIService test file

### DIFF
--- a/HeterogeneousCore/MPIServices/plugins/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/plugins/MPIService.cc
@@ -1,13 +1,22 @@
 // -*- C++ -*-
 
-#include <cassert>
-
 #include <mpi.h>
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace {
+  const char* mpi_thread_support_level[] = {
+      "MPI_THREAD_SINGLE",      // only one thread will execute (the process is single-threaded)
+      "MPI_THREAD_FUNNELED",    // only the thread that called MPI_Init_thread will make MPI calls
+      "MPI_THREAD_SERIALIZED",  // only one thread will make MPI library calls at one time
+      "MPI_THREAD_MULTIPLE"     // multiple threads may call MPI at once with no restrictions
+  };
+}
 
 class MPIService {
 public:
@@ -18,12 +27,42 @@ public:
 };
 
 MPIService::MPIService(edm::ParameterSet const& config, edm::ActivityRegistry& registry) {
+  // initializes the MPI execution environment, requesting multi-threading support
   int provided;
   MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
-  assert(provided == MPI_THREAD_MULTIPLE);
+  if (provided < MPI_THREAD_MULTIPLE) {
+    throw cms::Exception("UnsupportedFeature")
+        << "CMSSW requires the " << mpi_thread_support_level[MPI_THREAD_MULTIPLE]
+        << " multithreading support level, but the MPI library provides only the " << mpi_thread_support_level[provided]
+        << " level.";
+  } else {
+    edm::LogInfo log("MPIService");
+
+    // get the number of processes
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    log << "MPI_COMM_WORLD size: " << world_size << '\n';
+
+    // get the rank of the process
+    int world_rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    log << "MPI_COMM_WORLD rank: " << world_rank << '\n';
+
+    // get the name of the processor
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
+    log << "MPI processor name:  " << processor_name << '\n';
+
+    log << "The MPI library provides the " << mpi_thread_support_level[provided] << " multithreading support level\n";
+    log << "MPI successfully initialised";
+  }
 }
 
-MPIService::~MPIService() { MPI_Finalize(); }
+MPIService::~MPIService() {
+  // terminate the MPI execution environment
+  MPI_Finalize();
+}
 
 void MPIService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/HeterogeneousCore/MPIServices/test/testMPIService.py
+++ b/HeterogeneousCore/MPIServices/test/testMPIService.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process( "TEST" )
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('HeterogeneousCore.MPIServices.MPIService_cfi')
+process.MessageLogger.categories.append("MPIService")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32( 0 )
+)


### PR DESCRIPTION
#### PR description:

Minor updates to the `MPIService`: 
  - improve messages and error reporting;
  - add a python configuration to test the service.

#### PR validation:
```bash
$ cmsRun HeterogeneousCore/MPIServices/test/testMPIService.py
%MSG-i MPIService:  (NoModuleName) 16-Aug-2020 14:05:52 CEST pre-events
MPI_COMM_WORLD size: 1
MPI_COMM_WORLD rank: 0
MPI processor name:  fu-c2a02-37-02
The MPI library provides the MPI_THREAD_MULTIPLE multithreading support level
MPI successfully initialised
%MSG
```