### PR TITLE
Fix BS naming in siPixelRecHitsCUDAPreSplitting

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -29,6 +29,8 @@ gpu.toModify(siPixelRecHitsPreSplitting,
 siPixelRecHitsPreSplittingTask = cms.Task(siPixelRecHitsPreSplitting)
 
 siPixelRecHitsCUDAPreSplitting = _siPixelRecHitCUDA.clone()
+siPixelRecHitsCUDAPreSplitting.beamSpot = cms.InputTag("offlineBeamSpotToCUDA")
+
 siPixelRecHitsLegacyPreSplitting = _siPixelRecHitFromSOA.clone()
 siPixelRecHitsPreSplittingTaskCUDA = cms.Task(
     siPixelRecHitsCUDAPreSplitting,

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -28,8 +28,9 @@ gpu.toModify(siPixelRecHitsPreSplitting,
 
 siPixelRecHitsPreSplittingTask = cms.Task(siPixelRecHitsPreSplitting)
 
-siPixelRecHitsCUDAPreSplitting = _siPixelRecHitCUDA.clone()
-siPixelRecHitsCUDAPreSplitting.beamSpot = cms.InputTag("offlineBeamSpotToCUDA")
+siPixelRecHitsCUDAPreSplitting = _siPixelRecHitCUDA.clone(
+    beamSpot = "offlineBeamSpotToCUDA"
+)
 
 siPixelRecHitsLegacyPreSplitting = _siPixelRecHitFromSOA.clone()
 siPixelRecHitsPreSplittingTaskCUDA = cms.Task(
@@ -41,4 +42,3 @@ from Configuration.ProcessModifiers.gpu_cff import gpu
 _siPixelRecHitsPreSplittingTask_gpu = siPixelRecHitsPreSplittingTask.copy()
 _siPixelRecHitsPreSplittingTask_gpu.add(siPixelRecHitsPreSplittingTaskCUDA)
 gpu.toReplaceWith(siPixelRecHitsPreSplittingTask, _siPixelRecHitsPreSplittingTask_gpu)
-


### PR DESCRIPTION
Fixing BeamSpotCUDA input tag in siPixelRecHitsCUDAPreSplitting to be consistent with changes made in 51f18ad645011763db0eccde292a389abde0b7af
