### PR TITLE
Replace instead of recreate the Status_OnGPU path

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -50,7 +50,10 @@ def customiseCommon(process):
         src = cms.InputTag("statusOnGPU")
     )
 
-    process.Status_OnGPU = cms.Path(process.statusOnGPU + process.statusOnGPUFilter)
+    if 'Status_OnGPU' in process.__dict__:
+        replace_with(process.Status_OnGPU, cms.Path(process.statusOnGPU + process.statusOnGPUFilter))
+    else:
+        process.Status_OnGPU = cms.Path(process.statusOnGPU + process.statusOnGPUFilter)
 
 
     # make the ScoutingCaloMuonOutput endpath compatible with using Tasks in the Scouting paths


### PR DESCRIPTION
If the Status_OnGPU path exists already, replace its contente instead of
recreating it. This guarantuees that the order of the paths in the menu
and monitor toold does not change.