### PR TITLE
Make the the size of the binner (HistoContainer) settable at run time

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
@@ -34,7 +34,7 @@ public:
   auto hitsModuleStart() const { return m_hitsModuleStart; }
   auto hitsLayerStart() { return m_hitsLayerStart; }
   auto phiBinner() { return m_hist; }
-  auto binnerStorage() {return m_histStorage;}
+  auto binnerStorage() { return m_histStorage; }
   auto iphi() { return m_iphi; }
 
   // only the local coord and detector index
@@ -61,7 +61,7 @@ private:
 
   // needed as kernel params...
   Hist* m_hist;
-  Hist::index_type * m_histStorage;
+  Hist::index_type* m_histStorage;
   uint32_t* m_hitsLayerStart;
   int16_t* m_iphi;
 };
@@ -103,15 +103,15 @@ TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nH
   m_store32 = Traits::template make_device_unique<float[]>(nHits * n32 + 11, stream);
   m_HistStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::Hist>(stream);
 
-  static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type)==sizeof(float));
-  static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type)==sizeof(TrackingRecHit2DSOAView::Hist::index_type));
+  static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type) == sizeof(float));
+  static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type) == sizeof(TrackingRecHit2DSOAView::Hist::index_type));
 
   auto get16 = [&](int i) { return m_store16.get() + i * nHits; };
   auto get32 = [&](int i) { return m_store32.get() + i * nHits; };
 
   // copy all the pointers
   m_hist = view->m_hist = m_HistStore.get();
-  m_histStorage = view->m_histStorage = reinterpret_cast<TrackingRecHit2DSOAView::Hist::index_type *>(get32(9));
+  m_histStorage = view->m_histStorage = reinterpret_cast<TrackingRecHit2DSOAView::Hist::index_type*>(get32(9));
 
   view->m_xl = get32(0);
   view->m_yl = get32(1);

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h
@@ -43,6 +43,7 @@ public:
   cms::cuda::host::unique_ptr<uint32_t[]> hitsModuleStartToHostAsync(cudaStream_t stream) const;
 
 private:
+  // number of elements of size 16 and 32 respectively
   static constexpr uint32_t n16 = 4;
   static constexpr uint32_t n32 = 10;
   static_assert(sizeof(uint32_t) == sizeof(float));  // just stating the obvious
@@ -100,7 +101,8 @@ TrackingRecHit2DHeterogeneous<Traits>::TrackingRecHit2DHeterogeneous(uint32_t nH
   // this will break 1to1 correspondence with cluster and module locality
   // so unless proven VERY inefficient we keep it ordered as generated
   m_store16 = Traits::template make_device_unique<uint16_t[]>(nHits * n16, stream);
-  m_store32 = Traits::template make_device_unique<float[]>(nHits * n32 + 11, stream);
+  m_store32 =
+      Traits::template make_device_unique<float[]>(nHits * n32 + phase1PixelTopology::numberOfLayers + 1, stream);
   m_HistStore = Traits::template make_device_unique<TrackingRecHit2DSOAView::Hist>(stream);
 
   static_assert(sizeof(TrackingRecHit2DSOAView::hindex_type) == sizeof(float));

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
@@ -18,7 +18,7 @@ public:
   using hindex_type = uint32_t;  // if above is <=2^32
 
   using PhiBinner =
-      cms::cuda::HistoContainer<int16_t, 128, gpuClustering::MaxNumClusters, 8 * sizeof(int16_t), hindex_type, 10>;
+      cms::cuda::HistoContainer<int16_t, 128, -1, 8 * sizeof(int16_t), hindex_type, 10>;
 
   using Hist = PhiBinner;  // FIXME
 
@@ -96,6 +96,7 @@ private:
   uint32_t* m_hitsLayerStart;
 
   PhiBinner* m_hist;  // FIXME use a more descriptive name consistently
+  PhiBinner::index_type * m_histStorage;
 
   uint32_t m_nHits;
 };

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DSOAView.h
@@ -17,8 +17,7 @@ public:
   static constexpr uint32_t maxHits() { return gpuClustering::MaxNumClusters; }
   using hindex_type = uint32_t;  // if above is <=2^32
 
-  using PhiBinner =
-      cms::cuda::HistoContainer<int16_t, 128, -1, 8 * sizeof(int16_t), hindex_type, 10>;
+  using PhiBinner = cms::cuda::HistoContainer<int16_t, 128, -1, 8 * sizeof(int16_t), hindex_type, 10>;
 
   using Hist = PhiBinner;  // FIXME
 
@@ -96,7 +95,7 @@ private:
   uint32_t* m_hitsLayerStart;
 
   PhiBinner* m_hist;  // FIXME use a more descriptive name consistently
-  PhiBinner::index_type * m_histStorage;
+  PhiBinner::index_type* m_histStorage;
 
   uint32_t m_nHits;
 };

--- a/HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h
@@ -1,0 +1,54 @@
+#ifndef HeterogeneousCore_CUDAUtilities_interface_FlexiStorage_h
+#define HeterogeneousCore_CUDAUtilities_interface_FlexiStorage_h
+
+#include <cstdint>
+
+namespace cms {
+  namespace cuda {
+
+    template<typename I, int S>
+    class FlexiStorage {
+    public:
+ 
+      constexpr int capacity() const { return S;}
+
+      constexpr I & operator[](int i){ return m_v[i]; }
+      constexpr const I & operator[](int i) const { return m_v[i]; }
+
+      constexpr I * data() { return m_v;}
+     constexpr  I const * data() const { return m_v;}
+
+      private:
+       I m_v[S];
+    };
+
+
+   template<typename I>
+    class FlexiStorage<I, -1> {
+    public:
+
+      constexpr void init(I* v, int s) {
+       m_v = v;
+       m_capacity = s;
+      } 
+
+      constexpr int capacity() const { return m_capacity;}
+
+      constexpr I & operator[](int i){ return m_v[i]; }
+      constexpr const I & operator[](int i) const { return m_v[i]; }
+
+      constexpr I * data() { return m_v;}
+     constexpr  I const * data() const { return m_v;}
+
+      private:
+       I * m_v;
+       int m_capacity;
+    };
+
+
+  }
+
+}
+
+
+#endif

--- a/HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h
@@ -6,49 +6,44 @@
 namespace cms {
   namespace cuda {
 
-    template<typename I, int S>
+    template <typename I, int S>
     class FlexiStorage {
     public:
- 
-      constexpr int capacity() const { return S;}
+      constexpr int capacity() const { return S; }
 
-      constexpr I & operator[](int i){ return m_v[i]; }
-      constexpr const I & operator[](int i) const { return m_v[i]; }
+      constexpr I& operator[](int i) { return m_v[i]; }
+      constexpr const I& operator[](int i) const { return m_v[i]; }
 
-      constexpr I * data() { return m_v;}
-     constexpr  I const * data() const { return m_v;}
+      constexpr I* data() { return m_v; }
+      constexpr I const* data() const { return m_v; }
 
-      private:
-       I m_v[S];
+    private:
+      I m_v[S];
     };
 
-
-   template<typename I>
+    template <typename I>
     class FlexiStorage<I, -1> {
     public:
-
       constexpr void init(I* v, int s) {
-       m_v = v;
-       m_capacity = s;
-      } 
+        m_v = v;
+        m_capacity = s;
+      }
 
-      constexpr int capacity() const { return m_capacity;}
+      constexpr int capacity() const { return m_capacity; }
 
-      constexpr I & operator[](int i){ return m_v[i]; }
-      constexpr const I & operator[](int i) const { return m_v[i]; }
+      constexpr I& operator[](int i) { return m_v[i]; }
+      constexpr const I& operator[](int i) const { return m_v[i]; }
 
-      constexpr I * data() { return m_v;}
-     constexpr  I const * data() const { return m_v;}
+      constexpr I* data() { return m_v; }
+      constexpr I const* data() const { return m_v; }
 
-      private:
-       I * m_v;
-       int m_capacity;
+    private:
+      I* m_v;
+      int m_capacity;
     };
 
+  }  // namespace cuda
 
-  }
-
-}
-
+}  // namespace cms
 
 #endif

