### PR TITLE
Updating validation sequence for pixel only tracking workflows

### DIFF
--- a/DQMOffline/RecoB/python/PixelVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PixelVertexMonitor_cff.py
@@ -4,4 +4,5 @@ from DQMOffline.RecoB.PrimaryVertexMonitor_cff import pvMonitor as _pvMonitor
 pixelPVMonitor = _pvMonitor.clone(
     TopFolderName = "OfflinePixelPV",
     vertexLabel = "pixelVertices",
+    ndof        = cms.int32( 1 )
 )

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
@@ -22,6 +22,8 @@ def customizePixelTracksSoAonCPU(process) :
 
   process.reconstruction_step += process.siPixelRecHitHostSoA+process.pixelTrackSoA+process.pixelVertexSoA
 
+  process.pixelOnlyRecHitsAnalyzerV.src = cms.InputTag("siPixelRecHitHostSoA")
+
   return process
 
 def customizePixelTracksSoAonCPUForProfiling(process) :

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
@@ -22,7 +22,6 @@ def customizePixelTracksSoAonCPU(process) :
 
   process.reconstruction_step += process.siPixelRecHitHostSoA+process.pixelTrackSoA+process.pixelVertexSoA
 
-  process.pixelOnlyRecHitsAnalyzerV.src = cms.InputTag("siPixelRecHitHostSoA")
 
   return process
 

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
@@ -22,7 +22,6 @@ def customizePixelTracksSoAonCPU(process) :
 
   process.reconstruction_step += process.siPixelRecHitHostSoA+process.pixelTrackSoA+process.pixelVertexSoA
 
-
   return process
 
 def customizePixelTracksSoAonCPUForProfiling(process) :

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -219,8 +219,13 @@ globalValidationMuons = cms.Sequence()
 
 _phase_1_globalValidation = globalValidation.copy()
 _phase_1_globalValidation += siPixelPhase1OfflineDQM_sourceV
+
+_phase_1_globalValidationPixelTrackingOnly =  globalValidationPixelTrackingOnly.copy()
+_phase_1_globalValidationPixelTrackingOnly += siPixelPhase1ValidationPixelTrackingOnly_sourceV
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 (phase1Pixel & ~fastSim).toReplaceWith( globalValidation, _phase_1_globalValidation ) #module siPixelPhase1OfflineDQM_sourceV can't run in FastSim since siPixelClusters of type edmNew::DetSetVector are not produced
+(phase1Pixel & ~fastSim).toReplaceWith( globalValidationPixelTrackingOnly, _phase_1_globalValidationPixelTrackingOnly ) #module siPixelPhase1OfflineDQM_sourceV can't run in FastSim since siPixelClusters of type edmNew::DetSetVector are not produced
 
 _run3_globalValidation = globalValidation.copy()
 _run3_globalValidation += gemSimValid

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -73,8 +73,9 @@ postValidation_common = cms.Sequence()
 
 postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly
-    + postProcessorVertexSequence
+    + postProcessorVertexSequence	
 )
+
 
 postValidation_muons = cms.Sequence(
     recoMuonPostProcessors
@@ -115,8 +116,13 @@ postValidationOuterTracker = cms.Sequence( OuterTracker_harvestingV )
 
 _phase1_postValidation = postValidation.copy()
 _phase1_postValidation += siPixelPhase1OfflineDQM_harvestingV
+
+_phase1_postValidation_trackingOnly = postValidation_trackingOnly.copy()
+_phase1_postValidation_trackingOnly += siPixelPhase1OfflineDQM_harvestingV
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toReplaceWith( postValidation, _phase1_postValidation )
+phase1Pixel.toReplaceWith( postValidation_trackingOnly, _phase1_postValidation_trackingOnly)
 
 _run3_postValidation = postValidation.copy()
 _run3_postValidation += MuonGEMHitsPostProcessors

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -73,10 +73,8 @@ postValidation_common = cms.Sequence()
 
 postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly
-    + postProcessorVertexSequence	
+    + postProcessorVertexSequence
 )
-
-
 postValidation_muons = cms.Sequence(
     recoMuonPostProcessors
     + MuonGEMHitsPostProcessors

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -75,6 +75,7 @@ postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly
     + postProcessorVertexSequence
 )
+
 postValidation_muons = cms.Sequence(
     recoMuonPostProcessors
     + MuonGEMHitsPostProcessors

--- a/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
+++ b/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
@@ -20,3 +20,32 @@ siPixelPhase1OfflineDQM_sourceV = cms.Sequence(SiPixelPhase1DigisAnalyzerV
                                             + SiPixelPhase1TrackingParticleAnalyzerV
                                             )
 
+###PixelTracking only configurations for gpu wf###
+#digi
+pixelOnlyDigisAnalyzerV = SiPixelPhase1DigisAnalyzerV.clone()
+#cluster
+pixelOnlyTrackClustersAnalyzerV = SiPixelPhase1TrackClustersAnalyzerV.clone()
+pixelOnlyTrackClustersAnalyzerV.clusters = cms.InputTag('siPixelClustersPreSplitting')
+pixelOnlyTrackClustersAnalyzerV.tracks = cms.InputTag('pixelTracks')
+
+#rechit analyzer
+pixelOnlyRecHitsAnalyzerV = SiPixelPhase1RecHitsAnalyzerV.clone()
+pixelOnlyRecHitsAnalyzerV.src = cms.InputTag("siPixelRecHitsPreSplitting")
+pixelOnlyRecHitsAnalyzerV.pixelSimLinkSrc = cms.InputTag("simSiPixelDigis")
+pixelOnlyRecHitsAnalyzerV.ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
+                                                'TrackerHitsPixelBarrelHighTof',
+                                                'TrackerHitsPixelEndcapLowTof',
+                                                'TrackerHitsPixelEndcapHighTof')
+#Hits
+pixelOnlyHitsAnalyzerV = SiPixelPhase1HitsAnalyzerV.clone()
+pixelOnlyHitsAnalyzerV.tracksTag = cms.InputTag("pixelTracks")
+
+#TP
+pixelOnlyTrackingParticleAnalyzerV = SiPixelPhase1TrackingParticleAnalyzerV.clone()
+
+siPixelPhase1ValidationPixelTrackingOnly_sourceV = cms.Sequence(pixelOnlyDigisAnalyzerV 
+                                                                + pixelOnlyTrackClustersAnalyzerV 
+                                                                + pixelOnlyHitsAnalyzerV
+                                                                + pixelOnlyRecHitsAnalyzerV
+                                                                + pixelOnlyTrackingParticleAnalyzerV
+)

