### PR TITLE
fix esConsumes for PR #31721

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -57,6 +57,8 @@ public:
 private:
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
   edm::EDGetTokenT<SiPixelDigisSoA> digiGetToken_;
 
   edm::EDPutTokenT<edm::DetSetVector<PixelDigi>> digiPutToken_;
@@ -64,7 +66,8 @@ private:
 };
 
 SiPixelDigisClustersFromSoA::SiPixelDigisClustersFromSoA(const edm::ParameterSet& iConfig)
-    : digiGetToken_(consumes<SiPixelDigisSoA>(iConfig.getParameter<edm::InputTag>("src"))),
+    : topoToken_(esConsumes()),
+      digiGetToken_(consumes<SiPixelDigisSoA>(iConfig.getParameter<edm::InputTag>("src"))),
       digiPutToken_(produces<edm::DetSetVector<PixelDigi>>()),
       clusterPutToken_(produces<SiPixelClusterCollectionNew>()) {}
 
@@ -77,10 +80,7 @@ void SiPixelDigisClustersFromSoA::fillDescriptions(edm::ConfigurationDescription
 void SiPixelDigisClustersFromSoA::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   const auto& digis = iEvent.get(digiGetToken_);
   const uint32_t nDigis = digis.size();
-
-  edm::ESHandle<TrackerTopology> trackerTopologyHandle;
-  iSetup.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
-  const auto& ttopo = *trackerTopologyHandle;
+  const auto& ttopo = iSetup.getData(topoToken_);
 
   auto collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
   auto outputClusters = std::make_unique<SiPixelClusterCollectionNew>();

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,22 +40,24 @@ public:
 private:
   void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> cpeToken_;
+
   // The mess with inputs will be cleaned up when migrating to the new framework
   edm::EDGetTokenT<reco::BeamSpot> bsGetToken_;
   edm::EDGetTokenT<SiPixelClusterCollectionNew> clusterToken_;  // Legacy Clusters
   edm::EDPutTokenT<TrackingRecHit2DCPU> tokenHit_;
   edm::EDPutTokenT<HMSstorage> tokenModuleStart_;
-
-  std::string const cpeName_;
   bool const convert2Legacy_;
 };
 
 SiPixelRecHitSoAFromLegacy::SiPixelRecHitSoAFromLegacy(const edm::ParameterSet& iConfig)
-    : bsGetToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))},
+    : geomToken_(esConsumes()),
+      cpeToken_(esConsumes(edm::ESInputTag("",iConfig.getParameter<std::string>("CPE")))),
+      bsGetToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))},
       clusterToken_{consumes<SiPixelClusterCollectionNew>(iConfig.getParameter<edm::InputTag>("src"))},
       tokenHit_{produces<TrackingRecHit2DCPU>()},
       tokenModuleStart_{produces<HMSstorage>()},
-      cpeName_(iConfig.getParameter<std::string>("CPE")),
       convert2Legacy_(iConfig.getParameter<bool>("convertToLegacy")) {
   if (convert2Legacy_)
     produces<SiPixelRecHitCollectionNew>();
@@ -73,16 +74,8 @@ void SiPixelRecHitSoAFromLegacy::fillDescriptions(edm::ConfigurationDescriptions
 }
 
 void SiPixelRecHitSoAFromLegacy::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& es) const {
-  const TrackerGeometry* geom_ = nullptr;
-  const PixelClusterParameterEstimator* cpe_ = nullptr;
-
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
-  geom_ = geom.product();
-
-  edm::ESHandle<PixelClusterParameterEstimator> hCPE;
-  es.get<TkPixelCPERecord>().get(cpeName_, hCPE);
-  cpe_ = dynamic_cast<const PixelCPEBase*>(hCPE.product());
+  const TrackerGeometry* geom_ = &es.getData(geomToken_);
+  const PixelClusterParameterEstimator* cpe_ = dynamic_cast<const PixelCPEBase*>(&es.getData(cpeToken_));
 
   PixelCPEFast const* fcpe = dynamic_cast<const PixelCPEFast*>(cpe_);
   if (!fcpe) {


### PR DESCRIPTION
#### PR description:

Addresses comments about es consumes migration at https://github.com/cms-sw/cmssw/pull/31721

#### PR validation:

It compiles.
Tested successfully with:
```
cmsDriver.py step3 --conditions auto:phase1_2021_realistic -n 1000 --era Run3 --eventcontent RECOSIM,DQM --procModifiers gpu -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --dasquery="file dataset=/RelValTTbar_14TeV/CMSSW_11_2_0_pre6-PU_112X_mcRun3_2021_realistic_v7-v1/GEN-SIM-DIGI-RAW" --no_exec
```
on `cmg-gpu1080`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
