### PR TITLE
Address ECAL review comments regarding preprocessor directives

### DIFF
--- a/CUDADataFormats/EcalDigi/src/classes.h
+++ b/CUDADataFormats/EcalDigi/src/classes.h
@@ -1,3 +1,3 @@
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "CUDADataFormats/EcalDigi/interface/DigisCollection.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/CUDADataFormats/EcalRecHitSoA/interface/EcalRecHit.h
+++ b/CUDADataFormats/EcalRecHitSoA/interface/EcalRecHit.h
@@ -1,12 +1,12 @@
-#ifndef CUDADataFormats_EcalRecHitSoA_interface_EcalRecHit_soa_h
-#define CUDADataFormats_EcalRecHitSoA_interface_EcalRecHit_soa_h
+#ifndef CUDADataFormats_EcalRecHitSoA_interface_EcalRecHit_h
+#define CUDADataFormats_EcalRecHitSoA_interface_EcalRecHit_h
 
-#include <vector>
 #include <array>
+#include <vector>
 
+#include "CUDADataFormats/CaloCommon/interface/Common.h"
 #include "CUDADataFormats/EcalRecHitSoA/interface/RecoTypes.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
-#include "CUDADataFormats/CaloCommon/interface/Common.h"
 
 namespace ecal {
 
@@ -27,7 +27,6 @@ namespace ecal {
         extra;  // packed uint32_t for timeError, chi2, energyError
     typename StoragePolicy::template StorageSelector<uint32_t>::type
         flagBits;  // store rechit condition (see Flags enum) in a bit-wise way
-
     typename StoragePolicy::template StorageSelector<uint32_t>::type did;
 
     template <typename U = typename StoragePolicy::TagType>
@@ -43,5 +42,4 @@ namespace ecal {
 
 }  // namespace ecal
 
-#endif
-// RecoLocalCalo_EcalRecAlgos_interface_EcalRecHit_soa_h
+#endif  // CUDADataFormats_EcalRecHitSoA_interface_EcalRecHit_h

--- a/CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h
+++ b/CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h
@@ -1,13 +1,12 @@
 #ifndef CUDADataFormats_EcalRecHitSoA_interface_EcalUncalibratedRecHit_h
 #define CUDADataFormats_EcalRecHitSoA_interface_EcalUncalibratedRecHit_h
 
-#include <vector>
 #include <array>
-
-#include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
+#include <vector>
 
 #include "CUDADataFormats/CaloCommon/interface/Common.h"
 #include "CUDADataFormats/EcalRecHitSoA/interface/RecoTypes.h"
+#include "DataFormats/EcalDigi/interface/EcalDataFrame.h"
 
 namespace ecal {
 
@@ -44,4 +43,4 @@ namespace ecal {
 
 }  // namespace ecal
 
-#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalUncalibratedRecHit_h
+#endif  // CUDADataFormats_EcalRecHitSoA_interface_EcalUncalibratedRecHit_h

--- a/CUDADataFormats/EcalRecHitSoA/interface/RecoTypes.h
+++ b/CUDADataFormats/EcalRecHitSoA/interface/RecoTypes.h
@@ -1,5 +1,5 @@
-#ifndef CUDADataFormats_EcalRecHitSoA_interface_RecoTypes
-#define CUDADataFormats_EcalRecHitSoA_interface_RecoTypes
+#ifndef CUDADataFormats_EcalRecHitSoA_interface_RecoTypes_h
+#define CUDADataFormats_EcalRecHitSoA_interface_RecoTypes_h
 
 namespace ecal {
   namespace reco {
@@ -10,4 +10,4 @@ namespace ecal {
   }  // namespace reco
 }  // namespace ecal
 
-#endif
+#endif  // CUDADataFormats_EcalRecHitSoA_interface_RecoTypes_h

--- a/CUDADataFormats/EcalRecHitSoA/src/classes.h
+++ b/CUDADataFormats/EcalRecHitSoA/src/classes.h
@@ -1,4 +1,4 @@
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "CUDADataFormats/Common/interface/Product.h"
-#include "CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h"
 #include "CUDADataFormats/EcalRecHitSoA/interface/EcalRecHit.h"
+#include "CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalGainRatiosGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalGainRatiosGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalGainRatiosGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalGainRatiosGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalGainRatiosGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalGainRatiosGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalGainRatiosGPU {
 public:
@@ -37,7 +37,7 @@ private:
 
   cms::cuda::ESProduct<Product> product_;
 
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalGainRatiosGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalIntercalibConstantsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalIntercalibConstantsGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalIntercalibConstantsGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalIntercalibConstantsGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalIntercalibConstantsGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalIntercalibConstantsGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalIntercalibConstantsGPU {
 public:
@@ -37,7 +37,7 @@ private:
   std::vector<float> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalIntercalibConstantsGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAPDPNRatiosGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAPDPNRatiosGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalLaserAPDPNRatiosGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalLaserAPDPNRatiosGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalLaserAPDPNRatiosGPU {
 public:
@@ -47,7 +47,7 @@ private:
 
   cms::cuda::ESProduct<Product> product_;
 
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAPDPNRatiosRefGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAPDPNRatiosRefGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalLaserAPDPNRatiosRefGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalLaserAPDPNRatiosRefGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosRefGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosRefGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalLaserAPDPNRatiosRefGPU {
 public:
@@ -37,7 +37,7 @@ private:
   std::vector<float> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAPDPNRatiosRefGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAlphasGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAlphasGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalLaserAlphasGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalLaserAlphasGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAlphasGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAlphasGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalLaserAlphasGPU {
 public:
@@ -37,7 +37,7 @@ private:
   std::vector<float> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalLaserAlphasGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalLinearCorrectionsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalLinearCorrectionsGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalLinearCorrectionsGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalLinearCorrectionsGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalLinearCorrectionsGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalLinearCorrectionsGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalLinearCorrections.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalLinearCorrectionsGPU {
 public:
@@ -47,7 +47,7 @@ private:
 
   cms::cuda::ESProduct<Product> product_;
 
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalLinearCorrectionsGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalMultifitParametersGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalMultifitParametersGPU.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalCalo_EcalRecAlgos_interfaceEcalMultifitParametersGPU_h
-#define RecoLocalCalo_EcalRecAlgos_interfaceEcalMultifitParametersGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalMultifitParametersGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalMultifitParametersGPU_h
 
 #include <array>
 
@@ -8,7 +8,7 @@
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalMultifitParametersGPU {
 public:
@@ -33,7 +33,7 @@ private:
       timeFitParametersEB_, timeFitParametersEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif  // RecoLocalCalo_EcalRecAlgos_interfaceEcalMultifitParametersGPU_h
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalMultifitParametersGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPedestalsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPedestalsGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalPedestalsGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalPedestalsGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalPedestalsGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalPedestalsGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalPedestalsGPU {
 public:
@@ -41,7 +41,7 @@ private:
   std::vector<float, cms::cuda::HostAllocator<float>> rms_x1_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalPedestalsGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseCovariancesGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseCovariancesGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalPulseCovariancesGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalPulseCovariancesGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalPulseCovariancesGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalPulseCovariancesGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalPulseCovariances.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalPulseCovariancesGPU {
 public:
@@ -34,7 +34,7 @@ private:
   std::vector<EcalPulseCovariance> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalPulseCovariancesGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseShapesGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalPulseShapesGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalPulseShapesGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalPulseShapesGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalPulseShapesGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalPulseShapesGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalPulseShapesGPU {
 public:
@@ -34,7 +34,7 @@ private:
   std::vector<EcalPulseShape> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalPulseShapesGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitParametersGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitParametersGPU.h
@@ -1,5 +1,5 @@
-#ifndef RecoLocalCalo_EcalRecAlgos_interfaceEcalRecHitParametersGPU_h
-#define RecoLocalCalo_EcalRecAlgos_interfaceEcalRecHitParametersGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalRecHitParametersGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalRecHitParametersGPU_h
 
 #include <array>
 
@@ -8,7 +8,7 @@
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalRecHitParametersGPU {
 public:
@@ -41,7 +41,7 @@ private:
       expanded_flagbit_v_DB_reco_flags_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif  // RecoLocalCalo_EcalRecAlgos_interfaceEcalRecHitParametersGPU_h
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalRecHitParametersGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalRechitADCToGeVConstantGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalRechitADCToGeVConstantGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalRechitADCToGeVConstantGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalRechitADCToGeVConstantGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalRechitADCToGeVConstantGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalRechitADCToGeVConstantGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalRechitADCToGeVConstantGPU {
 public:
@@ -36,7 +36,7 @@ private:
 
   cms::cuda::ESProduct<Product> product_;
 
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalRechitADCToGeVConstantGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalRechitChannelStatusGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalRechitChannelStatusGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalRechitChannelStatusGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalRechitChannelStatusGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalRechitChannelStatusGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalRechitChannelStatusGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalRechitChannelStatusGPU {
 public:
@@ -36,7 +36,7 @@ private:
 
   cms::cuda::ESProduct<Product> product_;
 
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalRechitChannelStatusGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSamplesCorrelationGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSamplesCorrelationGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalSamplesCorrelationGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalSamplesCorrelationGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalSamplesCorrelationGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalSamplesCorrelationGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalSamplesCorrelation.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalSamplesCorrelationGPU {
 public:
@@ -38,7 +38,7 @@ private:
   std::vector<double> const& EEG1SamplesCorrelation_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalSamplesCorrelationGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeBiasCorrectionsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeBiasCorrectionsGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalTimeBiasCorrectionsGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalTimeBiasCorrectionsGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalTimeBiasCorrectionsGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalTimeBiasCorrectionsGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalTimeBiasCorrectionsGPU {
 public:
@@ -30,7 +30,7 @@ public:
 
   //
   static std::string name() { return std::string{"ecalTimeBiasCorrectionsGPU"}; }
-#endif
+#endif  // __CUDACC__
 
   std::vector<float> const& EBTimeCorrAmplitudeBins() const { return EBTimeCorrAmplitudeBins_; }
   std::vector<float> const& EETimeCorrAmplitudeBins() const { return EETimeCorrAmplitudeBins_; }
@@ -43,7 +43,7 @@ private:
 
 #ifndef __CUDACC__
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalTimeBiasCorrectionsGPU_h

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeCalibConstantsGPU.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalTimeCalibConstantsGPU.h
@@ -1,12 +1,12 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalTimeCalibConstantsGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalTimeCalibConstantsGPU_h
+#ifndef RecoLocalCalo_EcalRecAlgos_interface_EcalTimeCalibConstantsGPU_h
+#define RecoLocalCalo_EcalRecAlgos_interface_EcalTimeCalibConstantsGPU_h
 
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
-#endif
+#endif  // __CUDACC__
 
 class EcalTimeCalibConstantsGPU {
 public:
@@ -37,7 +37,7 @@ private:
   std::vector<float> const& valuesEE_;
 
   cms::cuda::ESProduct<Product> product_;
-#endif
+#endif  // __CUDACC__
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecAlgos_interface_EcalTimeCalibConstantsGPU_h

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.h
@@ -96,7 +96,7 @@ namespace ecal {
 #ifdef RUN_BUILD_AOS_RECHIT
     __global__ void kernel_build_rechit(
         float const* energies, float const* chi2s, uint32_t* dids, EcalUncalibratedRecHit* rechits, int nchannels);
-#endif
+#endif  // RUN_BUILD_AOS_RECHIT
 
   }  // namespace multifit
 }  // namespace ecal

--- a/RecoLocalCalo/EcalRecProducers/plugins/Common.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/Common.h
@@ -1,10 +1,10 @@
 #ifndef RecoLocalCalo_EcalRecProducers_plugins_Common_h
 #define RecoLocalCalo_EcalRecProducers_plugins_Common_h
 
-#include <cstdint>
-#include <cmath>
 #include <cassert>
 #include <chrono>
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 
 #include <cuda.h>

--- a/RecoLocalCalo/EcalRecProducers/plugins/DeclsForKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/DeclsForKernels.h
@@ -24,6 +24,7 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAPDPNRatiosRefGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalLaserAlphasGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalLinearCorrectionsGPU.h"
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalMultifitParametersGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalPedestalsGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalPulseCovariancesGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalPulseShapesGPU.h"
@@ -32,7 +33,6 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSamplesCorrelationGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalTimeBiasCorrectionsGPU.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalTimeCalibConstantsGPU.h"
-#include "RecoLocalCalo/EcalRecAlgos/interface/EcalMultifitParametersGPU.h"
 
 #include "EigenMatrixTypes_gpu.h"
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalESProducerGPU.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalESProducerGPU.h
@@ -1,15 +1,15 @@
-#ifndef RecoLocalCalo_EcalRecProducers_src_EcalESProducerGPU_h
-#define RecoLocalCalo_EcalRecProducers_src_EcalESProducerGPU_h
-
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#ifndef RecoLocalCalo_EcalRecProducers_plugins_EcalESProducerGPU_h
+#define RecoLocalCalo_EcalRecProducers_plugins_EcalESProducerGPU_h
 
 #include <iostream>
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/typelookup.h"
 
 template <typename Target, typename Source, typename Record>
 class EcalESProducerGPU : public edm::ESProducer {
@@ -41,4 +41,4 @@ private:
   edm::ESGetToken<Source, Record> token_;
 };
 
-#endif
+#endif  // RecoLocalCalo_EcalRecProducers_plugins_EcalESProducerGPU_h

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPURecord.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPURecord.h
@@ -1,8 +1,9 @@
-#ifndef EcalMultifitParametersGPURecord_h
-#define EcalMultifitParametersGPURecord_h
+#ifndef RecoLocalCalo_EcalRecProducers_plugins_EcalMultifitParametersGPURecord_h
+#define RecoLocalCalo_EcalRecProducers_plugins_EcalMultifitParametersGPURecord_h
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
 class EcalMultifitParametersGPURecord
     : public edm::eventsetup::EventSetupRecordImplementation<EcalMultifitParametersGPURecord> {};
 
-#endif
+#endif  // RecoLocalCalo_EcalRecProducers_plugins_EcalMultifitParametersGPURecord_h

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPURecord.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPURecord.h
@@ -1,8 +1,9 @@
-#ifndef EcalRecHitParametersGPURecord_h
-#define EcalRecHitParametersGPURecord_h
+#ifndef RecoLocalCalo_EcalRecProducers_plugins_EcalRecHitParametersGPURecord_h
+#define RecoLocalCalo_EcalRecProducers_plugins_EcalRecHitParametersGPURecord_h
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
 class EcalRecHitParametersGPURecord
     : public edm::eventsetup::EventSetupRecordImplementation<EcalRecHitParametersGPURecord> {};
 
-#endif
+#endif  // RecoLocalCalo_EcalRecProducers_plugins_EcalRecHitParametersGPURecord_h


### PR DESCRIPTION
Address the comments raised in cms-sw#31719 - **Patatrack integration - ECAL local reconstruction (7/N)**:
  - adjust include guards;
  - adjust comments on preprocessor macros.