### PR TITLE
Automatic HLT offload when a supported GPU is available

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -45,6 +45,7 @@ def customise_cpu_pixel(process):
 
     # FIXME replace the Sequences with empty ones to avoid exanding them during the (re)definition of Modules and EDAliases
 
+    process.HLTDoLocalPixelSequence = cms.Sequence()
     process.HLTRecoPixelTracksSequence = cms.Sequence()
     process.HLTRecopixelvertexingSequence = cms.Sequence()
 
@@ -107,9 +108,15 @@ def customise_cpu_pixel(process):
 
     # Tasks and Sequences
 
+    process.HLTDoLocalPixelTask = cms.Task(
+          process.hltSiPixelDigis,                          # legacy module
+          process.hltSiPixelClusters,                       # legacy module
+          process.hltSiPixelClustersCache,                  # legacy module
+          process.hltSiPixelRecHits)                        # legacy module
+
+    process.HLTDoLocalPixelSequence = cms.Sequence(process.HLTDoLocalPixelTask)
+
     process.HLTRecoPixelTracksTask = cms.Task(
-          process.hltPixelTracksFitter,                     # not used here, kept for compatibility with legacy sequences
-          process.hltPixelTracksFilter,                     # not used here, kept for compatibility with legacy sequences
           process.hltPixelTracksTrackingRegions,            # from the original sequence
           process.hltSiPixelRecHitSoA,                      # pixel rechits on cpu, converted to SoA
           process.hltPixelTracksHitQuadruplets,             # pixel ntuplets on cpu, in SoA format
@@ -119,12 +126,15 @@ def customise_cpu_pixel(process):
     process.HLTRecoPixelTracksSequence = cms.Sequence(process.HLTRecoPixelTracksTask)
 
     process.HLTRecopixelvertexingTask = cms.Task(
-         process.HLTRecoPixelTracksTask,
-         process.hltPixelVerticesSoA,                       # pixel vertices on cpu, in SoA format
-         process.hltPixelVertices,                          # pixel vertices on cpu, in legacy format
-         process.hltTrimmedPixelVertices)                   # from the original sequence
+          process.HLTRecoPixelTracksTask,
+          process.hltPixelVerticesSoA,                      # pixel vertices on cpu, in SoA format
+          process.hltPixelVertices,                         # pixel vertices on cpu, in legacy format
+          process.hltTrimmedPixelVertices)                  # from the original sequence
 
-    process.HLTRecopixelvertexingSequence = cms.Sequence(process.HLTRecopixelvertexingTask)
+    process.HLTRecopixelvertexingSequence = cms.Sequence(
+          process.hltPixelTracksFitter +                    # not used here, kept for compatibility with legacy sequences
+          process.hltPixelTracksFilter,                     # not used here, kept for compatibility with legacy sequences
+          process.HLTRecopixelvertexingTask)
 
 
     # done
@@ -273,8 +283,6 @@ def customise_gpu_pixel(process):
     process.HLTDoLocalPixelSequence = cms.Sequence(process.HLTDoLocalPixelTask)
 
     process.HLTRecoPixelTracksTask = cms.Task(
-          process.hltPixelTracksFitter,                     # not used here, kept for compatibility with legacy sequences
-          process.hltPixelTracksFilter,                     # not used here, kept for compatibility with legacy sequences
           process.hltPixelTracksTrackingRegions,            # from the original sequence
           process.hltPixelTracksHitQuadruplets,             # pixel ntuplets on gpu, in SoA format
           process.hltPixelTracksSoA,                        # pixel ntuplets on cpu, in SoA format
@@ -283,13 +291,16 @@ def customise_gpu_pixel(process):
     process.HLTRecoPixelTracksSequence = cms.Sequence(process.HLTRecoPixelTracksTask)
 
     process.HLTRecopixelvertexingTask = cms.Task(
-         process.HLTRecoPixelTracksTask,
-         process.hltPixelVerticesCUDA,                      # pixel vertices on gpu, in SoA format
-         process.hltPixelVerticesSoA,                       # pixel vertices on cpu, in SoA format
-         process.hltPixelVertices,                          # pixel vertices on cpu, in legacy format
-         process.hltTrimmedPixelVertices)                   # from the original sequence
+          process.HLTRecoPixelTracksTask,
+          process.hltPixelVerticesCUDA,                     # pixel vertices on gpu, in SoA format
+          process.hltPixelVerticesSoA,                      # pixel vertices on cpu, in SoA format
+          process.hltPixelVertices,                         # pixel vertices on cpu, in legacy format
+          process.hltTrimmedPixelVertices)                  # from the original sequence
 
