### PR TITLE
Backport: update propagate_const and add propagate_const_array (#32184)

### DIFF
--- a/FWCore/Utilities/interface/get_underlying_safe.h
+++ b/FWCore/Utilities/interface/get_underlying_safe.h
@@ -30,6 +30,7 @@
 // user include files
 
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_array.h"
 
 // forward declarations
 
@@ -46,6 +47,16 @@ namespace edm {
     return copy;
   }
 
+  template <typename T>
+  constexpr std::shared_ptr<T[]>& get_underlying_safe(propagate_const_array<std::shared_ptr<T[]>>& iP) {
+    return get_underlying(iP);
+  }
+  template <typename T>
+  constexpr std::shared_ptr<T const []> get_underlying_safe(propagate_const_array<std::shared_ptr<T[]>> const& iP) {
+    std::shared_ptr<T const[]> copy = get_underlying(iP);
+    return copy;
+  }
+
   // for bare pointer
   template <typename T>
   constexpr T*& get_underlying_safe(propagate_const<T*>& iP) {
@@ -53,6 +64,16 @@ namespace edm {
   }
   template <typename T>
   constexpr T const* get_underlying_safe(propagate_const<T*> const& iP) {
+    T const* copy = get_underlying(iP);
+    return copy;
+  }
+
+  template <typename T>
+  constexpr T* get_underlying_safe(propagate_const_array<T[]>& iP) {
+    return get_underlying(iP);
+  }
+  template <typename T>
+  constexpr T const* get_underlying_safe(propagate_const_array<T[]> const& iP) {
     T const* copy = get_underlying(iP);
     return copy;
   }
@@ -66,6 +87,17 @@ namespace edm {
   template <typename T>
   constexpr std::unique_ptr<T const> get_underlying_safe(propagate_const<std::unique_ptr<T>> const& iP) {
     std::unique_ptr<T const> copy = get_underlying(iP);
+    return copy;
+  }
+
+  template <typename T>
+  constexpr std::unique_ptr<T[]>& get_underlying_safe(propagate_const_array<std::unique_ptr<T[]>>& iP) {
+    return get_underlying(iP);
+  }
+  // the template below will deliberately not compile.
+  template <typename T>
+  constexpr std::unique_ptr<T const []> get_underlying_safe(propagate_const_array<std::unique_ptr<T[]>> const& iP) {
+    std::unique_ptr<T const[]> copy = get_underlying(iP);
     return copy;
   }
 

--- a/FWCore/Utilities/interface/get_underlying_safe.h
+++ b/FWCore/Utilities/interface/get_underlying_safe.h
@@ -37,34 +37,34 @@ namespace edm {
 
   // for std::shared_ptr
   template <typename T>
-  std::shared_ptr<T>& get_underlying_safe(propagate_const<std::shared_ptr<T>>& iP) {
+  constexpr std::shared_ptr<T>& get_underlying_safe(propagate_const<std::shared_ptr<T>>& iP) {
     return get_underlying(iP);
   }
   template <typename T>
-  std::shared_ptr<T const> get_underlying_safe(propagate_const<std::shared_ptr<T>> const& iP) {
+  constexpr std::shared_ptr<T const> get_underlying_safe(propagate_const<std::shared_ptr<T>> const& iP) {
     std::shared_ptr<T const> copy = get_underlying(iP);
     return copy;
   }
 
   // for bare pointer
   template <typename T>
-  T*& get_underlying_safe(propagate_const<T*>& iP) {
+  constexpr T*& get_underlying_safe(propagate_const<T*>& iP) {
     return get_underlying(iP);
   }
   template <typename T>
-  T const* get_underlying_safe(propagate_const<T*> const& iP) {
+  constexpr T const* get_underlying_safe(propagate_const<T*> const& iP) {
     T const* copy = get_underlying(iP);
     return copy;
   }
 
   // for std::unique_ptr
   template <typename T>
-  std::unique_ptr<T>& get_underlying_safe(propagate_const<std::unique_ptr<T>>& iP) {
+  constexpr std::unique_ptr<T>& get_underlying_safe(propagate_const<std::unique_ptr<T>>& iP) {
     return get_underlying(iP);
   }
-  // This template below will deliberately not compile.
+  // the template below will deliberately not compile.
   template <typename T>
-  std::unique_ptr<T const> get_underlying_safe(propagate_const<std::unique_ptr<T>> const& iP) {
+  constexpr std::unique_ptr<T const> get_underlying_safe(propagate_const<std::unique_ptr<T>> const& iP) {
     std::unique_ptr<T const> copy = get_underlying(iP);
     return copy;
   }

--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -32,47 +32,47 @@ namespace edm {
   class propagate_const;
 
   template <typename T>
-  T& get_underlying(propagate_const<T>&);
+  constexpr T& get_underlying(propagate_const<T>&);
   template <typename T>
-  T const& get_underlying(propagate_const<T> const&);
+  constexpr T const& get_underlying(propagate_const<T> const&);
 
   template <typename T>
   class propagate_const {
   public:
-    friend T& get_underlying<T>(propagate_const<T>&);
-    friend T const& get_underlying<T>(propagate_const<T> const&);
+    friend constexpr T& get_underlying<T>(propagate_const<T>&);
+    friend constexpr T const& get_underlying<T>(propagate_const<T> const&);
 
     using element_type = typename std::remove_reference<decltype(*std::declval<T&>())>::type;
 
-    propagate_const() = default;
+    constexpr propagate_const() = default;
 
-    propagate_const(propagate_const<T>&&) = default;
+    constexpr propagate_const(propagate_const<T>&&) = default;
     propagate_const(propagate_const<T> const&) = delete;
     template <typename U>
-    propagate_const(U&& iValue) : m_value(std::forward<U>(iValue)) {}
+    constexpr propagate_const(U&& iValue) : m_value(std::forward<U>(iValue)) {}
 
-    propagate_const<T>& operator=(propagate_const&&) = default;
+    constexpr propagate_const<T>& operator=(propagate_const&&) = default;
     propagate_const<T>& operator=(propagate_const<T> const&) = delete;
 
     template <typename U>
-    propagate_const& operator=(U&& iValue) {
+    constexpr propagate_const& operator=(U&& iValue) {
       m_value = std::forward<U>(iValue);
       return *this;
     }
 
     // ---------- const member functions ---------------------
-    element_type const* get() const { return to_raw_pointer(m_value); }
-    element_type const* operator->() const { return this->get(); }
-    element_type const& operator*() const { return *m_value; }
+    constexpr element_type const* get() const { return to_raw_pointer(m_value); }
+    constexpr element_type const* operator->() const { return this->get(); }
+    constexpr element_type const& operator*() const { return *m_value; }
 
-    operator element_type const*() const { return this->get(); }
+    constexpr operator element_type const *() const { return this->get(); }
 
     // ---------- member functions ---------------------------
-    element_type* get() { return to_raw_pointer(m_value); }
-    element_type* operator->() { return this->get(); }
-    element_type& operator*() { return *m_value; }
+    constexpr element_type* get() { return to_raw_pointer(m_value); }
+    constexpr element_type* operator->() { return this->get(); }
+    constexpr element_type& operator*() { return *m_value; }
 
-    operator element_type*() { return this->get(); }
+    constexpr operator element_type*() { return this->get(); }
 
   private:
     template <typename Up>
@@ -100,11 +100,11 @@ namespace edm {
   };
 
   template <typename T>
-  T& get_underlying(propagate_const<T>& iP) {
+  constexpr T& get_underlying(propagate_const<T>& iP) {
     return iP.m_value;
   }
   template <typename T>
-  T const& get_underlying(propagate_const<T> const& iP) {
+  constexpr T const& get_underlying(propagate_const<T> const& iP) {
     return iP.m_value;
   }
 

--- a/FWCore/Utilities/interface/propagate_const_array.h
+++ b/FWCore/Utilities/interface/propagate_const_array.h
@@ -1,0 +1,131 @@
+#ifndef FWCore_Utilities_interface_propagate_const_array_h
+#define FWCore_Utilities_interface_propagate_const_array_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     propagate_const_array
+// Description: Propagate const to array-like objects. Based on C++ experimental std::propagate_const.
+//              If used with an array of incomplete type, edm::propagate_const_array can only be declared
+//              and assigned to nullptr, but not assigned to an actual object or dereferenced.
+
+// system include files
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+
+  namespace impl {
+
+    // check if a type T has a subscript operator T[N]
+    template <typename, typename = void>
+    struct has_subscript_operator : std::false_type {};
+
+    template <typename T>
+    struct has_subscript_operator<T, std::void_t<decltype(std::declval<T&>()[0])>> : std::true_type {};
+
+    template <typename T>
+    constexpr auto has_subscript_operator_v = has_subscript_operator<T>::value;
+
+    // for a type T, return the type of the return value of the subscript operator T[N]
+    template <typename T, typename = void, typename = void>
+    struct subscript_type {};
+
+    // the specialisations for arrays allow supporting incomplete types
+    template <typename T>
+    struct subscript_type<T[]> {
+      using type = T;
+    };
+
+    template <typename T, int N>
+    struct subscript_type<T[N]> {
+      using type = T;
+    };
+
+    // for non-array types that implement the subscript operator[], a complete type is needed
+    template <typename T>
+    struct subscript_type<T, std::enable_if_t<not std::is_array_v<T>>, std::enable_if_t<has_subscript_operator_v<T>>> {
+      using type = typename std::remove_reference<decltype(std::declval<T&>()[0])>::type;
+    };
+
+    template <typename T>
+    using subscript_type_t = typename subscript_type<T>::type;
+
+  }  // namespace impl
+
+  template <typename T>
+  class propagate_const_array;
+
+  template <typename T>
+  constexpr std::decay_t<T>& get_underlying(propagate_const_array<T>&);
+  template <typename T>
+  constexpr std::decay_t<T> const& get_underlying(propagate_const_array<T> const&);
+
+  template <typename T>
+  class propagate_const_array {
+  public:
+    friend constexpr std::decay_t<T>& get_underlying<T>(propagate_const_array<T>&);
+    friend constexpr std::decay_t<T> const& get_underlying<T>(propagate_const_array<T> const&);
+
+    template <typename U>
+    friend class propagate_const_array;
+
+    using element_type = typename impl::subscript_type_t<T>;
+
+    constexpr propagate_const_array() = default;
+    constexpr propagate_const_array(propagate_const_array<T>&&) = default;
+    propagate_const_array(propagate_const_array<T> const&) = delete;
+    template <typename U>
+    constexpr propagate_const_array(U&& u) : m_value(std::forward<U>(u)) {}
+
+    constexpr propagate_const_array<T>& operator=(propagate_const_array&&) = default;
+    propagate_const_array<T>& operator=(propagate_const_array<T> const&) = delete;
+
+    template <typename U>
+    constexpr propagate_const_array& operator=(propagate_const_array<U>& other) {
+      static_assert(std::is_convertible_v<std::decay_t<U>, std::decay_t<T>>,
+                    "Cannot assign propagate_const_array<> of incompatible types");
+      m_value = other.m_value;
+      return *this;
+    }
+
+    template <typename U>
+    constexpr propagate_const_array& operator=(U&& u) {
+      m_value = std::forward<U>(u);
+      return *this;
+    }
+
+    // ---------- const member functions ---------------------
+    constexpr element_type const* get() const { return &m_value[0]; }
+    constexpr element_type const& operator[](std::ptrdiff_t pos) const { return m_value[pos]; }
+
+    constexpr operator element_type const *() const { return this->get(); }
+
+    // ---------- member functions ---------------------------
+    constexpr element_type* get() { return &m_value[0]; }
+    constexpr element_type& operator[](std::ptrdiff_t pos) { return m_value[pos]; }
+
+    constexpr operator element_type*() { return this->get(); }
+
+  private:
+    // ---------- member data --------------------------------
+    std::decay_t<T> m_value;
+  };
+
+  template <typename T>
+  constexpr std::decay_t<T>& get_underlying(propagate_const_array<T>& iP) {
+    return iP.m_value;
+  }
+
+  template <typename T>
+  constexpr std::decay_t<T> const& get_underlying(propagate_const_array<T> const& iP) {
+    return iP.m_value;
+  }
+
+}  // namespace edm
+
+#endif  // FWCore_Utilities_interface_propagate_const_array_h

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -42,7 +42,7 @@
   <use name="cppunit"/>
 </bin>
 
-<bin name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,esinputtag.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,indexset.cppunit.cpp">
+<bin name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,esinputtag.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp,vecarray.cppunit.cpp,reusableobjectholder_t.cppunit.cpp,propagate_const_t.cppunit.cpp,propagate_const_array_t.cppunit.cpp,indexset.cppunit.cpp">
   <use name="cppunit"/>
 </bin>
 

--- a/FWCore/Utilities/test/propagate_const_array_t.cppunit.cpp
+++ b/FWCore/Utilities/test/propagate_const_array_t.cppunit.cpp
@@ -1,0 +1,98 @@
+/*----------------------------------------------------------------------
+
+Test program for edm::propagate_const_array class.
+
+ ----------------------------------------------------------------------*/
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <memory>
+#include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const_array.h"
+
+class test_propagate_const_array : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(test_propagate_const_array);
+
+  CPPUNIT_TEST(test);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void test();
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(test_propagate_const_array);
+
+namespace {
+  class ConstChecker {
+  public:
+    int value() { return 0; }
+
+    int const value() const { return 1; }
+  };
+
+  // used to check that edm::propagate_const_array<T[]> works with incomplete types
+  class Incomplete;
+
+}  // namespace
+
+void test_propagate_const_array::test() {
+  // test for edm::propagate_const_array<T[]>
+  {
+    ConstChecker checker[10];
+    edm::propagate_const_array<ConstChecker[]> pChecker(checker);
+
+    CPPUNIT_ASSERT(0 == pChecker[1].value());
+    CPPUNIT_ASSERT(0 == pChecker.get()[1].value());
+    CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)[1].value());
+
+    const edm::propagate_const_array<ConstChecker[]> pConstChecker(checker);
+
+    CPPUNIT_ASSERT(1 == pConstChecker[1].value());
+    CPPUNIT_ASSERT(1 == pConstChecker.get()[1].value());
+    CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)[1].value());
+  }
+
+  // test for edm::propagate_const_array<shared_ptr<T>>
+  {
+    // std::make_shared<T[]> requires C++20
+    auto checker = std::shared_ptr<ConstChecker[]>(new ConstChecker[10]);
+    edm::propagate_const_array<std::shared_ptr<ConstChecker[]>> pChecker(checker);
+
+    CPPUNIT_ASSERT(0 == pChecker[1].value());
+    CPPUNIT_ASSERT(0 == pChecker.get()[1].value());
+    CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)[1].value());
+
+    const edm::propagate_const_array<std::shared_ptr<ConstChecker[]>> pConstChecker(checker);
+
+    CPPUNIT_ASSERT(1 == pConstChecker[1].value());
+    CPPUNIT_ASSERT(1 == pConstChecker.get()[1].value());
+    CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)[1].value());
+  }
+
+  // test for edm::propagate_const_array<unique_ptr<T>>
+  {
+    auto checker = std::make_unique<ConstChecker[]>(10);
+    edm::propagate_const_array<std::unique_ptr<ConstChecker[]>> pChecker(std::move(checker));
+
+    CPPUNIT_ASSERT(0 == pChecker[1].value());
+    CPPUNIT_ASSERT(0 == pChecker.get()[1].value());
+    CPPUNIT_ASSERT(0 == get_underlying_safe(pChecker)[1].value());
+
+    const edm::propagate_const_array<std::unique_ptr<ConstChecker[]>> pConstChecker(
+        std::make_unique<ConstChecker[]>(10));
+
+    CPPUNIT_ASSERT(1 == pConstChecker[1].value());
+    CPPUNIT_ASSERT(1 == pConstChecker.get()[1].value());
+  }
+
+  // test for edm::propagate_const_array<T[]> with incomplete types
+  {
+    edm::propagate_const_array<Incomplete[]> pIncomplete(nullptr);
+
+    CPPUNIT_ASSERT(nullptr == get_underlying(pIncomplete));
+  }
+}

--- a/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
+++ b/FWCore/Utilities/test/propagate_const_t.cppunit.cpp
@@ -7,6 +7,7 @@ Test program for edm::propagate_const class.
 #include <cppunit/extensions/HelperMacros.h>
 #include <memory>
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
+#include "FWCore/Utilities/interface/propagate_const.h"
 
 class test_propagate_const : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(test_propagate_const);
@@ -32,9 +33,14 @@ namespace {
 
     int const value() const { return 1; }
   };
+
+  // used to check that edm::propagate_const<T*> works with incomplete types
+  class Incomplete;
+
 }  // namespace
 
 void test_propagate_const::test() {
+  // test for edm::propagate_const<T*>
   {
     ConstChecker checker;
     edm::propagate_const<ConstChecker*> pChecker(&checker);
@@ -52,6 +58,7 @@ void test_propagate_const::test() {
     CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)->value());
   }
 
+  // test for edm::propagate_const<shared_ptr<T>>
   {
     auto checker = std::make_shared<ConstChecker>();
     edm::propagate_const<std::shared_ptr<ConstChecker>> pChecker(checker);
@@ -69,6 +76,7 @@ void test_propagate_const::test() {
     CPPUNIT_ASSERT(1 == get_underlying_safe(pConstChecker)->value());
   }
 
+  // test for edm::propagate_const<unique_ptr<T>>
   {
     auto checker = std::make_unique<ConstChecker>();
     edm::propagate_const<std::unique_ptr<ConstChecker>> pChecker(std::move(checker));
@@ -83,5 +91,13 @@ void test_propagate_const::test() {
     CPPUNIT_ASSERT(1 == pConstChecker.get()->value());
     CPPUNIT_ASSERT(pConstChecker.get()->value() == pConstChecker->value());
     CPPUNIT_ASSERT(pConstChecker.get()->value() == (*pConstChecker).value());
+  }
+
+  // test for edm::propagate_const<T*> with incomplete types
+  {
+    Incomplete* ptr = nullptr;
+    edm::propagate_const<Incomplete*> pIncomplete(ptr);
+
+    CPPUNIT_ASSERT(nullptr == pIncomplete.get());
   }
 }


### PR DESCRIPTION
#### PR description:

Update `edm::propagate_const<...>` and its unit test:
  - make most methods of edm::propagate_const<T> constexpr;
  - add a unit test for edm::propagate_const<incomplete_type *>.

Add `edm::propagate_const_array<...>` to support T[], unique_ptr<T[]>, etc.

Implement `edm::propagate_const_array` template with similar functionality to `edm::propagate_const`, but with a subscript operator and support for types like `T[]`, `std::unique_ptr<T[]>` and similar array-like types.

Add support for `get_underlying_safe<propagate_const_array<T>>`.

Add unit tests for `edm::propagate_const_array`:
  - `propagate_const_array<T[]>`
  - `propagate_const_array<unique_ptr<T[]>>`
  - `propagate_const_array<shared_ptr<T[]>>`
  - `propagate_const_array<incomplete_type[]>`

#### PR validation

Unit test `testFWCoreUtilities` builds and runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport cms-sw#32184 .