### PR TITLE
Update DQM clients for PixelVertexProducer pixel vertices

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -314,8 +314,7 @@ process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = 12
 process.pixelTracksTrackingRegions.RegionPSet.originXPos =  0.08
 process.pixelTracksTrackingRegions.RegionPSet.originYPos = -0.03
 process.pixelTracksTrackingRegions.RegionPSet.originZPos = 0.
-
-process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
+process.pixelVertices.PtMin = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
 process.tracking_FirstStep = cms.Sequence(
       process.siPixelDigis 

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -90,12 +90,12 @@ from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import 
 process.siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(src = 'siPixelClustersPreSplitting')
 process.load("RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi")
 process.load("RecoPixelVertexing.Configuration.RecoPixelVertexing_cff")
-process.pixelVertices.TkFilterParameters.minPt = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 process.pixelTracksTrackingRegions.RegionPSet.originRadius     = cms.double(0.4)
 process.pixelTracksTrackingRegions.RegionPSet.originHalfLength = cms.double(15.)
 process.pixelTracksTrackingRegions.RegionPSet.originXPos       = cms.double(0.08)
 process.pixelTracksTrackingRegions.RegionPSet.originYPos       = cms.double(-0.03)
 process.pixelTracksTrackingRegions.RegionPSet.originZPos       = cms.double(0.)
+process.pixelVertices.PtMin = process.pixelTracksTrackingRegions.RegionPSet.ptMin
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -126,7 +126,7 @@ process.dqmFEDIntegrity.fedFolderName = cms.untracked.string(folder_name)
 # Modules for the FED
 process.FEDModulesPath = cms.Path(
 			                        process.l1tStage2Fed
-			                      + process.siPixelDigis.cpu
+			                      + process.siPixelDigis
                                   + process.SiPixelHLTSource
                                   + process.siStripFEDCheck
 			                      + process.esRawToDigi


### PR DESCRIPTION
Update DQM clients for pixel vertices produced by PixelVertexProducer instead of PrimaryVertexProducer.

Fix the DQM/Integration unit test failures in
  - runtest.sh beam_dqm_sourceclient-live_cfg.py
  - runtest.sh beampixel_dqm_sourceclient-live_cfg.py
  - runtest.sh fed_dqm_sourceclient-live_cfg.py
