### PR TITLE
Update ESProducers following cms-sw#31556

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelGainCalibrationForHLTGPUESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelGainCalibrationForHLTGPUESProducer.cc
@@ -25,7 +25,9 @@ private:
 };
 
 SiPixelGainCalibrationForHLTGPUESProducer::SiPixelGainCalibrationForHLTGPUESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(gainsToken_).setConsumes(geometryToken_);
+  auto cc = setWhatProduced(this);
+  gainsToken_ = cc.consumes();
+  geometryToken_ = cc.consumes();
 }
 
 void SiPixelGainCalibrationForHLTGPUESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawESProducerGPU.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawESProducerGPU.h
@@ -15,10 +15,10 @@ template <typename Target, typename Source, typename Record>
 class EcalRawESProducerGPU : public edm::ESProducer {
 public:
   explicit EcalRawESProducerGPU(edm::ParameterSet const& ps) {
-    auto const label = ps.getParameter<std::string>("label");
-    auto name = ps.getParameter<std::string>("ComponentName");
+    auto const& label = ps.getParameter<std::string>("label");
+    auto const& name = ps.getParameter<std::string>("ComponentName");
     auto cc = setWhatProduced(this, name);
-    cc.setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = cc.consumes(edm::ESInputTag{"", label});
   }
 
   std::unique_ptr<Target> produce(Record const& record) {

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawESProducerGPU.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawESProducerGPU.h
@@ -15,10 +15,10 @@ template <typename Target, typename Source, typename Record>
 class HcalRawESProducerGPU : public edm::ESProducer {
 public:
   explicit HcalRawESProducerGPU(edm::ParameterSet const& ps) {
-    auto const label = ps.getParameter<std::string>("label");
-    std::string name = ps.getParameter<std::string>("ComponentName");
+    auto const& label = ps.getParameter<std::string>("label");
+    auto const& name = ps.getParameter<std::string>("ComponentName");
     auto cc = setWhatProduced(this, name);
-    cc.setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = cc.consumes(edm::ESInputTag{"", label});
   }
 
   std::unique_ptr<Target> produce(Record const& record) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalESProducerGPU.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalESProducerGPU.h
@@ -15,10 +15,10 @@ template <typename Target, typename Source, typename Record>
 class EcalESProducerGPU : public edm::ESProducer {
 public:
   explicit EcalESProducerGPU(edm::ParameterSet const& ps) {
-    auto const label = ps.getParameter<std::string>("label");
-    std::string name = ps.getParameter<std::string>("ComponentName");
+    auto const& label = ps.getParameter<std::string>("label");
+    auto const& name = ps.getParameter<std::string>("ComponentName");
     auto cc = setWhatProduced(this, name);
-    cc.setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = cc.consumes(edm::ESInputTag{"", label});
   }
 
   std::unique_ptr<Target> produce(Record const& record) {

--- a/RecoLocalCalo/HcalRecProducers/src/HcalESProducerGPU.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalESProducerGPU.h
@@ -20,11 +20,10 @@ template <typename Record, typename Target, typename Source>
 class HcalESProducerGPU : public edm::ESProducer {
 public:
   explicit HcalESProducerGPU(edm::ParameterSet const& ps) {
-    auto const label = ps.getParameter<std::string>("label");
-    std::string name = ps.getParameter<std::string>("ComponentName");
+    auto const& label = ps.getParameter<std::string>("label");
+    auto const& name = ps.getParameter<std::string>("ComponentName");
     auto cc = setWhatProduced(this, name);
-
-    cc.setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = cc.consumes(edm::ESInputTag{"", label});
   }
 
   std::unique_ptr<Target> produce(Record const& record) {
@@ -117,7 +116,7 @@ private:
   template <std::size_t N, typename CC>
   struct WalkConsumes {
     static void iterate(CC& cc, TokenType& tokens, std::vector<std::string> const& labels) {
-      cc.setConsumes(std::get<N>(tokens), edm::ESInputTag{"", labels[N]});
+      std::get<N>(tokens) = cc.consumes(edm::ESInputTag{"", labels[N]});
       WalkConsumes<N - 1, CC>::iterate(cc, tokens, labels);
     }
   };
@@ -125,7 +124,7 @@ private:
   template <typename CC>
   struct WalkConsumes<0, CC> {
     static void iterate(CC& cc, TokenType& tokens, std::vector<std::string> const& labels) {
-      cc.setConsumes(std::get<0>(tokens), edm::ESInputTag{"", labels[0]});
+      std::get<0>(tokens) = cc.consumes(edm::ESInputTag{"", labels[0]});
     }
   };
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelFedCablingMapGPUWrapperESProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelFedCablingMapGPUWrapperESProducer.cc
@@ -29,13 +29,13 @@ private:
 
 SiPixelFedCablingMapGPUWrapperESProducer::SiPixelFedCablingMapGPUWrapperESProducer(const edm::ParameterSet& iConfig)
     : useQuality_(iConfig.getParameter<bool>("UseQualityInfo")) {
-  std::string component = iConfig.getParameter<std::string>("ComponentName");
+  auto const& component = iConfig.getParameter<std::string>("ComponentName");
   auto cc = setWhatProduced(this, component);
-  cc.setConsumes(cablingMapToken_, edm::ESInputTag{"", iConfig.getParameter<std::string>("CablingMapLabel")});
+  cablingMapToken_ = cc.consumes(edm::ESInputTag{"", iConfig.getParameter<std::string>("CablingMapLabel")});
   if (useQuality_) {
-    cc.setConsumes(qualityToken_);
+    qualityToken_ = cc.consumes();
   }
-  cc.setConsumes(geometryToken_);
+  geometryToken_ = cc.consumes();
 }
 
 void SiPixelFedCablingMapGPUWrapperESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
@@ -39,20 +39,19 @@ private:
 
 using namespace edm;
 
-PixelCPEFastESProducer::PixelCPEFastESProducer(const edm::ParameterSet& p) {
-  std::string myname = p.getParameter<std::string>("ComponentName");
-  auto magname = p.getParameter<edm::ESInputTag>("MagneticFieldRecord");
+PixelCPEFastESProducer::PixelCPEFastESProducer(const edm::ParameterSet& p) : pset_(p) {
+  auto const& myname = p.getParameter<std::string>("ComponentName");
+  auto const& magname = p.getParameter<edm::ESInputTag>("MagneticFieldRecord");
   UseErrorsFromTemplates_ = p.getParameter<bool>("UseErrorsFromTemplates");
 
-  pset_ = p;
-  auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_, magname)
-      .setConsumes(pDDToken_)
-      .setConsumes(hTTToken_)
-      .setConsumes(lorentzAngleToken_, edm::ESInputTag(""));
-  c.setConsumes(lorentzAngleWidthToken_, edm::ESInputTag("", "forWidth"));
+  auto cc = setWhatProduced(this, myname);
+  magfieldToken_ = cc.consumes(magname);
+  pDDToken_ = cc.consumes();
+  hTTToken_ = cc.consumes();
+  lorentzAngleToken_ = cc.consumes(edm::ESInputTag(""));
+  lorentzAngleWidthToken_ = cc.consumes(edm::ESInputTag("", "forWidth"));
   if (UseErrorsFromTemplates_) {
-    c.setConsumes(genErrorDBObjectToken_);
+    genErrorDBObjectToken_ = cc.consumes();
   }
 }
 


### PR DESCRIPTION
Remove setConsumes() from ESConsumesCollector: the functionality was replaced with the type-deducing consumes().