### PR TITLE
Move the siPixelClusters.payloadType change to the SoA-on-CPU customisation

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -3,10 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerDefault_cfi import SiPixelClusterizerDefault as _SiPixelClusterizerDefault
 siPixelClusters = _SiPixelClusterizerDefault.clone()
 
-# *only for the cms-patatrack repository*
-# ensure reproducibility for CPU <--> GPU comparisons
-siPixelClusters.payloadType = "HLT"
-
 # phase1 pixel
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelClusters,

--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
@@ -2,9 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 def customizePixelTracksSoAonCPU(process):
   
-  process.CUDAService = cms.Service("CUDAService",
+  process.CUDAService = cms.Service('CUDAService',
     enabled = cms.untracked.bool(False)
   )
+
+  # ensure the same results when running on GPU (which supports only the 'HLT' payload) and CPU
+  process.siPixelClustersPreSplitting.cpu.payloadType = cms.string('HLT')
 
   from RecoLocalTracker.SiPixelRecHits.siPixelRecHitHostSoA_cfi import siPixelRecHitHostSoA
   process.siPixelRecHitsPreSplitting = siPixelRecHitHostSoA.clone(


### PR DESCRIPTION
Move the 
```python
siPixelClusters.payloadType = "HLT"
```
change to the SoA-on-CPU customisation.

This should make sure that any other workflow is not affected.