### PR TITLE
Fix HLT customisation following the HBHE updates

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -499,10 +499,7 @@ def customise_gpu_hcal(process):
         digisLabelF3HB = cms.string(""),
         maxChannelsF01HE = cms.uint32(10000),
         maxChannelsF5HB = cms.uint32(10000),
-        maxChannelsF3HB = cms.uint32(10000),
-        nsamplesF01HE = cms.uint32(8),
-        nsamplesF5HB = cms.uint32(8),
-        nsamplesF3HB = cms.uint32(8)
+        maxChannelsF3HB = cms.uint32(10000)
     )
 
     from RecoLocalCalo.HcalRecProducers.hbheRecHitProducerGPU_cfi import hbheRecHitProducerGPU as _hbheRecHitProducerGPU


### PR DESCRIPTION
Remove the HcalDigisProducerGPU parameters that are no longer present since #531.