-    process.HLTRecopixelvertexingSequence = cms.Sequence(process.HLTRecopixelvertexingTask)
+    process.HLTRecopixelvertexingSequence = cms.Sequence(
+          process.hltPixelTracksFitter +                    # not used here, kept for compatibility with legacy sequences
+          process.hltPixelTracksFilter,                     # not used here, kept for compatibility with legacy sequences
+          process.HLTRecopixelvertexingTask)
 
 
     # done
@@ -454,10 +465,15 @@ def customise_gpu_ecal(process):
 
     process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerSequence = cms.Sequence(process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask)
 
-    process.HLTDoFullUnpackingEgammaEcalTask = cms.Task(
-        process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask,
+    process.HLTPreshowerTask = cms.Task(
         process.hltEcalPreshowerDigis,                      # unpack ECAL preshower digis on the host
         process.hltEcalPreshowerRecHit)                     # build ECAL preshower rechits on the host
+
+    process.HLTPreshowerSequence = cms.Sequence(process.HLTPreshowerTask)
+
+    process.HLTDoFullUnpackingEgammaEcalTask = cms.Task(
+        process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask,
+        process.HLTPreshowerTask)
 
     process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(process.HLTDoFullUnpackingEgammaEcalTask)
 

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -4,10 +4,23 @@ from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
 from HLTrigger.Configuration.common import *
 
 
+# force the SwitchProducerCUDA choice to pick a specific backend: True for offloading to a GPU, False for running on the CPU
+def forceGpuOffload(status = True):
+    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
+    HeterogeneousCore.CUDACore.SwitchProducerCUDA._cuda_enabled_cached = bool(status)
+
+
+# reset the SwitchProducerCUDA choice to pick a backend depending on the availability of a supported GPU
+def resetGpuOffload():
+    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
+    HeterogeneousCore.CUDACore.SwitchProducerCUDA._cuda_enabled_cached = None
+    HeterogeneousCore.CUDACore.SwitchProducerCUDA._switch_cuda()
+
+
 # check if CUDA is enabled, using the same mechanism as the SwitchProducerCUDA
 def cudaIsEnabled():
-    from HeterogeneousCore.CUDACore.SwitchProducerCUDA import _switch_cuda
-    return _switch_cuda()[0]
+    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
+    return HeterogeneousCore.CUDACore.SwitchProducerCUDA._switch_cuda()[0]
 
 
 # customisation for running on CPUs or GPUs, common parts
@@ -24,16 +37,16 @@ def customiseCommon(process):
     # Paths
 
     # produce a boolean to track if the events ar being processed on gpu (true) or cpu (false)
-    process.hltOnGPU = SwitchProducerCUDA(
+    process.statusOnGPU = SwitchProducerCUDA(
         cpu  = cms.EDProducer("BooleanProducer", value = cms.bool(False)),
         cuda = cms.EDProducer("BooleanProducer", value = cms.bool(True))
     )
 
-    process.hltOnGpuFilter = cms.EDFilter("BooleanFilter",
-        src = cms.InputTag("hltOnGPU")
+    process.statusOnGPUFilter = cms.EDFilter("BooleanFilter",
+        src = cms.InputTag("statusOnGPU")
     )
 
-    process.OnGPU = cms.Path(process.hltOnGPU + process.hltOnGpuFilter)
+    process.status_OnGPU = cms.Path(process.statusOnGPU + process.statusOnGPUFilter)
 
 
     # EndPaths

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -505,6 +505,7 @@ def customiseEcalLocalReconstruction(process):
     """
 
     
+    # SwitchProducer wrapping the legacy ECAL rechits producer
     # the gpu unpacker does not produce the TPs used for the recovery, so the SwitchProducer alias does not provide them:
     #   - the cpu uncalibrated rechit producer may mark them for recovery, read the TPs explicitly from the legacy unpacker
     #   - the gpu uncalibrated rechit producer does not flag them for recovery, so the TPs are not necessary
@@ -515,6 +516,11 @@ def customiseEcalLocalReconstruction(process):
         cuda = process.hltEcalRecHit.clone(
             triggerPrimitiveDigiCollection = cms.InputTag('unused')
         )
+    )
+
+    # consume the ECAL rechits
+    process.hltEcalConsumer = cms.EDAnalyzer("GenericConsumer",
+        eventProducts = cms.untracked.vstring( 'hltEcalRecHit' )
     )
 
     # Tasks and Sequences
@@ -531,7 +537,9 @@ def customiseEcalLocalReconstruction(process):
         process.hltEcalDetIdToBeRecovered,                  # legacy producer
         process.hltEcalRecHit)                              # legacy producer
 
-    process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerSequence = cms.Sequence(process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask)
+    process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerSequence = cms.Sequence(
+        process.hltEcalConsumer,                            # consume the ECAL rechits
+        process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask)
 
     process.HLTPreshowerTask = cms.Task(
         process.hltEcalPreshowerDigis,                      # unpack ECAL preshower digis on the host
@@ -543,9 +551,13 @@ def customiseEcalLocalReconstruction(process):
         process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerTask,
         process.HLTPreshowerTask)
 
-    process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(process.HLTDoFullUnpackingEgammaEcalTask)
+    process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(
+        process.hltEcalConsumer,                            # consume the ECAL rechits
+        process.HLTDoFullUnpackingEgammaEcalTask)
 
-    process.HLTDoFullUnpackingEgammaEcalMFSequence = cms.Sequence(process.HLTDoFullUnpackingEgammaEcalTask)
+    process.HLTDoFullUnpackingEgammaEcalMFSequence = cms.Sequence(
+        process.hltEcalConsumer,                            # consume the ECAL rechits
+        process.HLTDoFullUnpackingEgammaEcalTask)
 
 
     # done
@@ -633,29 +645,38 @@ def customiseHcalLocalReconstruction(process):
         )
     )
 
+    # consume the HCAL rechits
+    process.hltHbheConsumer = cms.EDAnalyzer("GenericConsumer",
+        eventProducts = cms.untracked.vstring( 'hltHbhereco' )
+    )
+
 
     # Tasks and Sequences
 
     process.HLTDoLocalHcalTask = cms.Task(
-          process.hltHcalDigis,                             # legacy producer, unpack HCAL digis on cpu
-          process.hltHcalDigisGPU,                          # copy to gpu and convert to SoA format
-          process.hltHbherecoGPU,                           # run the HCAL local reconstruction (including Method 0 and MAHI) on gpu
-          process.hltHbherecoFromGPU,                       # transfer the HCAL rechits to the cpu, and convert them to the legacy format
-          process.hltHbhereco,                              # SwitchProducer between the legacy producer and the copy from gpu with conversion
-          process.hltHfprereco,                             # legacy producer
-          process.hltHfreco,                                # legacy producer
-          process.hltHoreco)                                # legacy producer
+        process.hltHcalDigis,                               # legacy producer, unpack HCAL digis on cpu
+        process.hltHcalDigisGPU,                            # copy to gpu and convert to SoA format
+        process.hltHbherecoGPU,                             # run the HCAL local reconstruction (including Method 0 and MAHI) on gpu
+        process.hltHbherecoFromGPU,                         # transfer the HCAL rechits to the cpu, and convert them to the legacy format
+        process.hltHbhereco,                                # SwitchProducer between the legacy producer and the copy from gpu with conversion
+        process.hltHfprereco,                               # legacy producer
+        process.hltHfreco,                                  # legacy producer
+        process.hltHoreco)                                  # legacy producer
 
-    process.HLTDoLocalHcalSequence = cms.Sequence(process.HLTDoLocalHcalTask)
+    process.HLTDoLocalHcalSequence = cms.Sequence(
+        process.hltHbheConsumer,                            # consume the HCAL rechits
+        process.HLTDoLocalHcalTask)
 
     process.HLTStoppedHSCPLocalHcalRecoTask = cms.Task(
-          process.hltHcalDigis,                             # legacy producer, unpack HCAL digis on cpu
-          process.hltHcalDigisGPU,                          # copy to gpu and convert to SoA format
-          process.hltHbherecoGPU,                           # run the HCAL local reconstruction (including Method 0 and MAHI) on gpu
-          process.hltHbherecoFromGPU,                       # transfer the HCAL rechits to the cpu, and convert them to the legacy format
-          process.hltHbhereco)                              # SwitchProducer between the legacy producer and the copy from gpu with conversion
+        process.hltHcalDigis,                               # legacy producer, unpack HCAL digis on cpu
+        process.hltHcalDigisGPU,                            # copy to gpu and convert to SoA format
+        process.hltHbherecoGPU,                             # run the HCAL local reconstruction (including Method 0 and MAHI) on gpu
+        process.hltHbherecoFromGPU,                         # transfer the HCAL rechits to the cpu, and convert them to the legacy format
+        process.hltHbhereco)                                # SwitchProducer between the legacy producer and the copy from gpu with conversion
 
-    process.HLTStoppedHSCPLocalHcalReco = cms.Sequence(process.HLTStoppedHSCPLocalHcalRecoTask)
+    process.HLTStoppedHSCPLocalHcalReco = cms.Sequence(
+        process.hltHbheConsumer,                            # consume the HCAL rechits
+        process.HLTStoppedHSCPLocalHcalRecoTask)
 
 
     # done


### PR DESCRIPTION
Update the customisation function names, unifying the "common" part and splitting the Pixel part into local reconstruction and track reconstruction.

Rewrite the customisation to use Task, SwitchProducerCUDA and EDAlias to make the offload automatic when a supported GPU is available.

Make the Scouting endpaths compatible with Tasks.

Add a Path to track if the code is running on the CPU or being offloaded to the GPU.

Add functions to force, forbid, or reset to automatic the choice of offloading to a GPU.