--- a/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h
@@ -96,9 +96,9 @@ namespace cms {
               typename I = uint32_t,  // type stored in the container (usually an index in a vector of the input values)
               uint32_t NHISTS = 1     // number of histos stored
               >
-    class HistoContainer : public OneToManyAssoc<I,NHISTS * NBINS + 1,SIZE> {
+    class HistoContainer : public OneToManyAssoc<I, NHISTS * NBINS + 1, SIZE> {
     public:
-      using Base = OneToManyAssoc<I,NBINS,SIZE>;
+      using Base = OneToManyAssoc<I, NBINS, SIZE>;
       using Counter = typename Base::Counter;
       using index_type = typename Base::Counter;
       using UT = typename std::make_unsigned<T>::type;
@@ -163,7 +163,6 @@ namespace cms {
         assert(w > 0);
         this->content[w - 1] = j;
       }
-
     };
 
   }  // namespace cuda

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -35,8 +35,8 @@ namespace cms {
     template <typename Assoc>
     __global__ void zeroAndInit(OneToManyAssocView<Assoc> view) {
       auto h = view.assoc;
-      assert(1==gridDim.x);
-      assert(0==blockIdx.x);
+      assert(1 == gridDim.x);
+      assert(0 == blockIdx.x);
 
       int first = threadIdx.x;
 

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -20,13 +20,25 @@ namespace cms {
   namespace cuda {
 
     template <typename Assoc>
-    __global__ void zeroAndInit(
-        Assoc *h, typename Assoc::index_type *mem, int s, typename Assoc::Counter *c, int32_t n) {
+    struct OneToManyAssocView {
+      using Counter = typename Assoc::Counter;
+      using index_type = typename Assoc::index_type;
+
+      Assoc *assoc;
+      Counter *offStorage = nullptr;
+      index_type *contentStorage = nullptr;
+      int32_t offSize = -1;
+      int32_t contentSize = -1;
+    };
+
+    template <typename Assoc>
+    __global__ void zeroAndInit(OneToManyAssocView<Assoc> view) {
+      auto h = view.assoc;
       int first = blockDim.x * blockIdx.x + threadIdx.x;
 
       if (0 == first) {
         h->psws = 0;
-        h->initStorage(c, n, mem, s);
+        h->initStorage(view);
       }
       __syncthreads();
       for (int i = first, nt = h->totOnes(); i < nt; i += gridDim.x * blockDim.x) {
@@ -35,57 +47,56 @@ namespace cms {
     }
 
     template <typename Assoc>
-    inline __attribute__((always_inline)) void launchZero(Assoc *__restrict__ h,
-                                                          typename Assoc::index_type *mem,
-                                                          int s,
-                                                          typename Assoc::Counter *c,
-                                                          int32_t n,
+    inline __attribute__((always_inline)) void launchZero(OneToManyAssocView<Assoc> view,
                                                           cudaStream_t stream
 #ifndef __CUDACC__
                                                           = cudaStreamDefault
 #endif
     ) {
+
       if constexpr (Assoc::ctCapacity() < 0) {
-        assert(mem);
-        assert(s > 0);
+        assert(view.contentStorage);
+        assert(view.contentSize > 0);
       }
       auto nOnes = Assoc::ctNOnes();
       if constexpr (Assoc::ctNOnes() < 0) {
-        assert(c);
-        assert(n > 0);
-        nOnes = n;
+        assert(view.offStorage);
+        assert(view.offSize > 0);
+        nOnes = view.offSize;
       }
       assert(nOnes > 0);
 #ifdef __CUDACC__
       auto nthreads = 1024;
       auto nblocks = (nOnes + nthreads - 1) / nthreads;
-      zeroAndInit<<<nblocks, nthreads, 0, stream>>>(h, mem, s, c, n);
+      zeroAndInit<<<nblocks, nthreads, 0, stream>>>(view);
       cudaCheck(cudaGetLastError());
 #else
-      h->initStorage(c, n, mem, s);
+      auto h = view.assoc;
+      assert(h);
+      h->initStorage(view);
       h->zero();
       h->psws = 0;
 #endif
     }
 
     template <typename Assoc>
-    inline __attribute__((always_inline)) void launchFinalize(Assoc *__restrict__ h,
-                                                              typename Assoc::Counter *c,
-                                                              int32_t n,
+    inline __attribute__((always_inline)) void launchFinalize(OneToManyAssocView<Assoc> view,
                                                               cudaStream_t stream
 #ifndef __CUDACC__
                                                               = cudaStreamDefault
 #endif
     ) {
+      auto h = view.assoc;
+      assert(h);
 #ifdef __CUDACC__
       using Counter = typename Assoc::Counter;
-      auto nOnes = Assoc::ctNOnes();
       Counter *poff = (Counter *)((char *)(h) + offsetof(Assoc, off));
+      auto nOnes = Assoc::ctNOnes();
       if constexpr (Assoc::ctNOnes() < 0) {
-        assert(c);
-        assert(n > 0);
-        nOnes = n;
-        poff = c;
+        assert(view.offStorage);
+        assert(view.offSize > 0);
+        nOnes = view.offSize;
+        poff = view.offStorage;
       }
       assert(nOnes > 0);
       int32_t *ppsws = (int32_t *)((char *)(h) + offsetof(Assoc, psws));
@@ -109,6 +120,7 @@ namespace cms {
               >
     class OneToManyAssoc {
     public:
+      using View = OneToManyAssocView<OneToManyAssoc<I, ONES, SIZE>>;
       using Counter = uint32_t;
 
       using CountersOnly = OneToManyAssoc<I, ONES, 0>;
@@ -134,20 +146,19 @@ namespace cms {
       static constexpr int32_t ctCapacity() { return SIZE; }
       constexpr auto capacity() const { return content.capacity(); }
 
-      __host__ __device__ void initStorage(Counter *c, int32_t n, I *d, int32_t s) {
-        if constexpr (ctNOnes() < 0) {
-          assert(c);
-          assert(n > 0);
-          off.init(c, n);
-        }
+      __host__ __device__ void initStorage(View view) {
+        assert(view.assoc == this);
         if constexpr (ctCapacity() < 0) {
-          assert(d);
-          assert(s > 0);
-          content.init(d, s);
+          assert(view.contentStorage);
+          assert(view.contentSize > 0);
+          content.init(view.contentStorage, view.contentSize);
+        }
+        if constexpr (ctNOnes() < 0) {
+          assert(view.offStorage);
+          assert(view.offSize > 0);
+          off.init(view.offStorage, view.offSize);
         }
       }
-
-      __host__ __device__ void initStorage(I *d, int32_t s) { content.init(d, s); }
 
       __host__ __device__ void zero() {
         for (int32_t i = 0; i < totOnes(); ++i) {

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -1,0 +1,254 @@
+#ifndef HeterogeneousCore_CUDAUtilities_interface_OneToManyAssoc_h
+#define HeterogeneousCore_CUDAUtilities_interface_OneToManyAssoc_h
+
+#include <algorithm>
+#ifndef __CUDA_ARCH__
+#include <atomic>
+#endif  // __CUDA_ARCH__
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/AtomicPairCounter.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudastdAlgorithm.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/prefixScan.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h"
+
+namespace cms {
+  namespace cuda {
+
+    template <typename Assoc>
+    __global__ void zeroAndInit(Assoc *h, typename Assoc::index_type *mem, int s, typename Assoc::Counter * c,  int32_t n) {
+      int first = blockDim.x * blockIdx.x + threadIdx.x;
+
+      if (0 == first) {
+        h->psws = 0;
+        h->initStorage(c,n,mem, s);
+      }
+      __syncthreads();
+      for (int i = first, nt = h->totOnes(); i < nt; i += gridDim.x * blockDim.x) {
+        h->off[i] = 0;
+      }
+     }
+
+ 
+    template <typename Assoc>
+    inline __attribute__((always_inline)) void launchZero(Assoc *__restrict__ h,
+                                                          typename Assoc::index_type *mem,
+                                                          int s,
+							  typename Assoc::Counter * c,  int32_t n,
+                                                          cudaStream_t stream
+#ifndef __CUDACC__
+                                                          = cudaStreamDefault
+#endif
+    ) {
+      if constexpr (Assoc::ctCapacity() < 0) {
+        assert(mem);
+        assert(s > 0);
+      }
+      auto nOnes = Assoc::ctNOnes();
+      if constexpr (Assoc::ctNOnes() < 0) {
+        assert(c);
+        assert(n > 0);
+	nOnes = n;
+      }
+      assert(nOnes>0);
+#ifdef __CUDACC__
+      auto nthreads = 1024;
+      auto nblocks = (nOnes + nthreads - 1) / nthreads;
+      zeroAndInit<<<nblocks, nthreads, 0, stream>>>(h, mem, s,c,n);
+      cudaCheck(cudaGetLastError());
+#else
+      h->initStorage(c,n,mem, s);
+      h->zero();
+      h->psws = 0;
+#endif
+    }
+
+    template <typename Assoc>
+    inline __attribute__((always_inline)) void launchFinalize(Assoc *__restrict__ h,
+							  typename Assoc::Counter * c,  int32_t n,
+                                                              cudaStream_t stream
+#ifndef __CUDACC__
+                                                              = cudaStreamDefault
+#endif
+    ) {
+#ifdef __CUDACC__
+      using Counter =  typename Assoc::Counter;
+      auto nOnes = Assoc::ctNOnes();
+      Counter * poff = (Counter *)((char *)(h) + offsetof(Assoc, off));
+      if constexpr (Assoc::ctNOnes() < 0) {
+        assert(c);
+        assert(n > 0);
+	nOnes = n;
+	poff = c;
+      }
+      assert(nOnes>0);
+      int32_t * ppsws = (int32_t *)((char *)(h) + offsetof(Assoc, psws));
+      auto nthreads = 1024;
+      auto nblocks = (nOnes + nthreads - 1) / nthreads;
+      multiBlockPrefixScan<<<nblocks, nthreads, sizeof(int32_t) * nblocks, stream>>>(
+          poff, poff, nOnes, ppsws);
+      cudaCheck(cudaGetLastError());
+#else
+      h->finalize();
+#endif
+    }
+
+
+    template <typename Assoc>
+    __global__ void finalizeBulk(AtomicPairCounter const *apc, Assoc *__restrict__ assoc) {
+      assoc->bulkFinalizeFill(*apc);
+    }
+
+
+    template < typename I,  // type stored in the container (usually an index in a vector of the input values)
+               int32_t ONES,  // number of "Ones" If -1 is initialized at runtime using external storage
+               int32_t SIZE    // max number of element. If -1 is initialized at runtime using external storage
+               >
+    class OneToManyAssoc {
+    public:
+      using Counter = uint32_t;
+
+      using CountersOnly = OneToManyAssoc<I, ONES, 0>;
+
+      using index_type = I;
+ 
+      static constexpr uint32_t ilog2(uint32_t v) {
+        constexpr uint32_t b[] = {0x2, 0xC, 0xF0, 0xFF00, 0xFFFF0000};
+        constexpr uint32_t s[] = {1, 2, 4, 8, 16};
+
+        uint32_t r = 0;  // result of log2(v) will go here
+        for (auto i = 4; i >= 0; i--)
+          if (v & b[i]) {
+            v >>= s[i];
+            r |= s[i];
+          }
+        return r;
+      }
+
+ 
+      static constexpr int32_t ctNOnes() { return ONES; }
+      constexpr auto totOnes() const { return off.capacity(); }
+      constexpr auto nOnes() const { return totOnes()-1; }
+      static constexpr int32_t ctCapacity() { return SIZE; }
+      constexpr auto capacity() const { return content.capacity(); }
+
+
+      __host__ __device__ void initStorage(Counter * c,  int32_t n, I *d, int32_t s) {
+	if constexpr (ctNOnes() < 0) {
+	  assert(c);
+          assert(n > 0);
+	  off.init(c,n);
+	}  
+	if constexpr (ctCapacity() < 0) {
+	  assert(d);
+          assert(s > 0);
+          content.init(d, s);
+        }
+      }
+      
+      __host__ __device__ void initStorage(I *d, int32_t s) { content.init(d, s); }
+
+      __host__ __device__ void zero() {
+        for (int32_t i = 0; i < totOnes(); ++i) {
+           off[i] = 0;
+        }
+      }
+	
+      __host__ __device__ __forceinline__ void add(CountersOnly const &co) {
+        for (int32_t i = 0; i < totOnes(); ++i) {
+#ifdef __CUDA_ARCH__
+          atomicAdd(off.data() + i, co.off[i]);
+#else
+          auto &a = (std::atomic<Counter> &)(off[i]);
+          a += co.off[i];
+#endif
+        }
+      }
+
+      static __host__ __device__ __forceinline__ uint32_t atomicIncrement(Counter &x) {
+#ifdef __CUDA_ARCH__
+        return atomicAdd(&x, 1);
+#else
+        auto &a = (std::atomic<Counter> &)(x);
+        return a++;
+#endif
+      }
+
+      static __host__ __device__ __forceinline__ uint32_t atomicDecrement(Counter &x) {
+#ifdef __CUDA_ARCH__
+        return atomicSub(&x, 1);
+#else
+        auto &a = (std::atomic<Counter> &)(x);
+        return a--;
+#endif
+      }
+
+      __host__ __device__ __forceinline__ void count(int32_t b) {
+        assert(b < nOnes());
+        atomicIncrement(off[b]);
+      }
+
+      __host__ __device__ __forceinline__ void fill(int32_t b, index_type j) {
+        assert(b < nOnes());
+        auto w = atomicDecrement(off[b]);
+        assert(w > 0);
+        content[w - 1] = j;
+      }
+
+      __host__ __device__ __forceinline__ int32_t bulkFill(AtomicPairCounter &apc, index_type const *v, uint32_t n) {
+        auto c = apc.add(n);
+        if (int(c.m) >= nOnes())
+          return -int32_t(c.m);
+        off[c.m] = c.n;
+        for (uint32_t j = 0; j < n; ++j)
+          content[c.n + j] = v[j];
+        return c.m;
+      }
+
+      __host__ __device__ __forceinline__ void bulkFinalize(AtomicPairCounter const &apc) {
+        off[apc.get().m] = apc.get().n;
+      }
+
+      __host__ __device__ __forceinline__ void bulkFinalizeFill(AtomicPairCounter const &apc) {
+        int m = apc.get().m;
+        auto n = apc.get().n;
+        if (m >= nOnes()) {  // overflow!
+          off[nOnes()] = uint32_t(off[nOnes() - 1]);
+          return;
+        }
+        auto first = m + blockDim.x * blockIdx.x + threadIdx.x;
+        for (int i = first; i < totOnes(); i += gridDim.x * blockDim.x) {
+          off[i] = n;
+        }
+      }
+
+ 
+
+      __host__ __device__ __forceinline__ void finalize(Counter *ws = nullptr) {
+        assert(off[totOnes() - 1] == 0);
+        blockPrefixScan(off.data(), totOnes(), ws);
+        assert(off[totOnes() - 1] == off[totOnes() - 2]);
+      }
+
+      constexpr auto size() const { return uint32_t(off[totOnes() - 1]); }
+      constexpr auto size(uint32_t b) const { return off[b + 1] - off[b]; }
+
+      constexpr index_type const *begin() const { return content.data(); }
+      constexpr index_type const *end() const { return begin() + size(); }
+
+      constexpr index_type const *begin(uint32_t b) const { return content.data() + off[b]; }
+      constexpr index_type const *end(uint32_t b) const { return content.data() + off[b + 1]; }
+
+      FlexiStorage<Counter,ONES> off;
+      int32_t psws;  // prefix-scan working space
+      FlexiStorage<index_type, SIZE> content;
+    };
+
+  }  // namespace cuda
+}  // namespace cms
+
+#endif  // HeterogeneousCore_CUDAUtilities_interface_HistoContainer_h

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -47,14 +47,14 @@ namespace cms {
     }
 
     template <typename Assoc>
-    inline __attribute__((always_inline)) void launchZero(Assoc * h,
+    inline __attribute__((always_inline)) void launchZero(Assoc *h,
                                                           cudaStream_t stream
 #ifndef __CUDACC__
                                                           = cudaStreamDefault
 #endif
     ) {
-     typename Assoc::View view = {h,nullptr,nullptr,-1,-1};
-     launchZero(view, stream);
+      typename Assoc::View view = {h, nullptr, nullptr, -1, -1};
+      launchZero(view, stream);
     }
     template <typename Assoc>
     inline __attribute__((always_inline)) void launchZero(OneToManyAssocView<Assoc> view,
@@ -89,15 +89,15 @@ namespace cms {
 #endif
     }
 
-   template <typename Assoc>
-    inline __attribute__((always_inline)) void launchFinalize(Assoc * h,
+    template <typename Assoc>
+    inline __attribute__((always_inline)) void launchFinalize(Assoc *h,
                                                               cudaStream_t stream
 #ifndef __CUDACC__
                                                               = cudaStreamDefault
 #endif
     ) {
-     typename Assoc::View view = {h,nullptr,nullptr,-1,-1};
-     launchFinalize(view,stream);
+      typename Assoc::View view = {h, nullptr, nullptr, -1, -1};
+      launchFinalize(view, stream);
     }
 
     template <typename Assoc>

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -24,7 +24,7 @@ namespace cms {
       using Counter = typename Assoc::Counter;
       using index_type = typename Assoc::index_type;
 
-      Assoc *assoc;
+      Assoc *assoc = nullptr;
       Counter *offStorage = nullptr;
       index_type *contentStorage = nullptr;
       int32_t offSize = -1;

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -104,7 +104,7 @@ namespace cms {
     }
 
     template <typename I,    // type stored in the container (usually an index in a vector of the input values)
-              int32_t ONES,  // number of "Ones" If -1 is initialized at runtime using external storage
+              int32_t ONES,  // number of "Ones"  +1. If -1 is initialized at runtime using external storage
               int32_t SIZE   // max number of element. If -1 is initialized at runtime using external storage
               >
     class OneToManyAssoc {

--- a/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/OneToManyAssoc.h
@@ -47,6 +47,16 @@ namespace cms {
     }
 
     template <typename Assoc>
+    inline __attribute__((always_inline)) void launchZero(Assoc * h,
+                                                          cudaStream_t stream
+#ifndef __CUDACC__
+                                                          = cudaStreamDefault
+#endif
+    ) {
+     typename Assoc::View view = {h,nullptr,nullptr,-1,-1};
+     launchZero(view, stream);
+    }
+    template <typename Assoc>
     inline __attribute__((always_inline)) void launchZero(OneToManyAssocView<Assoc> view,
                                                           cudaStream_t stream
 #ifndef __CUDACC__
@@ -77,6 +87,17 @@ namespace cms {
       h->zero();
       h->psws = 0;
 #endif
+    }
+
+   template <typename Assoc>
+    inline __attribute__((always_inline)) void launchFinalize(Assoc * h,
+                                                              cudaStream_t stream
+#ifndef __CUDACC__
+                                                              = cudaStreamDefault
+#endif
+    ) {
+     typename Assoc::View view = {h,nullptr,nullptr,-1,-1};
+     launchFinalize(view,stream);
     }
 
     template <typename Assoc>

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -52,6 +52,14 @@
     <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   </bin>
 
+ <bin file="HistoContainerRT_t.cu" name="gpuHistoContainerRT_t">
+    <flags CUDA_FLAGS="-g"/>
+  </bin>
+
+  <bin file="HistoContainerRT_t.cu" name="gpuHistoContainerRT_debug">
+    <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
+  </bin>
+
   <bin file="OneHistoContainer_t.cu" name="gpuOneHistoContainer_t">
     <flags CUDA_FLAGS="-g"/>
   </bin>

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -40,6 +40,10 @@
     <flags CXXFLAGS="-g"/>
   </bin>
 
+  <bin file="FlexiStorage_t.cpp">
+   <flags CXXFLAGS="-g"/>
+  </bin>
+
   <bin file="HistoContainer_t.cu" name="gpuHistoContainer_t">
     <flags CUDA_FLAGS="-g"/>
   </bin>

--- a/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/test/BuildFile.xml
@@ -88,6 +88,19 @@
     <flags CXXFLAGS="-g"/>
   </bin>
 
+  <bin file="OneToManyAssoc_t.cu" name="gpuOneToManyAssocRT_t">
+    <flags CUDA_FLAGS="-g -DRUNTIME_SIZE"/>
+  </bin>
+
+  <bin file="OneToManyAssoc_t.cu" name="gpuOneToManyAssocRT_debug">
+    <flags CUDA_FLAGS="-g -DGPU_DEBUG -DRUNTIME_SIZE"/>
+  </bin>
+
+  <bin file="OneToManyAssoc_t.cpp" name="cpuOneToManyAssocRT_t">
+    <flags CXXFLAGS="-g -DRUNTIME_SIZE"/>
+  </bin>
+
+
   <bin file="prefixScan_t.cu" name="gpuPrefixScan_t">
     <flags CUDA_FLAGS="-g"/>
   </bin>

--- a/HeterogeneousCore/CUDAUtilities/test/FlexiStorage_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/FlexiStorage_t.cpp
@@ -1,0 +1,41 @@
+#include "HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h"
+
+
+
+#include<cassert>
+
+using namespace cms::cuda;
+
+int main() {
+
+
+  FlexiStorage<int,1024> a;
+
+  assert(a.capacity()==1024);
+
+  FlexiStorage<int,-1> v;
+
+  v.init(a.data(),20);
+
+  assert(v.capacity()==20);
+
+  assert(v.data()==a.data());
+
+  a[4]=42;
+
+  assert(42==a[4]);
+  assert(42==v[4]);
+
+  auto const & ac = a;
+  auto const & vc = v;
+
+  assert(42==ac[4]);
+  assert(42==vc[4]);
+
+  assert(ac.data()==vc.data());
+
+
+  return 0;
+
+
+};

--- a/HeterogeneousCore/CUDAUtilities/test/FlexiStorage_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/FlexiStorage_t.cpp
@@ -1,41 +1,34 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/FlexiStorage.h"
 
-
-
-#include<cassert>
+#include <cassert>
 
 using namespace cms::cuda;
 
 int main() {
+  FlexiStorage<int, 1024> a;
 
+  assert(a.capacity() == 1024);
 
-  FlexiStorage<int,1024> a;
+  FlexiStorage<int, -1> v;
 
-  assert(a.capacity()==1024);
+  v.init(a.data(), 20);
 
-  FlexiStorage<int,-1> v;
+  assert(v.capacity() == 20);
 
-  v.init(a.data(),20);
+  assert(v.data() == a.data());
 
-  assert(v.capacity()==20);
+  a[4] = 42;
 
-  assert(v.data()==a.data());
+  assert(42 == a[4]);
+  assert(42 == v[4]);
 
-  a[4]=42;
+  auto const& ac = a;
+  auto const& vc = v;
 
-  assert(42==a[4]);
-  assert(42==v[4]);
+  assert(42 == ac[4]);
+  assert(42 == vc[4]);
 
-  auto const & ac = a;
-  auto const & vc = v;
-
-  assert(42==ac[4]);
-  assert(42==vc[4]);
-
-  assert(ac.data()==vc.data());
-
+  assert(ac.data() == vc.data());
 
   return 0;
-
-
 };

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
@@ -37,7 +37,6 @@ void go() {
   auto h_s = make_device_unique<uint32_t[]>(N, nullptr);
   // auto h_s = make_device_unique<Hist::index_type[]>(N, nullptr);
 
-
   auto off_d = make_device_unique<uint32_t[]>(nParts + 1, nullptr);
 
   for (int it = 0; it < 5; ++it) {
@@ -74,11 +73,11 @@ void go() {
 
     cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
 
-    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, h_s.get(),0);
+    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, h_s.get(), 0);
     cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
-    assert(h.capacity()==offsets[10]);
-    cudaCheck(cudaMemcpy(mem, h_s.get(), N*sizeof(uint32_t), cudaMemcpyDeviceToHost));
-    h.initStorage(mem,N);
+    assert(h.capacity() == offsets[10]);
+    cudaCheck(cudaMemcpy(mem, h_s.get(), N * sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    h.initStorage(mem, N);
     assert(0 == h.off[0]);
     assert(offsets[10] == h.size());
 

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
@@ -76,8 +76,11 @@ void go() {
     fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, h_s.get(), 0);
     cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
     assert(h.capacity() == offsets[10]);
+    // get content
     cudaCheck(cudaMemcpy(mem, h_s.get(), N * sizeof(uint32_t), cudaMemcpyDeviceToHost));
-    h.initStorage(mem, N);
+    typename Hist::View view = {&h, nullptr, mem, -1, N};
+    // plug correct content
+    h.initStorage(view);
     assert(0 == h.off[0]);
     assert(offsets[10] == h.size());
 

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
@@ -28,7 +28,7 @@ void go() {
 
   using Hist = HistoContainer<T, 128, -1, 8 * sizeof(T), uint32_t, nParts>;
   std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
-            << Hist::ctCapacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
+            << Hist::ctCapacity() << ' ' << offsetof(Hist, content) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
 
   Hist h;

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainerRT_t.cu
@@ -1,0 +1,163 @@
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/HistoContainer.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+using namespace cms::cuda;
+
+template <typename T>
+void go() {
+  std::mt19937 eng;
+  std::uniform_int_distribution<T> rgen(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+
+  constexpr int N = 12000;
+  T v[N];
+  auto v_d = make_device_unique<T[]>(N, nullptr);
+
+  cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+
+  constexpr uint32_t nParts = 10;
+  constexpr uint32_t partSize = N / nParts;
+  uint32_t offsets[nParts + 1];
+
+  using Hist = HistoContainer<T, 128, -1, 8 * sizeof(T), uint32_t, nParts>;
+  std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
+            << Hist::ctCapacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
+            << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
+
+  Hist h;
+  uint32_t mem[N];
+  auto h_d = make_device_unique<Hist[]>(1, nullptr);
+  auto h_s = make_device_unique<uint32_t[]>(N, nullptr);
+  // auto h_s = make_device_unique<Hist::index_type[]>(N, nullptr);
+
+
+  auto off_d = make_device_unique<uint32_t[]>(nParts + 1, nullptr);
+
+  for (int it = 0; it < 5; ++it) {
+    offsets[0] = 0;
+    for (uint32_t j = 1; j < nParts + 1; ++j) {
+      offsets[j] = offsets[j - 1] + partSize - 3 * j;
+      assert(offsets[j] <= N);
+    }
+
+    if (it == 1) {  // special cases...
+      offsets[0] = 0;
+      offsets[1] = 0;
+      offsets[2] = 19;
+      offsets[3] = 32 + offsets[2];
+      offsets[4] = 123 + offsets[3];
+      offsets[5] = 256 + offsets[4];
+      offsets[6] = 311 + offsets[5];
+      offsets[7] = 2111 + offsets[6];
+      offsets[8] = 256 * 11 + offsets[7];
+      offsets[9] = 44 + offsets[8];
+      offsets[10] = 3297 + offsets[9];
+      assert(offsets[10] <= N);
+    }
+
+    cudaCheck(cudaMemcpy(off_d.get(), offsets, 4 * (nParts + 1), cudaMemcpyHostToDevice));
+
+    for (long long j = 0; j < N; j++)
+      v[j] = rgen(eng);
+
+    if (it == 2) {  // big bin
+      for (long long j = 1000; j < 2000; j++)
+        v[j] = sizeof(T) == 1 ? 22 : 3456;
+    }
+
+    cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
+
+    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, h_s.get(),0);
+    cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
+    assert(h.capacity()==offsets[10]);
+    cudaCheck(cudaMemcpy(mem, h_s.get(), N*sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    h.initStorage(mem,N);
+    assert(0 == h.off[0]);
+    assert(offsets[10] == h.size());
+
+    auto verify = [&](uint32_t i, uint32_t k, uint32_t t1, uint32_t t2) {
+      assert(t1 < N);
+      assert(t2 < N);
+      if (T(v[t1] - v[t2]) <= 0)
+        std::cout << "for " << i << ':' << v[k] << " failed " << v[t1] << ' ' << v[t2] << std::endl;
+    };
+
+    auto incr = [](auto& k) { return k = (k + 1) % Hist::nbins(); };
+
+    // make sure it spans 3 bins...
+    auto window = T(1300);
+
+    for (uint32_t j = 0; j < nParts; ++j) {
+      auto off = Hist::histOff(j);
+      for (uint32_t i = 0; i < Hist::nbins(); ++i) {
+        auto ii = i + off;
+        if (0 == h.size(ii))
+          continue;
+        auto k = *h.begin(ii);
+        if (j % 2)
+          k = *(h.begin(ii) + (h.end(ii) - h.begin(ii)) / 2);
+        auto bk = h.bin(v[k]);
+        assert(bk == i);
+        assert(k < offsets[j + 1]);
+        auto kl = h.bin(v[k] - window);
+        auto kh = h.bin(v[k] + window);
+        assert(kl != i);
+        assert(kh != i);
+        // std::cout << kl << ' ' << kh << std::endl;
+
+        auto me = v[k];
+        auto tot = 0;
+        auto nm = 0;
+        bool l = true;
+        auto khh = kh;
+        incr(khh);
+        for (auto kk = kl; kk != khh; incr(kk)) {
+          if (kk != kl && kk != kh)
+            nm += h.size(kk + off);
+          for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p) {
+            if (std::min(std::abs(T(v[*p] - me)), std::abs(T(me - v[*p]))) > window) {
+            } else {
+              ++tot;
+            }
+          }
+          if (kk == i) {
+            l = false;
+            continue;
+          }
+          if (l)
+            for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p)
+              verify(i, k, k, (*p));
+          else
+            for (auto p = h.begin(kk + off); p < h.end(kk + off); ++p)
+              verify(i, k, (*p), k);
+        }
+        if (!(tot >= nm)) {
+          std::cout << "too bad " << j << ' ' << i << ' ' << int(me) << '/' << (int)T(me - window) << '/'
+                    << (int)T(me + window) << ": " << kl << '/' << kh << ' ' << khh << ' ' << tot << '/' << nm
+                    << std::endl;
+        }
+        if (l)
+          std::cout << "what? " << j << ' ' << i << ' ' << int(me) << '/' << (int)T(me - window) << '/'
+                    << (int)T(me + window) << ": " << kl << '/' << kh << ' ' << khh << ' ' << tot << '/' << nm
+                    << std::endl;
+        assert(!l);
+      }
+    }
+  }
+}
+
+int main() {
+  cms::cudatest::requireDevices();
+
+  go<int16_t>();
+  go<int8_t>();
+
+  return 0;
+}

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -28,7 +28,7 @@ void go() {
   using HistR = HistoContainer<T, NBINS, -1, S>;
   using Hist = HistoContainer<T, NBINS, N, S>;
   using Hist4 = HistoContainer<T, NBINS, N, S, uint16_t, 4>;
-  std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' '
+  std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' ' << HistR::ctNOnes() << ' '
             << HistR::ctCapacity() << ' ' << (rmax - rmin) / HistR::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -28,8 +28,8 @@ void go() {
   using HistR = HistoContainer<T, NBINS, -1, S>;
   using Hist = HistoContainer<T, NBINS, N, S>;
   using Hist4 = HistoContainer<T, NBINS, N, S, uint16_t, 4>;
-  std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' ' << HistR::ctNOnes() << ' '
-            << HistR::ctCapacity() << ' ' << (rmax - rmin) / HistR::nbins() << std::endl;
+  std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' '
+            << HistR::ctNOnes() << ' ' << HistR::ctCapacity() << ' ' << (rmax - rmin) / HistR::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 
   std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -28,7 +28,7 @@ void go() {
   using HistR = HistoContainer<T, NBINS, -1, S>;
   using Hist = HistoContainer<T, NBINS, N, S>;
   using Hist4 = HistoContainer<T, NBINS, N, S, uint16_t, 4>;
- std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' '
+  std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' '
             << HistR::ctCapacity() << ' ' << (rmax - rmin) / HistR::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 
@@ -43,8 +43,8 @@ void go() {
 
   uint32_t mem[N];
   HistR hr;
-  hr.initStorage(mem,N);
-  std::cout <<"HistoContainerR " << hr.capacity() << std::endl;
+  hr.initStorage(mem, N);
+  std::cout << "HistoContainerR " << hr.capacity() << std::endl;
   assert(hr.capacity() == N);
   Hist h;
   Hist4 h4;
@@ -103,8 +103,8 @@ void go() {
 
     for (uint32_t i = 0; i < Hist::nbins(); ++i) {
       assert(h.size(i) == hr.size(i));
-      assert(*h.begin(i)==*hr.begin(i));
-    } 
+      assert(*h.begin(i) == *hr.begin(i));
+    }
 
     for (uint32_t i = 0; i < Hist::nbins(); ++i) {
       if (0 == h.size(i))

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -25,51 +25,72 @@ void go() {
   constexpr int N = 12000;
   T v[N];
 
+  using HistR = HistoContainer<T, NBINS, -1, S>;
   using Hist = HistoContainer<T, NBINS, N, S>;
   using Hist4 = HistoContainer<T, NBINS, N, S, uint16_t, 4>;
+ std::cout << "HistoContainerR " << HistR::nbits() << ' ' << HistR::nbins() << ' ' << HistR::totbins() << ' '
+            << HistR::ctCapacity() << ' ' << (rmax - rmin) / HistR::nbins() << std::endl;
+  std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
+
   std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
-            << Hist::capacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
+            << Hist::ctCapacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
   std::cout << "HistoContainer4 " << Hist4::nbits() << ' ' << Hist4::nbins() << ' ' << Hist4::totbins() << ' '
-            << Hist4::capacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
+            << Hist4::ctCapacity() << ' ' << (rmax - rmin) / Hist::nbins() << std::endl;
   for (auto nh = 0; nh < 4; ++nh)
     std::cout << "bins " << int(Hist4::bin(0)) + Hist4::histOff(nh) << ' ' << int(Hist::bin(rmin)) + Hist4::histOff(nh)
               << ' ' << int(Hist::bin(rmax)) + Hist4::histOff(nh) << std::endl;
 
+  uint32_t mem[N];
+  HistR hr;
+  hr.initStorage(mem,N);
+  std::cout <<"HistoContainerR " << hr.capacity() << std::endl;
+  assert(hr.capacity() == N);
   Hist h;
   Hist4 h4;
+  assert(h.capacity() == N);
+  assert(h4.capacity() == N);
+
   for (int it = 0; it < 5; ++it) {
     for (long long j = 0; j < N; j++)
       v[j] = rgen(eng);
     if (it == 2)
       for (long long j = N / 2; j < N / 2 + N / 4; j++)
         v[j] = 4;
+    hr.zero();
     h.zero();
     h4.zero();
+    assert(hr.size() == 0);
     assert(h.size() == 0);
     assert(h4.size() == 0);
     for (long long j = 0; j < N; j++) {
+      hr.count(v[j]);
       h.count(v[j]);
       if (j < 2000)
         h4.count(v[j], 2);
       else
         h4.count(v[j], j % 4);
     }
+    assert(hr.size() == 0);
     assert(h.size() == 0);
     assert(h4.size() == 0);
+    hr.finalize();
     h.finalize();
     h4.finalize();
     assert(h.size() == N);
     assert(h4.size() == N);
     for (long long j = 0; j < N; j++) {
+      hr.fill(v[j], j);
       h.fill(v[j], j);
       if (j < 2000)
         h4.fill(v[j], j, 2);
       else
         h4.fill(v[j], j, j % 4);
     }
+    assert(hr.off[0] == 0);
     assert(h.off[0] == 0);
     assert(h4.off[0] == 0);
+    assert(hr.size() == N);
     assert(h.size() == N);
     assert(h4.size() == N);
 
@@ -79,6 +100,11 @@ void go() {
       if (i != j && T(v[t1] - v[t2]) <= 0)
         std::cout << "for " << i << ':' << v[k] << " failed " << v[t1] << ' ' << v[t2] << std::endl;
     };
+
+    for (uint32_t i = 0; i < Hist::nbins(); ++i) {
+      assert(h.size(i) == hr.size(i));
+      assert(*h.begin(i)==*hr.begin(i));
+    } 
 
     for (uint32_t i = 0; i < Hist::nbins(); ++i) {
       if (0 == h.size(i))

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cpp
@@ -43,7 +43,8 @@ void go() {
 
   uint32_t mem[N];
   HistR hr;
-  hr.initStorage(mem, N);
+  typename HistR::View view{&hr, nullptr, mem, -1, N};
+  hr.initStorage(view);
   std::cout << "HistoContainerR " << hr.capacity() << std::endl;
   assert(hr.capacity() == N);
   Hist h;

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -28,8 +28,10 @@ void go() {
 
   using Hist = HistoContainer<T, 128, N, 8 * sizeof(T), uint32_t, nParts>;
   std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
-            << Hist::ctCapacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
+            << Hist::ctCapacity() << ' ' << offsetof(Hist, content) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
+
+  assert(Hist::totbins()==Hist::ctNOnes());
 
   Hist h;
   auto h_d = make_device_unique<Hist[]>(1, nullptr);

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -28,7 +28,7 @@ void go() {
 
   using Hist = HistoContainer<T, 128, N, 8 * sizeof(T), uint32_t, nParts>;
   std::cout << "HistoContainer " << (int)(offsetof(Hist, off)) << ' ' << Hist::nbins() << ' ' << Hist::totbins() << ' '
-            << Hist::capacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
+            << Hist::ctCapacity() << ' ' << offsetof(Hist, bins) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
 
   Hist h;

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -55,7 +55,7 @@ void go() {
       offsets[8] = 256 * 11 + offsets[7];
       offsets[9] = 44 + offsets[8];
       offsets[10] = 3297 + offsets[9];
-     assert(offsets[10] <= N);
+      assert(offsets[10] <= N);
     }
 
     cudaCheck(cudaMemcpy(off_d.get(), offsets, 4 * (nParts + 1), cudaMemcpyHostToDevice));
@@ -70,7 +70,7 @@ void go() {
 
     cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
 
-    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, nullptr,0);
+    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, nullptr, 0);
     cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
     assert(0 == h.off[0]);
     assert(offsets[10] == h.size());

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -55,6 +55,7 @@ void go() {
       offsets[8] = 256 * 11 + offsets[7];
       offsets[9] = 44 + offsets[8];
       offsets[10] = 3297 + offsets[9];
+     assert(offsets[10] <= N);
     }
 
     cudaCheck(cudaMemcpy(off_d.get(), offsets, 4 * (nParts + 1), cudaMemcpyHostToDevice));
@@ -69,7 +70,7 @@ void go() {
 
     cudaCheck(cudaMemcpy(v_d.get(), v, N * sizeof(T), cudaMemcpyHostToDevice));
 
-    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, 0);
+    fillManyFromVector(h_d.get(), nParts, v_d.get(), off_d.get(), offsets[10], 256, nullptr,0);
     cudaCheck(cudaMemcpy(&h, h_d.get(), sizeof(Hist), cudaMemcpyDeviceToHost));
     assert(0 == h.off[0]);
     assert(offsets[10] == h.size());

--- a/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/HistoContainer_t.cu
@@ -31,7 +31,7 @@ void go() {
             << Hist::ctCapacity() << ' ' << offsetof(Hist, content) - offsetof(Hist, off) << ' '
             << (std::numeric_limits<T>::max() - std::numeric_limits<T>::min()) / Hist::nbins() << std::endl;
 
-  assert(Hist::totbins()==Hist::ctNOnes());
+  assert(Hist::totbins() == Hist::ctNOnes());
 
   Hist h;
   auto h_d = make_device_unique<Hist[]>(1, nullptr);

--- a/HeterogeneousCore/CUDAUtilities/test/OneHistoContainer_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/OneHistoContainer_t.cu
@@ -112,7 +112,7 @@ void go() {
   assert(v_d.get());
 
   using Hist = HistoContainer<T, NBINS, N, S>;
-  std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::capacity() << ' '
+  std::cout << "HistoContainer " << Hist::nbits() << ' ' << Hist::nbins() << ' ' << Hist::ctCapacity() << ' '
             << (rmax - rmin) / Hist::nbins() << std::endl;
   std::cout << "bins " << int(Hist::bin(0)) << ' ' << int(Hist::bin(rmin)) << ' ' << int(Hist::bin(rmax)) << std::endl;
 

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -243,9 +243,10 @@ int main() {
   a_st2 = a_st2_d.get();
   sa_st2 = sa_st2_d.get();
 #endif
-
-  launchZero(a_d.get(), a_st2, a_n2, a_st, a_n, 0);
-  launchZero(sa_d.get(), sa_st2, a_n2, nullptr, 0, 0);
+  Assoc::View aView = {a_d.get(), a_st, a_st2, a_n, a_n2};
+  launchZero(aView, 0);
+  SmallAssoc::View saView = {sa_d.get(), nullptr, sa_st2, -1, a_n2};
+  launchZero(saView, 0);
 
 #ifdef __CUDACC__
   auto nThreads = 256;
@@ -253,14 +254,14 @@ int main() {
 
   count<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
 
-  launchFinalize(a_d.get(), a_st, a_n, 0);
+  launchFinalize(aView, 0);
   verify<<<1, 1>>>(a_d.get());
   fill<<<nBlocks, nThreads>>>(v_d.get(), a_d.get(), N);
   verifyFill<<<1, 1>>>(a_d.get(), n);
 
 #else
   count(v_d, a_d.get(), N);
-  launchFinalize(a_d.get(), a_st, a_n);
+  launchFinalize(aView);
   verify(a_d.get());
   fill(v_d, a_d.get(), N);
   verifyFill(a_d.get(), n);
@@ -319,9 +320,10 @@ int main() {
   m1_st = m1_st_d.get();
   m2_st = m1_st_d.get();
 #endif
-
-  launchZero(m1_d.get(), m1_st, m_n, nullptr, 0, 0);
-  launchZero(m2_d.get(), m2_st, m_n, nullptr, 0, 0);
+  Multiplicity::View view1 = {m1_d.get(), nullptr, m1_st, -1, m_n};
+  Multiplicity::View view2 = {m2_d.get(), nullptr, m2_st, -1, m_n};
+  launchZero(view1, 0);
+  launchZero(view2, 0);
 
 #ifdef __CUDACC__
   nBlocks = (4 * N + nThreads - 1) / nThreads;
@@ -329,8 +331,8 @@ int main() {
   countMultiLocal<<<nBlocks, nThreads>>>(v_d.get(), m2_d.get(), N);
   verifyMulti<<<1, Multiplicity::ctNOnes()>>>(m1_d.get(), m2_d.get());
 
-  launchFinalize(m1_d.get(), nullptr, 0, 0);
-  launchFinalize(m2_d.get(), nullptr, 0, 0);
+  launchFinalize(view1, 0);
+  launchFinalize(view2, 0);
   verifyMulti<<<1, Multiplicity::ctNOnes()>>>(m1_d.get(), m2_d.get());
 
   cudaCheck(cudaGetLastError());
@@ -340,8 +342,8 @@ int main() {
   countMultiLocal(v_d, m2_d.get(), N);
   verifyMulti(m1_d.get(), m2_d.get());
 
-  launchFinalize(m1_d.get(), nullptr, 0);
-  launchFinalize(m2_d.get(), nullptr, 0);
+  launchFinalize(view1, 0);
+  launchFinalize(view2, 0);
   verifyMulti(m1_d.get(), m2_d.get());
 #endif
   return 0;

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -176,7 +176,7 @@ int main() {
   auto v_d = tr.data();
 #endif
 
-  launchZero(a_d.get(), nullptr,0, 0);
+  launchZero(a_d.get(), nullptr, 0, 0);
 
 #ifdef __CUDACC__
   auto nThreads = 256;
@@ -276,8 +276,8 @@ int main() {
   auto m1_d = std::make_unique<Multiplicity>();
   auto m2_d = std::make_unique<Multiplicity>();
 #endif
-  launchZero(m1_d.get(), nullptr,0,0);
-  launchZero(m2_d.get(), nullptr,0,0);
+  launchZero(m1_d.get(), nullptr, 0, 0);
+  launchZero(m2_d.get(), nullptr, 0, 0);
 
 #ifdef __CUDACC__
   nBlocks = (4 * N + nThreads - 1) / nThreads;

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -77,7 +77,7 @@ __global__ void fill(TK const* __restrict__ tk, Assoc* __restrict__ assoc, int32
   }
 }
 
-__global__ void verify(Assoc* __restrict__ assoc) { assert(assoc->size() < Assoc::capacity()); }
+__global__ void verify(Assoc* __restrict__ assoc) { assert(assoc->size() < Assoc::ctCapacity()); }
 
 template <typename Assoc>
 __global__ void fillBulk(AtomicPairCounter* apc, TK const* __restrict__ tk, Assoc* __restrict__ assoc, int32_t n) {
@@ -92,7 +92,7 @@ template <typename Assoc>
 __global__ void verifyBulk(Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) {
   if (apc->get().m >= Assoc::nbins())
     printf("Overflow %d %d\n", apc->get().m, Assoc::nbins());
-  assert(assoc->size() < Assoc::capacity());
+  assert(assoc->size() < Assoc::ctCapacity());
 }
 
 int main() {
@@ -118,9 +118,9 @@ int main() {
   assert(gridDim.z == 1);
 #endif
 
-  std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::capacity() << std::endl;
+  std::cout << "OneToManyAssoc " << sizeof(Assoc) << ' ' << Assoc::nbins() << ' ' << Assoc::ctCapacity() << std::endl;
   std::cout << "OneToManyAssoc (small) " << sizeof(SmallAssoc) << ' ' << SmallAssoc::nbins() << ' '
-            << SmallAssoc::capacity() << std::endl;
+            << SmallAssoc::ctCapacity() << std::endl;
 
   std::mt19937 eng;
 

--- a/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
+++ b/HeterogeneousCore/CUDAUtilities/test/OneToManyAssoc_t.h
@@ -176,7 +176,7 @@ int main() {
   auto v_d = tr.data();
 #endif
 
-  launchZero(a_d.get(), 0);
+  launchZero(a_d.get(), nullptr,0, 0);
 
 #ifdef __CUDACC__
   auto nThreads = 256;
@@ -276,8 +276,8 @@ int main() {
   auto m1_d = std::make_unique<Multiplicity>();
   auto m2_d = std::make_unique<Multiplicity>();
 #endif
-  launchZero(m1_d.get(), 0);
-  launchZero(m2_d.get(), 0);
+  launchZero(m1_d.get(), nullptr,0,0);
+  launchZero(m2_d.get(), nullptr,0,0);
 
 #ifdef __CUDACC__
   nBlocks = (4 * N + nThreads - 1) / nThreads;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -64,7 +64,7 @@ namespace pixelgpudetails {
 
     if (nHits) {
       cms::cuda::fillManyFromVector(
-          hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, nullptr, stream);
+          hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, hits_d.binnerStorage(), stream);
       cudaCheck(cudaGetLastError());
     }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -63,7 +63,8 @@ namespace pixelgpudetails {
     }
 
     if (nHits) {
-      cms::cuda::fillManyFromVector(hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, nullptr, stream);
+      cms::cuda::fillManyFromVector(
+          hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, nullptr, stream);
       cudaCheck(cudaGetLastError());
     }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelRecHits.cu
@@ -63,7 +63,7 @@ namespace pixelgpudetails {
     }
 
     if (nHits) {
-      cms::cuda::fillManyFromVector(hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, stream);
+      cms::cuda::fillManyFromVector(hits_d.phiBinner(), 10, hits_d.iphi(), hits_d.hitsLayerStart(), nHits, 256, nullptr, stream);
       cudaCheck(cudaGetLastError());
     }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
@@ -240,7 +240,7 @@ void SiPixelRecHitSoAFromLegacy::produce(edm::StreamID streamID, edm::Event& iEv
     output->hitsLayerStart()[i] = hitsModuleStart[cpeView.layerGeometry().layerStart[i]];
   }
   cms::cuda::fillManyFromVector(
-      output->phiBinner(), 10, output->iphi(), output->hitsLayerStart(), numberOfHits, 256, nullptr);
+      output->phiBinner(), 10, output->iphi(), output->hitsLayerStart(), numberOfHits, 256, output->binnerStorage());
 
   // std::cout << "created HitSoa for " <<  numberOfClusters << " clusters in " << numberOfDetUnits << " Dets" << std::endl;
   iEvent.put(std::move(output));

--- a/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BrokenLineFitOnGPU.h
@@ -45,7 +45,7 @@ __global__ void kernelBLFastFit(Tuples const *__restrict__ foundNtuplets,
 
 #ifdef BROKENLINE_DEBUG
   if (0 == local_start) {
-    printf("%d total Ntuple\n", foundNtuplets->nbins());
+    printf("%d total Ntuple\n", foundNtuplets->nOnes());
     printf("%d Ntuple of size %d for %d hits to fit\n", tupleMultiplicity->size(nHits), nHits, hitsInFit);
   }
 #endif
@@ -58,7 +58,7 @@ __global__ void kernelBLFastFit(Tuples const *__restrict__ foundNtuplets,
 
     // get it from the ntuple container (one to one to helix)
     auto tkid = *(tupleMultiplicity->begin(nHits) + tuple_idx);
-    assert(tkid < foundNtuplets->nbins());
+    assert(tkid < foundNtuplets->nOnes());
 
     assert(foundNtuplets->size(tkid) == nHits);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -61,6 +61,7 @@ namespace CAConstants {
   using OuterHitOfCell = cms::cuda::VecArray<uint32_t, maxCellsPerHit()>;
   using TuplesContainer = cms::cuda::OneToManyAssoc<hindex_type, maxTuples(), 5 * maxTuples()>;
   using HitToTuple = cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples()>;  // 3.5 should be enough
+  //  using HitToTuple = cms::cuda::OneToManyAssoc<tindex_type, pixelGPUConstants::maxNumberOfHits, 4 * maxTuples()>;  // 3.5 should be enough
   using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 8, maxTuples()>;
 
 }  // namespace CAConstants

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -60,8 +60,7 @@ namespace CAConstants {
 
   using OuterHitOfCell = cms::cuda::VecArray<uint32_t, maxCellsPerHit()>;
   using TuplesContainer = cms::cuda::OneToManyAssoc<hindex_type, maxTuples(), 5 * maxTuples()>;
-  using HitToTuple =
-      cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples()>;  // 3.5 should be enough
+  using HitToTuple = cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples()>;  // 3.5 should be enough
   using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 8, maxTuples()>;
 
 }  // namespace CAConstants

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAConstants.h
@@ -61,7 +61,7 @@ namespace CAConstants {
   using OuterHitOfCell = cms::cuda::VecArray<uint32_t, maxCellsPerHit()>;
   using TuplesContainer = cms::cuda::OneToManyAssoc<hindex_type, maxTuples(), 5 * maxTuples()>;
   using HitToTuple =
-      cms::cuda::OneToManyAssoc<tindex_type, pixelGPUConstants::maxNumberOfHits, 4 * maxTuples()>;  // 3.5 should be enough
+      cms::cuda::OneToManyAssoc<tindex_type, -1, 4 * maxTuples()>;  // 3.5 should be enough
   using TupleMultiplicity = cms::cuda::OneToManyAssoc<tindex_type, 8, maxTuples()>;
 
 }  // namespace CAConstants

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -75,7 +75,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   assert(tuples_d && quality_d);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, cudaStream);
+  cms::cuda::launchZero(tuples_d, nullptr, 0, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -75,7 +75,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   assert(tuples_d && quality_d);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, nullptr, 0, nullptr, 0, cudaStream);
+  cms::cuda::launchZero(tuples_d, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
@@ -123,7 +123,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tuples_d, quality_d);
 
   kernel_countMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
-  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), nullptr, 0, cudaStream);
+  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), cudaStream);
   kernel_fillMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
 
   if (nhits > 1 && m_params.lateFishbone_) {
@@ -165,7 +165,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   // fill hit->track "map"
   kernel_countHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
-  cms::cuda::launchFinalize(device_hitToTuple_.get(), nullptr, 0, cudaStream);
+  cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
   kernel_fillHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
 
   // remove duplicates (tracks that share a hit)

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -75,7 +75,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   assert(tuples_d && quality_d);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, nullptr, 0, cudaStream);
+  cms::cuda::launchZero(tuples_d, nullptr, 0, nullptr, 0, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
@@ -123,7 +123,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tuples_d, quality_d);
 
   kernel_countMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
-  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), cudaStream);
+  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), nullptr, 0, cudaStream);
   kernel_fillMultiplicity(tuples_d, quality_d, device_tupleMultiplicity_.get());
 
   if (nhits > 1 && m_params.lateFishbone_) {
@@ -165,7 +165,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   // fill hit->track "map"
   kernel_countHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
-  cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
+  cms::cuda::launchFinalize(device_hitToTuple_.get(), nullptr, 0, cudaStream);
   kernel_fillHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
 
   // remove duplicates (tracks that share a hit)

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -165,7 +165,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   // fill hit->track "map"
   kernel_countHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
-  cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
+  cms::cuda::launchFinalize(hitToTupleView_, cudaStream);
   kernel_fillHitInTracks(tuples_d, quality_d, device_hitToTuple_.get());
 
   // remove duplicates (tracks that share a hit)

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -21,7 +21,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   auto *quality_d = (Quality *)(&tracks_d->m_quality);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, nullptr, 0, nullptr, 0, cudaStream);
+  cms::cuda::launchZero(tuples_d, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
@@ -108,7 +108,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   numberOfBlocks = (3 * CAConstants::maxTuples() / 4 + blockSize - 1) / blockSize;
   kernel_countMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
       tuples_d, quality_d, device_tupleMultiplicity_.get());
-  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), nullptr, 0, cudaStream);
+  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), cudaStream);
   kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
       tuples_d, quality_d, device_tupleMultiplicity_.get());
   cudaCheck(cudaGetLastError());
@@ -250,7 +250,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     kernel_countHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
         tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());
-    cms::cuda::launchFinalize(device_hitToTuple_.get(), nullptr, 0, cudaStream);
+    cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
     cudaCheck(cudaGetLastError());
     kernel_fillHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -21,7 +21,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   auto *quality_d = (Quality *)(&tracks_d->m_quality);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, nullptr, 0, cudaStream);
+  cms::cuda::launchZero(tuples_d, nullptr, 0,nullptr, 0, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
@@ -95,7 +95,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 #endif
 
   blockSize = 128;
-  numberOfBlocks = (HitContainer::totbins() + blockSize - 1) / blockSize;
+  numberOfBlocks = (HitContainer::ctNOnes() + blockSize - 1) / blockSize;
   cms::cuda::finalizeBulk<<<numberOfBlocks, blockSize, 0, cudaStream>>>(device_hitTuple_apc_, tuples_d);
 
   // remove duplicates (tracks that share a doublet)
@@ -108,7 +108,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   numberOfBlocks = (3 * CAConstants::maxTuples() / 4 + blockSize - 1) / blockSize;
   kernel_countMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
       tuples_d, quality_d, device_tupleMultiplicity_.get());
-  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), cudaStream);
+  cms::cuda::launchFinalize(device_tupleMultiplicity_.get(), nullptr, 0, cudaStream);
   kernel_fillMultiplicity<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
       tuples_d, quality_d, device_tupleMultiplicity_.get());
   cudaCheck(cudaGetLastError());
@@ -250,7 +250,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     kernel_countHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
         tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());
-    cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
+    cms::cuda::launchFinalize(device_hitToTuple_.get(), nullptr, 0, cudaStream);
     cudaCheck(cudaGetLastError());
     kernel_fillHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -21,7 +21,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   auto *quality_d = (Quality *)(&tracks_d->m_quality);
 
   // zero tuples
-  cms::cuda::launchZero(tuples_d, nullptr, 0,nullptr, 0, cudaStream);
+  cms::cuda::launchZero(tuples_d, nullptr, 0, nullptr, 0, cudaStream);
 
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -26,9 +26,10 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   auto nhits = hh.nHits();
   assert(nhits <= pixelGPUConstants::maxNumberOfHits);
 
-#ifdef  NTUPLE_DEBUG
+#ifdef NTUPLE_DEBUG
   std::cout << "start tuple building. N hits " << nhits << std::endl;
-  if (nhits<2) std::cout << "too few hits " << nhits << std::endl;
+  if (nhits < 2)
+    std::cout << "too few hits " << nhits << std::endl;
 #endif
 
   //
@@ -227,7 +228,6 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   int32_t nhits = hh.nHits();
 
-
   auto blockSize = 64;
 
   // classify tracks based on kinematics
@@ -255,12 +255,13 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
 
   if (m_params.minHitsPerNtuplet_ < 4 || m_params.doStats_) {
     // fill hit->track "map"
-    assert(hitToTupleView_.offSize>nhits);
+    assert(hitToTupleView_.offSize > nhits);
     numberOfBlocks = (3 * CAConstants::maxNumberOfQuadruplets() / 4 + blockSize - 1) / blockSize;
     kernel_countHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
         tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());
-    assert((hitToTupleView_.assoc==device_hitToTuple_.get()) && (hitToTupleView_.offStorage==device_hitToTupleStorage_.get()) && (hitToTupleView_.offSize>0));
+    assert((hitToTupleView_.assoc == device_hitToTuple_.get()) &&
+           (hitToTupleView_.offStorage == device_hitToTupleStorage_.get()) && (hitToTupleView_.offSize > 0));
     cms::cuda::launchFinalize(hitToTupleView_, cudaStream);
     cudaCheck(cudaGetLastError());
     kernel_fillHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, quality_d, device_hitToTuple_.get());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -250,7 +250,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     kernel_countHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(
         tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());
-    cms::cuda::launchFinalize(device_hitToTuple_.get(), cudaStream);
+    cms::cuda::launchFinalize(hitToTupleView_, cudaStream);
     cudaCheck(cudaGetLastError());
     kernel_fillHitInTracks<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, quality_d, device_hitToTuple_.get());
     cudaCheck(cudaGetLastError());

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -171,7 +171,7 @@ public:
   void fillHitDetIndices(HitsView const* hv, TkSoA* tuples_d, cudaStream_t cudaStream);
 
   void buildDoublets(HitsOnCPU const& hh, cudaStream_t stream);
-  void allocateOnGPU(cudaStream_t stream);
+  void allocateOnGPU(int32_t nHits,cudaStream_t stream);
   void cleanup(cudaStream_t cudaStream);
 
   static void printCounters(Counters const* counters);
@@ -190,6 +190,9 @@ private:
   uint32_t* device_nCells_ = nullptr;
 
   unique_ptr<HitToTuple> device_hitToTuple_;
+  unique_ptr<HitToTuple::Counter[]> device_hitToTupleStorage_;
+  HitToTuple::View hitToTupleView_;
+
   cms::cuda::AtomicPairCounter* device_hitToTuple_apc_ = nullptr;
 
   cms::cuda::AtomicPairCounter* device_hitTuple_apc_ = nullptr;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -171,7 +171,7 @@ public:
   void fillHitDetIndices(HitsView const* hv, TkSoA* tuples_d, cudaStream_t cudaStream);
 
   void buildDoublets(HitsOnCPU const& hh, cudaStream_t stream);
-  void allocateOnGPU(int32_t nHits,cudaStream_t stream);
+  void allocateOnGPU(int32_t nHits, cudaStream_t stream);
   void cleanup(cudaStream_t cudaStream);
 
   static void printCounters(Counters const* counters);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -1,6 +1,8 @@
 #ifndef RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorKernels_h
 #define RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorKernels_h
 
+// #define GPU_DEBUG
+
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 #include "GPUCACell.h"
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -15,6 +15,10 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t 
   device_theCellNeighbors_ = Traits::template make_unique<CAConstants::CellNeighborsVector>(stream);
   device_theCellTracks_ = Traits::template make_unique<CAConstants::CellTracksVector>(stream);
 
+#ifdef  GPU_DEBUG
+  std::cout << "Allocation for tuple building. N hits " << nHits << std::endl;
+#endif
+
   nHits++;  // storage requires one more counter;
   assert(nHits > 0);
   device_hitToTuple_ = Traits::template make_unique<HitToTuple>(stream);
@@ -39,4 +43,8 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t 
   }
   cms::cuda::launchZero(device_tupleMultiplicity_.get(), stream);
   cms::cuda::launchZero(hitToTupleView_, stream);  // we may wish to keep it in the edm...
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+#endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -34,6 +34,6 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   } else {
     *device_nCells_ = 0;
   }
-  cms::cuda::launchZero(device_tupleMultiplicity_.get(), stream);
-  cms::cuda::launchZero(device_hitToTuple_.get(), stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr,0,stream);
+  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0,stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -15,7 +15,7 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t 
   device_theCellNeighbors_ = Traits::template make_unique<CAConstants::CellNeighborsVector>(stream);
   device_theCellTracks_ = Traits::template make_unique<CAConstants::CellTracksVector>(stream);
 
-#ifdef  GPU_DEBUG
+#ifdef GPU_DEBUG
   std::cout << "Allocation for tuple building. N hits " << nHits << std::endl;
 #endif
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -34,6 +34,6 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   } else {
     *device_nCells_ = 0;
   }
-  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr,0,stream);
-  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0,stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, stream);
+  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0, stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -34,6 +34,6 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   } else {
     *device_nCells_ = 0;
   }
-  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, stream);
-  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0, stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, nullptr, 0,stream);
+  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0, nullptr, 0,stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -34,7 +34,6 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   } else {
     *device_nCells_ = 0;
   }
-  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, nullptr, 0, stream);
-  cms::cuda::launchZero(
-      device_hitToTuple_.get(), nullptr, 0, nullptr, 0, stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(device_tupleMultiplicity_.get(), stream);
+  cms::cuda::launchZero(device_hitToTuple_.get(), stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -34,6 +34,7 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   } else {
     *device_nCells_ = 0;
   }
-  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, nullptr, 0,stream);
-  cms::cuda::launchZero(device_hitToTuple_.get(), nullptr, 0, nullptr, 0,stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(device_tupleMultiplicity_.get(), nullptr, 0, nullptr, 0, stream);
+  cms::cuda::launchZero(
+      device_hitToTuple_.get(), nullptr, 0, nullptr, 0, stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -15,10 +15,10 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t 
   device_theCellNeighbors_ = Traits::template make_unique<CAConstants::CellNeighborsVector>(stream);
   device_theCellTracks_ = Traits::template make_unique<CAConstants::CellTracksVector>(stream);
 
-  nHits++; // storage requires one more counter;
-  assert(nHits>0);
+  nHits++;  // storage requires one more counter;
+  assert(nHits > 0);
   device_hitToTuple_ = Traits::template make_unique<HitToTuple>(stream);
-  device_hitToTupleStorage_ = Traits::template make_unique<HitToTuple::Counter[]>(nHits,stream);
+  device_hitToTupleStorage_ = Traits::template make_unique<HitToTuple::Counter[]>(nHits, stream);
   hitToTupleView_.assoc = device_hitToTuple_.get();
   hitToTupleView_.offStorage = device_hitToTupleStorage_.get();
   hitToTupleView_.offSize = nHits;
@@ -32,9 +32,7 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t 
   device_nCells_ = (uint32_t*)(device_storage_.get() + 2);
 
   // FIXME: consider collapsing these 3 in one adhoc kernel
-  if
-      constexpr
-      (std::is_same<Traits, cms::cudacompat::GPUTraits>::value) {
+  if constexpr (std::is_same<Traits, cms::cudacompat::GPUTraits>::value) {
     cudaCheck(cudaMemsetAsync(device_nCells_, 0, sizeof(uint32_t), stream));
   } else {
     *device_nCells_ = 0;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsAlloc.h
@@ -4,9 +4,9 @@
 
 template <>
 #ifdef __CUDACC__
-void CAHitNtupletGeneratorKernelsGPU::allocateOnGPU(cudaStream_t stream) {
+void CAHitNtupletGeneratorKernelsGPU::allocateOnGPU(int32_t nHits, cudaStream_t stream) {
 #else
-void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
+void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(int32_t nHits, cudaStream_t stream) {
 #endif
   //////////////////////////////////////////////////////////
   // ALLOCATIONS FOR THE INTERMEDIATE RESULTS (STAYS ON WORKER)
@@ -15,7 +15,13 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   device_theCellNeighbors_ = Traits::template make_unique<CAConstants::CellNeighborsVector>(stream);
   device_theCellTracks_ = Traits::template make_unique<CAConstants::CellTracksVector>(stream);
 
+  nHits++; // storage requires one more counter;
+  assert(nHits>0);
   device_hitToTuple_ = Traits::template make_unique<HitToTuple>(stream);
+  device_hitToTupleStorage_ = Traits::template make_unique<HitToTuple::Counter[]>(nHits,stream);
+  hitToTupleView_.assoc = device_hitToTuple_.get();
+  hitToTupleView_.offStorage = device_hitToTupleStorage_.get();
+  hitToTupleView_.offSize = nHits;
 
   device_tupleMultiplicity_ = Traits::template make_unique<TupleMultiplicity>(stream);
 
@@ -25,15 +31,14 @@ void CAHitNtupletGeneratorKernelsCPU::allocateOnGPU(cudaStream_t stream) {
   device_hitToTuple_apc_ = (cms::cuda::AtomicPairCounter*)device_storage_.get() + 1;
   device_nCells_ = (uint32_t*)(device_storage_.get() + 2);
 
+  // FIXME: consider collapsing these 3 in one adhoc kernel
   if
-#ifndef __CUDACC__
       constexpr
-#endif
       (std::is_same<Traits, cms::cudacompat::GPUTraits>::value) {
     cudaCheck(cudaMemsetAsync(device_nCells_, 0, sizeof(uint32_t), stream));
   } else {
     *device_nCells_ = 0;
   }
   cms::cuda::launchZero(device_tupleMultiplicity_.get(), stream);
-  cms::cuda::launchZero(device_hitToTuple_.get(), stream);  // we may wish to keep it in the edm...
+  cms::cuda::launchZero(hitToTupleView_, stream);  // we may wish to keep it in the edm...
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -5,7 +5,6 @@
 // #define NTUPLE_DEBUG
 // #define GPU_DEBUG
 
-
 #include <cmath>
 #include <cstdint>
 
@@ -87,8 +86,8 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
       printf("cellNeighbors overflow\n");
     if (cellTracks && cellTracks->full())
       printf("cellTracks overflow\n");
-    if (int(hitToTuple->nOnes())<nHits) 
-      printf("ERROR hitToTuple  overflow %d %d\n",hitToTuple->nOnes(),nHits);
+    if (int(hitToTuple->nOnes()) < nHits)
+      printf("ERROR hitToTuple  overflow %d %d\n", hitToTuple->nOnes(), nHits);
   }
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -195,6 +195,12 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
   }
   kernels.classifyTuples(hits_d, soa, stream);
 
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+  std::cout << "finished building pixel tracks on GPU" << std::endl;
+#endif
+
   return tracks;
 }
 
@@ -228,9 +234,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
   kernels.classifyTuples(hits_d, soa, nullptr);
 
 #ifdef GPU_DEBUG
-  cudaDeviceSynchronize();
-  cudaCheck(cudaGetLastError());
-  std::cout << "finished building pixel tracks" << std::endl;
+  std::cout << "finished building pixel tracks on CPU" << std::endl;
 #endif
 
   return tracks;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -178,7 +178,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
   CAHitNtupletGeneratorKernelsGPU kernels(m_params);
   kernels.counters_ = m_counters;
 
-  kernels.allocateOnGPU(stream);
+  kernels.allocateOnGPU(hits_d.nHits(),stream);
 
   kernels.buildDoublets(hits_d, stream);
   kernels.launchKernels(hits_d, soa, stream);
@@ -204,7 +204,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
 
   CAHitNtupletGeneratorKernelsCPU kernels(m_params);
   kernels.counters_ = m_counters;
-  kernels.allocateOnGPU(nullptr);
+  kernels.allocateOnGPU(hits_d.nHits(),nullptr);
 
   kernels.buildDoublets(hits_d, nullptr);
   kernels.launchKernels(hits_d, soa, nullptr);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -178,7 +178,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuplesAsync(TrackingRecH
   CAHitNtupletGeneratorKernelsGPU kernels(m_params);
   kernels.counters_ = m_counters;
 
-  kernels.allocateOnGPU(hits_d.nHits(),stream);
+  kernels.allocateOnGPU(hits_d.nHits(), stream);
 
   kernels.buildDoublets(hits_d, stream);
   kernels.launchKernels(hits_d, soa, stream);
@@ -204,7 +204,7 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
 
   CAHitNtupletGeneratorKernelsCPU kernels(m_params);
   kernels.counters_ = m_counters;
-  kernels.allocateOnGPU(hits_d.nHits(),nullptr);
+  kernels.allocateOnGPU(hits_d.nHits(), nullptr);
 
   kernels.buildDoublets(hits_d, nullptr);
   kernels.launchKernels(hits_d, soa, nullptr);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -2,6 +2,8 @@
 // Original Author: Felice Pantaleo, CERN
 //
 
+// #define GPU_DEBUG
+
 #include <array>
 #include <cassert>
 #include <functional>
@@ -224,6 +226,12 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
   }
 
   kernels.classifyTuples(hits_d, soa, nullptr);
+
+#ifdef GPU_DEBUG
+  cudaDeviceSynchronize();
+  cudaCheck(cudaGetLastError());
+  std::cout << "finished building pixel tracks" << std::endl;
+#endif
 
   return tracks;
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/RiemannFitOnGPU.h
@@ -51,7 +51,7 @@ __global__ void kernelFastFit(Tuples const *__restrict__ foundNtuplets,
 
     // get it from the ntuple container (one to one to helix)
     auto tkid = *(tupleMultiplicity->begin(nHits) + tuple_idx);
-    assert(tkid < foundNtuplets->nbins());
+    assert(tkid < foundNtuplets->nOnes());
 
     assert(foundNtuplets->size(tkid) == nHits);
 


### PR DESCRIPTION
This is "step1&2" and makes LocalReco independent from the size of the event and tuple-making independent of the number of hits.
Some of the containers used by the CA will remain of fixed size (cannot be extended during the pattern recognition).

In a third step phase1 and phase2 will be still kept separate (fixed number of modules, separate geometries etc)
even if fully configurable at runtime.

tested. no regression. even timing seems ok.