--- a/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
+++ b/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
@@ -24,21 +24,24 @@ siPixelPhase1OfflineDQM_sourceV = cms.Sequence(SiPixelPhase1DigisAnalyzerV
 #digi
 pixelOnlyDigisAnalyzerV = SiPixelPhase1DigisAnalyzerV.clone()
 #cluster
-pixelOnlyTrackClustersAnalyzerV = SiPixelPhase1TrackClustersAnalyzerV.clone()
-pixelOnlyTrackClustersAnalyzerV.clusters = cms.InputTag('siPixelClustersPreSplitting')
-pixelOnlyTrackClustersAnalyzerV.tracks = cms.InputTag('pixelTracks')
+pixelOnlyTrackClustersAnalyzerV = SiPixelPhase1TrackClustersAnalyzerV.clone(
+    clusters = 'siPixelClustersPreSplitting',
+    tracks = 'pixelTracks'
+)
 
 #rechit analyzer
-pixelOnlyRecHitsAnalyzerV = SiPixelPhase1RecHitsAnalyzerV.clone()
-pixelOnlyRecHitsAnalyzerV.src = cms.InputTag("siPixelRecHitsPreSplitting")
-pixelOnlyRecHitsAnalyzerV.pixelSimLinkSrc = cms.InputTag("simSiPixelDigis")
-pixelOnlyRecHitsAnalyzerV.ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
-                                                'TrackerHitsPixelBarrelHighTof',
-                                                'TrackerHitsPixelEndcapLowTof',
-                                                'TrackerHitsPixelEndcapHighTof')
+pixelOnlyRecHitsAnalyzerV = SiPixelPhase1RecHitsAnalyzerV.clone(
+    src = 'siPixelRecHitsPreSplitting',
+    pixelSimLinkSrc = 'simSiPixelDigis',
+    ROUList = ('TrackerHitsPixelBarrelLowTof',
+               'TrackerHitsPixelBarrelHighTof',
+               'TrackerHitsPixelEndcapLowTof',
+               'TrackerHitsPixelEndcapHighTof')
+)
 #Hits
-pixelOnlyHitsAnalyzerV = SiPixelPhase1HitsAnalyzerV.clone()
-pixelOnlyHitsAnalyzerV.tracksTag = cms.InputTag("pixelTracks")
+pixelOnlyHitsAnalyzerV = SiPixelPhase1HitsAnalyzerV.clone(
+    tracksTag = 'pixelTracks'
+)
 
 #TP
 pixelOnlyTrackingParticleAnalyzerV = SiPixelPhase1TrackingParticleAnalyzerV.clone()

--- a/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
+++ b/Validation/SiPixelPhase1ConfigV/python/SiPixelPhase1OfflineDQM_sourceV_cff.py
@@ -20,16 +20,18 @@ siPixelPhase1OfflineDQM_sourceV = cms.Sequence(SiPixelPhase1DigisAnalyzerV
                                             + SiPixelPhase1TrackingParticleAnalyzerV
                                             )
 
-###PixelTracking only configurations for gpu wf###
-#digi
+### Pixel Tracking-only configurations for the GPU workflow
+
+# Pixel digis
 pixelOnlyDigisAnalyzerV = SiPixelPhase1DigisAnalyzerV.clone()
-#cluster
+
+# Pixel clusters
 pixelOnlyTrackClustersAnalyzerV = SiPixelPhase1TrackClustersAnalyzerV.clone(
     clusters = 'siPixelClustersPreSplitting',
     tracks = 'pixelTracks'
 )
 
-#rechit analyzer
+# Pixel rechit analyzer
 pixelOnlyRecHitsAnalyzerV = SiPixelPhase1RecHitsAnalyzerV.clone(
     src = 'siPixelRecHitsPreSplitting',
     pixelSimLinkSrc = 'simSiPixelDigis',
@@ -38,12 +40,13 @@ pixelOnlyRecHitsAnalyzerV = SiPixelPhase1RecHitsAnalyzerV.clone(
                'TrackerHitsPixelEndcapLowTof',
                'TrackerHitsPixelEndcapHighTof')
 )
-#Hits
+
+# Pixel hits
 pixelOnlyHitsAnalyzerV = SiPixelPhase1HitsAnalyzerV.clone(
     tracksTag = 'pixelTracks'
 )
 
-#TP
+# Tracking particles
 pixelOnlyTrackingParticleAnalyzerV = SiPixelPhase1TrackingParticleAnalyzerV.clone()
 
 siPixelPhase1ValidationPixelTrackingOnly_sourceV = cms.Sequence(pixelOnlyDigisAnalyzerV 


### PR DESCRIPTION
#### PR description:
In this PR, the validation modules for pixel digis, clusters and rechits are added to the pixel only tracking  validation sequence. The PR also includes a fix for the cut on ndof for the primary vertex monitor.

#### PR validation:
This has been tested with 11634.0(customized for pixel only tracking), 11634.502.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
