### PR TITLE
Implement comments for Patatrack integration - ECAL local reconstruction (7/N) #31719 

### DIFF
--- a/CUDADataFormats/EcalRecHitSoA/src/classes_def.xml
+++ b/CUDADataFormats/EcalRecHitSoA/src/classes_def.xml
@@ -9,12 +9,12 @@
     <class name="edm::Wrapper<cms::cuda::Product<ecal::RecHit<calo::common::ViewStoragePolicy>>>" persistent="false"/>
     <class name="edm::Wrapper<cms::cuda::Product<ecal::RecHit<calo::common::DevStoragePolicy>>>" persistent="false"/>
         
-    <class name="ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>"/>
-    <class name="edm::Wrapper<ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>>"/>
-    <class name="ecal::RecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>"/>
-    <class name="edm::Wrapper<ecal::RecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>>"/>
-    <class name="ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<std::allocator>>"/>
-    <class name="edm::Wrapper<ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<std::allocator>>>"/>
-    <class name="ecal::RecHit<calo::common::VecStoragePolicy<std::allocator>>"/>
-    <class name="edm::Wrapper<ecal::RecHit<calo::common::VecStoragePolicy<std::allocator>>>"/>
+    <class name="ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>" persistent="false"/>
+    <class name="edm::Wrapper<ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>>" persistent="false"/>
+    <class name="ecal::RecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>" persistent="false"/>
+    <class name="edm::Wrapper<ecal::RecHit<calo::common::VecStoragePolicy<calo::common::CUDAHostAllocatorAlias>>>" persistent="false"/>
+    <class name="ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<std::allocator>>" persistent="false"/>
+    <class name="edm::Wrapper<ecal::UncalibratedRecHit<calo::common::VecStoragePolicy<std::allocator>>>" persistent="false"/>
+    <class name="ecal::RecHit<calo::common::VecStoragePolicy<std::allocator>>" persistent="false"/>
+    <class name="edm::Wrapper<ecal::RecHit<calo::common::VecStoragePolicy<std::allocator>>>" persistent="false"/>
 </lcgdict>

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigiGPU.cc
@@ -116,7 +116,6 @@ void EcalRawToDigiGPU::acquire(edm::Event const& event,
   uint32_t currentCummOffset = 0;
   uint32_t counter = 0;
   for (auto const& fed : fedsToUnpack_) {
-    //std::cout << "fed: " << fed << std::endl;
     auto const& data = rawDataHandle->FEDData(fed);
     auto const nbytes = data.size();
 
@@ -145,9 +144,6 @@ void EcalRawToDigiGPU::produce(edm::Event& event, edm::EventSetup const& setup) 
   // get the number of channels
   outputGPU_.digisEB.size = outputCPU_.nchannels[0];
   outputGPU_.digisEE.size = outputCPU_.nchannels[1];
-
-  //ecal::DigisCollection digisEB{outputGPU_.idsEB, outputGPU_.samplesEB, nchannelsEB};
-  //ecal::DigisCollection digisEE{outputGPU_.idsEE, outputGPU_.samplesEE, nchannelsEE};
 
   ctx.emplace(event, digisEBToken_, std::move(outputGPU_.digisEB));
   ctx.emplace(event, digisEEToken_, std::move(outputGPU_.digisEE));

--- a/EventFilter/EcalRawToDigi/plugins/UnpackGPU.cu
+++ b/EventFilter/EcalRawToDigi/plugins/UnpackGPU.cu
@@ -130,9 +130,6 @@ namespace ecal {
       // indices
       auto const ifed = blockIdx.x;
 
-      // FIXME: use only the very first fed
-      //if (ifed!=10) return;
-
       // offset in bytes
       auto const offset = offsets[ifed];
       // fed id
@@ -143,9 +140,6 @@ namespace ecal {
       auto* samples = isBarrel ? samplesEB : samplesEE;
       auto* ids = isBarrel ? idsEB : idsEE;
       auto* pChannelsCounter = isBarrel ? &pChannelsCounterEBEE[0] : &pChannelsCounterEBEE[1];
-
-      // FIXME: debugging
-      //printf("ifed = %u fed = %d offset = %u size = %u\n", ifed, fed, offset, size);
 
       // offset to the right raw buffer
       uint64_t const* buffer = reinterpret_cast<uint64_t const*>(data + offset);
@@ -225,7 +219,6 @@ namespace ecal {
           sampleValues[7] = wdata2 & 0x3fff;
           sampleValues[8] = (wdata2 >> 16) & 0x3fff;
           sampleValues[9] = (wdata2 >> 32) & 0x3fff;
-          //printf("stripid = %u xtalid = %u\n", stripid, xtalid);
 
           // check gain
           bool isSaturation = true;

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
@@ -103,14 +103,6 @@ namespace ecal {
         auto const hashedId = isBarrel ? ecal::reconstruction::hashedIndexEB(did.rawId())
                                        : offsetForHashes + ecal::reconstruction::hashedIndexEE(did.rawId());
 
-        //
-        // pulse shape template
-        /*
-        for (int isample=sample; isample<EcalPulseShape::TEMPLATESAMPLES; 
-            isample+=nsamples)
-            shapes_out[ch](isample + 7) = shapes_in[hashedId].pdfval[isample];
-            */
-
         // will be used in the future for setting state
         auto const rmsForChecking = rms_x12[hashedId];
 
@@ -141,7 +133,6 @@ namespace ecal {
 
         //
         // unrolled reductions
-        // TODO
         //
         if (sample < 5) {
           shr_hasSwitchToGain6[threadIdx.x] =
@@ -275,7 +266,8 @@ namespace ecal {
 
             // if saturation is in the max sample and not in the first 5
             if (!saturated_before_max && shr_hasSwitchToGain0[threadMax])
-              energies[inputCh] = 49140;  // 4095 * 12
+              energies[inputCh] = 49140;  // 4095 * 12 (maximum ADC range * MultiGainPreAmplifier (MGPA) gain)
+                                          // This is the actual maximum range that is set when we saturate.
                                           //---- AM FIXME : no pedestal subtraction???
                                           //It should be "(4095. - pedestal) * gainratio"
 
@@ -385,17 +377,11 @@ namespace ecal {
 
           // non-divergent branches
           if (gainidx == 0)
-            //noise_value = rms_x12[ch]*rms_x12[ch]*noisecorrs[0](ty, tx);
             noise_value = rms_x12[hashedId] * rms_x12[hashedId] * G12SamplesCorrelation[vidx];
           if (gainidx == 1)
-            //                noise_value = gain12Over6[ch]*gain12Over6[ch] * rms_x6[ch]*rms_x6[ch]
-            //                    *noisecorrs[1](ty, tx);
             noise_value = gain12Over6[hashedId] * gain12Over6[hashedId] * rms_x6[hashedId] * rms_x6[hashedId] *
                           G6SamplesCorrelation[vidx];
           if (gainidx == 2)
-            //                noise_value = gain12Over6[ch]*gain12Over6[ch]
-            //                    * gain6Over1[ch]*gain6Over1[ch] * rms_x1[ch]*rms_x1[ch]
-            //                    * noisecorrs[2](ty, tx);
             noise_value = gain12Over6[hashedId] * gain12Over6[hashedId] * gain6Over1[hashedId] * gain6Over1[hashedId] *
                           rms_x1[hashedId] * rms_x1[hashedId] * G1SamplesCorrelation[vidx];
           if (!dynamicPedestal && addPedestalUncertainty > 0.f)
@@ -404,22 +390,16 @@ namespace ecal {
           int gainidx = 0;
           char mask = gainidx;
           int pedestal = gainNoise[ch][ty] == mask ? 1 : 0;
-          //            noise_value += /* gainratio is 1*/ rms_x12[ch]*rms_x12[ch]
-          //                *pedestal*noisecorrs[0](ty, tx);
-          noise_value +=
-              /* gainratio is 1*/ rms_x12[hashedId] * rms_x12[hashedId] * pedestal * G12SamplesCorrelation[vidx];
+          noise_value += rms_x12[hashedId] * rms_x12[hashedId] * pedestal * G12SamplesCorrelation[vidx]; // gainratio is 1
           // non-divergent branch
           if (!dynamicPedestal && addPedestalUncertainty > 0.f) {
-            noise_value += /* gainratio is 1 */
-                addPedestalUncertainty * addPedestalUncertainty * pedestal;
+            noise_value += addPedestalUncertainty * addPedestalUncertainty * pedestal; // gainratio is 1
           }
 
           //
           gainidx = 1;
           mask = gainidx;
           pedestal = gainNoise[ch][ty] == mask ? 1 : 0;
-          //            noise_value += gain12Over6[ch]*gain12Over6[ch]
-          //                *rms_x6[ch]*rms_x6[ch]*pedestal*noisecorrs[1](ty, tx);
           noise_value += gain12Over6[hashedId] * gain12Over6[hashedId] * rms_x6[hashedId] * rms_x6[hashedId] *
                          pedestal * G6SamplesCorrelation[vidx];
           // non-divergent branch
@@ -433,8 +413,6 @@ namespace ecal {
           mask = gainidx;
           pedestal = gainNoise[ch][ty] == mask ? 1 : 0;
           float tmp = gain6Over1[hashedId] * gain12Over6[hashedId];
-          //            noise_value += tmp*tmp * rms_x1[ch]*rms_x1[ch]
-          //                *pedestal*noisecorrs[2](ty, tx);
           noise_value += tmp * tmp * rms_x1[hashedId] * rms_x1[hashedId] * pedestal * G1SamplesCorrelation[vidx];
           // non-divergent branch
           if (!dynamicPedestal && addPedestalUncertainty > 0.f) {
@@ -454,9 +432,6 @@ namespace ecal {
       }
 
       // pulse matrix
-      //    int const bx = tx - 5; // -5 -4 -3 ... 3 4
-      //    int bx = (*bxs)(tx);
-      //    int const offset = 7 - 3 - bx;
       int const posToAccess = 9 - tx + ty;  // see cpu for reference
       float const value = posToAccess >= 7 ? pulse_shape[hashedId].pdfval[posToAccess - 7] : 0;
       pulse_matrix[ch](ty, tx) = value;
@@ -473,7 +448,7 @@ namespace ecal {
       // indices
       int const tx = threadIdx.x + blockIdx.x * blockDim.x;
       int const ch = tx / nsamples;
-      int const iii = tx % nsamples;  // this is to address activeBXs
+      int const sampleidx = tx % nsamples;  // this is to address activeBXs
 
       if (ch >= nchannels)
         return;
@@ -486,11 +461,11 @@ namespace ecal {
       // configure shared memory and cp into it
       extern __shared__ char smem[];
       SampleVector::Scalar* values = reinterpret_cast<SampleVector::Scalar*>(smem);
-      values[threadIdx.x] = amplitudes[ch](iii);
+      values[threadIdx.x] = amplitudes[ch](sampleidx);
       __syncthreads();
 
       // get the sample for this bx
-      auto const sample = static_cast<int>(activeBXs[ch](iii)) + 5;
+      auto const sample = static_cast<int>(activeBXs[ch](sampleidx)) + 5;
 
       // store back to global
       amplitudes[ch](sample) = values[threadIdx.x];

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <limits>
 
 #include <cuda.h>

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <limits>
 
 #include <cuda.h>
@@ -359,7 +360,7 @@ namespace ecal {
       auto const* G1SamplesCorrelation = isBarrel ? G1SamplesCorrelationEB : G1SamplesCorrelationEE;
       bool tmp2 = isSaturated[ch];
       bool hasGainSwitch = tmp0 || tmp1 || tmp2;
-      auto const vidx = ecal::abs(ty - tx);
+      auto const vidx = std::abs(ty - tx);
 
       // non-divergent branch for all threads per block
       if (hasGainSwitch) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationCommonKernels.cu
@@ -103,6 +103,9 @@ namespace ecal {
         auto const hashedId = isBarrel ? ecal::reconstruction::hashedIndexEB(did.rawId())
                                        : offsetForHashes + ecal::reconstruction::hashedIndexEE(did.rawId());
 
+        //
+        // pulse shape template
+
         // will be used in the future for setting state
         auto const rmsForChecking = rms_x12[hashedId];
 
@@ -390,7 +393,8 @@ namespace ecal {
           int gainidx = 0;
           char mask = gainidx;
           int pedestal = gainNoise[ch][ty] == mask ? 1 : 0;
-          noise_value += rms_x12[hashedId] * rms_x12[hashedId] * pedestal * G12SamplesCorrelation[vidx]; // gainratio is 1
+          //            NB: gainratio is 1, that is why it does not appear in the formula
+          noise_value += rms_x12[hashedId] * rms_x12[hashedId] * pedestal * G12SamplesCorrelation[vidx];
           // non-divergent branch
           if (!dynamicPedestal && addPedestalUncertainty > 0.f) {
             noise_value += addPedestalUncertainty * addPedestalUncertainty * pedestal; // gainratio is 1

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
@@ -17,64 +17,6 @@
 namespace ecal {
   namespace multifit {
 
-    void eigen_solve_submatrix(SampleMatrix& mat, SampleVector& invec, SampleVector& outvec, unsigned NP) {
-      using namespace Eigen;
-      switch (NP) {  // pulse matrix is always square.
-        case 10: {
-          Matrix<SampleMatrix::Scalar, 10, 10> temp = mat.topLeftCorner<10, 10>();
-          outvec.head<10>() = temp.ldlt().solve(invec.head<10>());
-          break;
-        }
-        case 9: {
-          Matrix<SampleMatrix::Scalar, 9, 9> temp = mat.topLeftCorner<9, 9>();
-          outvec.head<9>() = temp.ldlt().solve(invec.head<9>());
-          break;
-        }
-        case 8: {
-          Matrix<SampleMatrix::Scalar, 8, 8> temp = mat.topLeftCorner<8, 8>();
-          outvec.head<8>() = temp.ldlt().solve(invec.head<8>());
-          break;
-        }
-        case 7: {
-          Matrix<SampleMatrix::Scalar, 7, 7> temp = mat.topLeftCorner<7, 7>();
-          outvec.head<7>() = temp.ldlt().solve(invec.head<7>());
-          break;
-        }
-        case 6: {
-          Matrix<SampleMatrix::Scalar, 6, 6> temp = mat.topLeftCorner<6, 6>();
-          outvec.head<6>() = temp.ldlt().solve(invec.head<6>());
-          break;
-        }
-        case 5: {
-          Matrix<SampleMatrix::Scalar, 5, 5> temp = mat.topLeftCorner<5, 5>();
-          outvec.head<5>() = temp.ldlt().solve(invec.head<5>());
-          break;
-        }
-        case 4: {
-          Matrix<SampleMatrix::Scalar, 4, 4> temp = mat.topLeftCorner<4, 4>();
-          outvec.head<4>() = temp.ldlt().solve(invec.head<4>());
-          break;
-        }
-        case 3: {
-          Matrix<SampleMatrix::Scalar, 3, 3> temp = mat.topLeftCorner<3, 3>();
-          outvec.head<3>() = temp.ldlt().solve(invec.head<3>());
-          break;
-        }
-        case 2: {
-          Matrix<SampleMatrix::Scalar, 2, 2> temp = mat.topLeftCorner<2, 2>();
-          outvec.head<2>() = temp.ldlt().solve(invec.head<2>());
-          break;
-        }
-        case 1: {
-          Matrix<SampleMatrix::Scalar, 1, 1> temp = mat.topLeftCorner<1, 1>();
-          outvec.head<1>() = temp.ldlt().solve(invec.head<1>());
-          break;
-        }
-        default:
-          return;
-      }
-    }
-
     template <typename MatrixType>
     __device__ __forceinline__ bool update_covariance(EcalPulseCovariance const& pulse_covariance,
                                                       MatrixType& inverse_cov,

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
@@ -1,4 +1,4 @@
-#include <iostream>
+#include <cmath>
 #include <limits>
 
 #include <cuda.h>
@@ -297,7 +297,7 @@ namespace ecal {
           auto deltachi2 = chi2_now - chi2;
           chi2 = chi2_now;
 
-          if (ecal::abs(deltachi2) < 1e-3)
+          if (std::abs(deltachi2) < 1e-3)
             break;
 
           //---- AM: TEST

--- a/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/AmplitudeComputationKernels.cu
@@ -89,7 +89,7 @@ namespace ecal {
       DataType* shrAtAStorage = reinterpret_cast<DataType*>(shrmem) +
                                 calo::multifit::MapSymM<DataType, NPULSES>::total * (threadIdx.x + blockDim.x);
 
-      // FIXME: remove eitehr idx or ch -> they are teh same thing
+      // channel
       int idx = threadIdx.x + blockDim.x * blockIdx.x;
 
 // ref the right ptr
@@ -99,14 +99,13 @@ namespace ecal {
       ARRANGE(energies);
 #undef ARRANGE
 
-      auto const ch = idx;
       if (idx < nchannels) {
         if (static_cast<MinimizationState>(acState[idx]) == MinimizationState::Precomputed)
           return;
 
         // get the hash
-        int const inputCh = ch >= offsetForInputs ? ch - offsetForInputs : ch;
-        auto const* dids = ch >= offsetForInputs ? dids_ee : dids_eb;
+        int const inputCh = idx >= offsetForInputs ? idx - offsetForInputs : idx;
+        auto const* dids = idx >= offsetForInputs ? dids_ee : dids_eb;
         auto const did = DetId{dids[inputCh]};
         auto const isBarrel = did.subdetId() == EcalBarrel;
         auto const hashedId = isBarrel ? ecal::reconstruction::hashedIndexEB(did.rawId())

--- a/RecoLocalCalo/EcalRecProducers/plugins/Common.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/Common.h
@@ -1,14 +1,7 @@
 #ifndef RecoLocalCalo_EcalRecProducers_plugins_Common_h
 #define RecoLocalCalo_EcalRecProducers_plugins_Common_h
 
-#include <cassert>
-#include <chrono>
-#include <cmath>
-#include <cstdint>
-#include <iostream>
-
-#include <cuda.h>
-#include <cuda_runtime.h>
+#include <algorithm>
 
 // a workaround for std::abs not being a constexpr function
 namespace ecal {
@@ -27,20 +20,5 @@ namespace ecal {
   }  // namespace mgpa
 
 }  // namespace ecal
-
-template <typename T>
-struct DurationMeasurer {
-  DurationMeasurer(std::string const& msg) : msg_{msg}, start_{std::chrono::high_resolution_clock::now()} {}
-
-  ~DurationMeasurer() {
-    auto end = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<T>(end - start_).count();
-    std::cout << msg_ << "\nduration = " << duration << std::endl;
-  }
-
-private:
-  std::string msg_;
-  std::chrono::high_resolution_clock::time_point start_;
-};
 
 #endif  // RecoLocalCalo_EcalRecProducers_plugins_Common_h

--- a/RecoLocalCalo/EcalRecProducers/plugins/Common.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/Common.h
@@ -1,15 +1,8 @@
 #ifndef RecoLocalCalo_EcalRecProducers_plugins_Common_h
 #define RecoLocalCalo_EcalRecProducers_plugins_Common_h
 
-#include <algorithm>
-
 // a workaround for std::abs not being a constexpr function
 namespace ecal {
-
-  template <typename T>
-  constexpr T abs(T const& value) {
-    return ::std::max(value, -value);
-  }
 
   // temporary
   namespace mgpa {

--- a/RecoLocalCalo/EcalRecProducers/plugins/DeclsForKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/DeclsForKernels.h
@@ -227,8 +227,6 @@ namespace ecal {
       EcalMultifitParametersGPU::Product const& multifitParameters;
     };
 
-    //*/
-
     struct xyz {
       int x, y, z;
     };
@@ -269,7 +267,6 @@ namespace ecal {
       float EBLaserMAX;
       float EELaserMAX;
 
-      //       std::vector<std::vector<uint32_t> > v_DB_reco_flags;
       int* expanded_v_DB_reco_flags;
       uint32_t* expanded_Sizes_v_DB_reco_flags;
       uint32_t* expanded_flagbit_v_DB_reco_flags;
@@ -278,16 +275,12 @@ namespace ecal {
       uint32_t flagmask;
       uint32_t maxNumberHitsEB;
       uint32_t maxNumberHitsEE;
-
-      //
-      //       bool shouldRunTimingComputation;
     };
 
     struct EventOutputDataGPU {
       RecHit<::calo::common::DevStoragePolicy> recHitsEB, recHitsEE;
 
       void allocate(ConfigurationParameters const& configParameters, cudaStream_t cudaStream) {
-        //      void allocate(uint32_t size) {
         //---- configParameters -> needed only to decide if to save the timing information or not
         auto const sizeEB = configParameters.maxNumberHitsEB;
         recHitsEB.energy = cms::cuda::make_device_unique<::ecal::reco::StorageScalarType[]>(sizeEB, cudaStream);
@@ -317,13 +310,12 @@ namespace ecal {
       EcalRechitADCToGeVConstantGPU::Product const& ADCToGeV;
       EcalIntercalibConstantsGPU::Product const& Intercalib;
       EcalRechitChannelStatusGPU::Product const& ChannelStatus;
-      //
+
       EcalLaserAPDPNRatiosGPU::Product const& LaserAPDPNRatios;
       EcalLaserAPDPNRatiosRefGPU::Product const& LaserAPDPNRatiosRef;
       EcalLaserAlphasGPU::Product const& LaserAlphas;
       EcalLinearCorrectionsGPU::Product const& LinearCorrections;
-      //
-      //
+
       uint32_t offsetForHashes;
     };
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalCPURecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalCPURecHitProducer.cc
@@ -1,9 +1,11 @@
+//#define ECAL_RECO_CUDA_DEBUG
+
+#ifdef ECAL_RECO_CUDA_DEBUG
 #include <iostream>
+#endif
 
 // framework
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,6 +20,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 #include "CUDADataFormats/EcalRecHitSoA/interface/EcalRecHit.h"
+
 
 class EcalCPURecHitProducer : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
@@ -72,8 +75,10 @@ void EcalCPURecHitProducer::acquire(edm::Event const& event,
   recHitsEB_.resize(ebRecHits.size);
   recHitsEE_.resize(eeRecHits.size);
 
-  //     std::cout << " [EcalCPURecHitProducer::acquire] ebRecHits.size = " << ebRecHits.size << std::endl;
-  //     std::cout << " [EcalCPURecHitProducer::acquire] eeRecHits.size = " << eeRecHits.size << std::endl;
+#ifdef ECAL_RECO_CUDA_DEBUG
+  std::cout << " [EcalCPURecHitProducer::acquire] ebRecHits.size = " << ebRecHits.size << std::endl;
+  std::cout << " [EcalCPURecHitProducer::acquire] eeRecHits.size = " << eeRecHits.size << std::endl;
+#endif
 
   // enqeue transfers
   cudaCheck(cudaMemcpyAsync(recHitsEB_.did.data(),
@@ -134,19 +139,19 @@ void EcalCPURecHitProducer::acquire(edm::Event const& event,
                             cudaMemcpyDeviceToHost,
                             ctx.stream()));
 
-  //     for (unsigned int ieb = 0; ieb <  ebRecHits.size ; ieb++) {
-  //       if (recHitsEB_.extra[ieb] != 0 ) std::cout << " [ " << ieb << " :: " << ebRecHits.size << " ] [ " << recHitsEB_.did[ieb] << " ] eb extra = " << recHitsEB_.extra[ieb] << std::endl;
-  //     }
+#ifdef ECAL_RECO_CUDA_DEBUG
+  for (unsigned int ieb = 0; ieb <  ebRecHits.size ; ieb++) {
+    if (recHitsEB_.extra[ieb] != 0 ) std::cout << " [ " << ieb << " :: " << ebRecHits.size << " ] [ " << recHitsEB_.did[ieb] << " ] eb extra = " << recHitsEB_.extra[ieb] << std::endl;
+  }
 
-  //
-  //     for (unsigned int ieb = 0; ieb <  ebRecHits.size ; ieb++) {
-  //       if (recHitsEB_.energy[ieb] != 0 ) std::cout << " [ " << ieb << " :: " << ebRecHits.size << " ] [ " << recHitsEB_.did[ieb] << " ] eb energy = " << recHitsEB_.energy[ieb] << std::endl;
-  //     }
-  //
-  //     for (unsigned int iee = 0; iee <  eeRecHits.size ; iee++) {
-  //       if (recHitsEE_.energy[iee] != 0 ) std::cout << " [ " << iee << " :: " << eeRecHits.size << " ] [ " << recHitsEE_.did[iee] << " ] ee energy = " << recHitsEE_.energy[iee] << std::endl;
-  //     }
-  //
+  for (unsigned int ieb = 0; ieb <  ebRecHits.size ; ieb++) {
+    if (recHitsEB_.energy[ieb] != 0 ) std::cout << " [ " << ieb << " :: " << ebRecHits.size << " ] [ " << recHitsEB_.did[ieb] << " ] eb energy = " << recHitsEB_.energy[ieb] << std::endl;
+  }
+
+  for (unsigned int iee = 0; iee <  eeRecHits.size ; iee++) {
+    if (recHitsEE_.energy[iee] != 0 ) std::cout << " [ " << iee << " :: " << eeRecHits.size << " ] [ " << recHitsEE_.did[iee] << " ] ee energy = " << recHitsEE_.energy[iee] << std::endl;
+  }
+#endif
 }
 
 void EcalCPURecHitProducer::produce(edm::Event& event, edm::EventSetup const& setup) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalCPUUncalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalCPUUncalibRecHitProducer.cc
@@ -2,8 +2,6 @@
 
 // framework
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEDProducer.h"
-//#include "HeterogeneousCore/Producer/interface/HeterogeneousEvent.h"
 
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
@@ -47,8 +45,7 @@ void EcalCPUUncalibRecHitProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<std::string>("recHitsOutLabelEE", "EcalUncalibRecHitsEE");
   desc.add<bool>("containsTimingInformation", false);
 
-  std::string label = "ecalCPUUncalibRecHitProducer";
-  confDesc.add(label, desc);
+  confDesc.add("ecalCPUUncalibRecHitProducer", desc);
 }
 
 EcalCPUUncalibRecHitProducer::EcalCPUUncalibRecHitProducer(const edm::ParameterSet& ps)

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
@@ -30,7 +30,7 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  edm::ParameterSet const& pset_;
+  edm::ParameterSet const pset_;
 };
 
 EcalMultifitParametersGPUESProducer::EcalMultifitParametersGPUESProducer(edm::ParameterSet const& pset) : pset_{pset} {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalMultifitParametersGPUESProducer.cc
@@ -1,5 +1,4 @@
 #include <array>
-#include <iostream>
 #include <tuple>
 #include <utility>
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.cu
@@ -139,10 +139,6 @@ namespace ecal {
       //
 
       for (int ch = threadIdx.x + blockDim.x * blockIdx.x; ch < nchannels; ch += blockDim.x * gridDim.x) {
-        //       int ch = threadIdx.x + blockDim.x*blockIdx.x;
-
-        //       if (ch < nchannels) {
-
         bool isEndcap = (ch >= nChannelsBarrel);
 
         int const inputCh = isEndcap ? ch - nChannelsBarrel : ch;
@@ -166,8 +162,6 @@ namespace ecal {
         // first EB and then EE
 
         ::ecal::reco::StorageScalarType const* amplitude = isEndcap ? amplitude_ee : amplitude_eb;
-
-        //::ecal::reco::StorageScalarType const* time_in = isEndcap ? time_ee : time_eb;
 
         ::ecal::reco::StorageScalarType const* chi2_in = isEndcap ? chi2_ee : chi2_eb;
 
@@ -401,9 +395,6 @@ namespace ecal {
         value &= ~mask;
         value |= (rawChi2 & ((1U << width) - 1)) << offset;
 
-        //         extra[ch] = value;
-        //
-
         // rawEnergy is actually "error" !!!
         uint32_t rawEnergy = 0;
 
@@ -417,8 +408,6 @@ namespace ecal {
         float amplitudeError_ch = 0.;  // amplitudeError[ch];
 
         if (amplitudeError_ch > 0.001) {
-          //           uint16_t exponent = getPower10(amplitudeError_ch);
-
           static constexpr float p10[] = {1.e-2f, 1.e-1f, 1.f, 1.e1f, 1.e2f, 1.e3f, 1.e4f, 1.e5f, 1.e6f};
           int b = amplitudeError_ch < p10[4] ? 0 : 5;
           for (; b < 9; ++b)
@@ -603,7 +592,6 @@ namespace ecal {
                            cudaStream_t cudaStream) {
       int nchannels = eventInputGPU.ebUncalibRecHits.size + eventInputGPU.eeUncalibRecHits.size;
 
-      //       unsigned int nchannels_per_block = 32;
       unsigned int nchannels_per_block = 16;
       unsigned int threads_min = nchannels_per_block;
       unsigned int blocks_min = (nchannels + threads_min - 1) / threads_min;  // TEST : to be optimized (AM)
@@ -612,11 +600,7 @@ namespace ecal {
       // kernel create rechit
       //
 
-      //       auto const nbytesShared = 2 * threads_min * MapSymM<DataType, SampleVector::RowsAtCompileTime>::total * sizeof(DataType);
-
       kernel_create_ecal_rehit<<<blocks_min, threads_min, 0, cudaStream>>>(
-          //       kernel_create_ecal_rehit <<< blocks_min, threads_min, nbytesShared, cudaStream >>> (
-          //       kernel_create_ecal_rehit <<< blocks_min, threads_min >>> (
           // configuration
           configParameters.ChannelStatusToBeExcluded,
           configParameters.ChannelStatusToBeExcludedSize,

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.cu
@@ -503,10 +503,7 @@ namespace ecal {
           flagBits[inputCh] |= (0x1 << (RecHitFlags::RecHitFlags_kGood));
         }
 
-        if (isBarrel && (lasercalib < EBLaserMIN || lasercalib > EBLaserMAX)) {
-          flagBits[inputCh] |= (0x1 << (RecHitFlags::RecHitFlags_kPoorCalib));
-        }
-        if (!isBarrel && (lasercalib < EELaserMIN || lasercalib > EELaserMAX)) {
+        if ((isBarrel && (lasercalib < EBLaserMIN || lasercalib > EBLaserMAX)) || (!isBarrel && (lasercalib < EELaserMIN || lasercalib > EELaserMAX))) {
           flagBits[inputCh] |= (0x1 << (RecHitFlags::RecHitFlags_kPoorCalib));
         }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitBuilderKernels.h
@@ -80,7 +80,6 @@ namespace ecal {
 
     void create_ecal_rehit(EventInputDataGPU const& eventInputGPU,
                            EventOutputDataGPU& eventOutputGPU,
-                           //     eventDataForScratchGPU_,
                            ConditionsProducts const& conditions,
                            ConfigurationParameters const& configParameters,
                            uint32_t const nChannelsBarrel,

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitConvertGPU2CPUFormat.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitConvertGPU2CPUFormat.cc
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "CUDADataFormats/EcalRecHitSoA/interface/EcalRecHit.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
@@ -61,10 +59,6 @@ void EcalRecHitConvertGPU2CPUFormat::produce(edm::Event& event, edm::EventSetup 
   recHitsCPUEB->reserve(hRecHitsGPUEB.energy.size());
   recHitsCPUEE->reserve(hRecHitsGPUEE.energy.size());
 
-  //
-  //     explicit EcalRecHit(const DetId& id, float energy, float time, uint32_t extra = 0, uint32_t flagBits = 0):
-  //
-
   for (uint32_t i = 0; i < hRecHitsGPUEB.energy.size(); ++i) {
     //
     // Save only if energy is >= 0 !
@@ -79,14 +73,6 @@ void EcalRecHitConvertGPU2CPUFormat::produce(edm::Event& event, edm::EventSetup 
                                  hRecHitsGPUEB.extra[i],
                                  hRecHitsGPUEB.flagBits[i]);
     }
-
-    //       std::cout << " EB :: extra [" << i << "::" << hRecHitsGPUEB.energy.size() << "] = " << hRecHitsGPUEB.extra[i] << std::endl;
-
-    //         (*recHitsCPUEB)[i].setJitterError(hRecHitsGPUEB.timeError[i]);
-    //         auto const offset = i * EcalDataFrame::MAXSAMPLES;
-    //         for (uint32_t sample=0; sample<EcalDataFrame::MAXSAMPLES; ++sample)
-    //             (*recHitsCPUEB)[i].setOutOfTimeAmplitude(
-    //                 sample, hRecHitsGPUEB.energysAll[offset + sample]);
   }
 
   for (uint32_t i = 0; i < hRecHitsGPUEE.energy.size(); ++i) {
@@ -103,14 +89,6 @@ void EcalRecHitConvertGPU2CPUFormat::produce(edm::Event& event, edm::EventSetup 
                                  hRecHitsGPUEE.extra[i],
                                  hRecHitsGPUEE.flagBits[i]);
     }
-
-    //       std::cout << " EE :: extra [" << i << "::" << hRecHitsGPUEE.energy.size() << "] = " << hRecHitsGPUEE.extra[i] << std::endl;
-
-    //         (*recHitsCPUEE)[i].setJitterError(hRecHitsGPUEE.timeError[i]);
-    //         auto const offset = i * EcalDataFrame::MAXSAMPLES;
-    //         for (uint32_t sample=0; sample<EcalDataFrame::MAXSAMPLES; ++sample)
-    //             (*recHitsCPUEE)[i].setOutOfTimeAmplitude(
-    //                 sample, hRecHitsGPUEE.energysAll[offset + sample]);
   }
 
   event.put(std::move(recHitsCPUEB), recHitsLabelCPUEB_);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPUESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPUESProducer.cc
@@ -1,5 +1,4 @@
 #include <array>
-#include <iostream>
 #include <tuple>
 #include <utility>
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPUESProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitParametersGPUESProducer.cc
@@ -30,7 +30,7 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  edm::ParameterSet const& pset_;
+  edm::ParameterSet const pset_;
 };
 
 EcalRecHitParametersGPUESProducer::EcalRecHitParametersGPUESProducer(edm::ParameterSet const& pset) : pset_{pset} {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducerGPU.cc
@@ -163,7 +163,6 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
 
   neb_ = ebUncalibRecHits.size;
   nee_ = eeUncalibRecHits.size;
-  // std::cout << " [EcalRecHitProducerGPU::acquire]  neb_:nee_ = " << neb_ << " : " << nee_ << std::endl;
 
   if ((neb_ > configParameters_.maxNumberHitsEB) || (nee_ > configParameters_.maxNumberHitsEE)) {
     edm::LogError("EcalRecHitProducerGPU")
@@ -210,12 +209,10 @@ void EcalRecHitProducerGPU::acquire(edm::Event const& event,
   ecal::rechit::ConditionsProducts conditions{ADCToGeVConstantProduct,
                                               IntercalibConstantsProduct,
                                               ChannelStatusProduct,
-                                              //
                                               LaserAPDPNRatiosProduct,
                                               LaserAPDPNRatiosRefProduct,
                                               LaserAlphasProduct,
                                               LinearCorrectionsProduct,
-                                              //
                                               IntercalibConstantsHandle_->getOffset()};
 
   // dev mem

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitConvertGPU2CPUFormat.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitConvertGPU2CPUFormat.cc
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
@@ -38,8 +36,7 @@ void EcalUncalibRecHitConvertGPU2CPUFormat::fillDescriptions(edm::ConfigurationD
   desc.add<std::string>("recHitsLabelCPUEB", "EcalUncalibRecHitsEB");
   desc.add<std::string>("recHitsLabelCPUEE", "EcalUncalibRecHitsEE");
 
-  std::string label = "ecalUncalibRecHitConvertGPU2CPUFormat";
-  confDesc.add(label, desc);
+  confDesc.add("ecalUncalibRecHitConvertGPU2CPUFormat", desc);
 }
 
 EcalUncalibRecHitConvertGPU2CPUFormat::EcalUncalibRecHitConvertGPU2CPUFormat(const edm::ParameterSet& ps)

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitMultiFitAlgo_gpu_new.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitMultiFitAlgo_gpu_new.cu
@@ -176,9 +176,6 @@ namespace ecal {
             offsetForInputs);
         cudaCheck(cudaGetLastError());
 
-        //
-        //
-        //
         int sharedBytes = EcalDataFrame::MAXSAMPLES * nchannels_per_block * 4 * sizeof(SampleVector::Scalar);
         auto const threads_nullhypot = threads_1d;
         auto const blocks_nullhypot = blocks_1d;
@@ -226,9 +223,6 @@ namespace ecal {
             offsetForInputs);
         cudaCheck(cudaGetLastError());
 
-        //
-        //
-        //
         auto const threads_findamplchi2 = threads_1d;
         auto const blocks_findamplchi2 = blocks_1d;
         int const sharedBytesFindAmplChi2 = 2 * threads_findamplchi2 * sizeof(SampleVector::Scalar);
@@ -258,9 +252,6 @@ namespace ecal {
                                                                     offsetForInputs);
         cudaCheck(cudaGetLastError());
 
-        //
-        //
-        //
         auto const threads_timecorr = 32;
         auto const blocks_timecorr =
             threads_timecorr > totalChannels ? 1 : (totalChannels + threads_timecorr - 1) / threads_timecorr;
@@ -308,14 +299,6 @@ namespace ecal {
             totalChannels);
         cudaCheck(cudaGetLastError());
       }
-
-      /*
-    cudaEventRecord(end_event, 0);
-    cudaEventSynchronize(end_event);
-    float ms;
-    cudaEventElapsedTime(&ms, start_event, end_event);
-    std::cout << "elapsed time = " << ms << std::endl;
-    */
     }
 
   }  // namespace multifit

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "CUDADataFormats/EcalRecHitSoA/interface/EcalUncalibratedRecHit.h"
 #include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
 #include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
@@ -104,8 +102,7 @@ void EcalUncalibRecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<std::vector<uint32_t>>("kernelMinimizeThreads", {32, 1, 1});
   // ---- default false or true? It was set to true, but at HLT it is false
   desc.add<bool>("shouldRunTimingComputation", false);
-  std::string label = "ecalUncalibRecHitProducerGPU";
-  confDesc.add(label, desc);
+  confDesc.add("ecalUncalibRecHitProducerGPU", desc);
 }
 
 EcalUncalibRecHitProducerGPU::EcalUncalibRecHitProducerGPU(const edm::ParameterSet& ps)

--- a/RecoLocalCalo/EcalRecProducers/plugins/KernelHelpers.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/KernelHelpers.cu
@@ -83,15 +83,7 @@ namespace ecal {
             iz = -1;
           }
           ieta *= iz;
-          //   int iphi_ = iphi;
-          //   if (iphi_ > 360) {
-          //     iphi_ -= 360;
-          //   }
           int ix = ieta - 1;
-          //   int iy = (iphi_ - 1) % 20;
-          //   if (iz == -1) {
-          //     iy = 19 - iy;
-          //   }
 
           return ix;
         }
@@ -101,12 +93,10 @@ namespace ecal {
           if (ieta < 0) {
             iz = -1;
           }
-          //   ieta *= iz;
           int iphi_ = iphi;
           if (iphi_ > 360) {
             iphi_ -= 360;
           }
-          //   int ix = ieta - 1;
           int iy = (iphi_ - 1) % 20;
           if (iz == -1) {
             iy = 19 - iy;
@@ -154,13 +144,8 @@ namespace ecal {
       int ism = idcc - 9;
 
       int iside = side(ieta, (int)(iphi(id)));
-      //   int iside = positiveZ(id) ? 1 : 0;
 
       return (1 + 2 * (ism - 1) + iside);
-      //   return ieta;
-      //   return (int) (iphi(id));
-      //   return idcc;
-      //   return iside;
     }
 
     namespace internal {

--- a/RecoLocalCalo/EcalRecProducers/plugins/TimeComputationKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/TimeComputationKernels.cu
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <limits>
 
 #include <cuda.h>
@@ -42,7 +41,6 @@ namespace ecal {
       // TODO: make sure that this branch plays nicely with __syncthreads inside
       // can there be a deadlock even if the thread is inactive
       if (ch < nchannels) {
-        //
         int sample = tx % nsamples;
 
         // shared mem inits
@@ -82,10 +80,6 @@ namespace ecal {
 
         if (sample == 0) {
           // note, subtract to remove the double counting of sample == 3
-          //s_sum0[ltx] += s_sum0[ltx+1] - s_sum0[ltx+3];
-          //s_sum1[ltx] += s_sum1[ltx+1] - s_sum1[ltx+3];
-          //s_sumA[ltx] += s_sumA[ltx+1] - s_sumA[ltx+3];
-          //s_sumAA[ltx] += s_sumAA[ltx+1] - s_sumAA[ltx+3];
           const auto sum0 = s_sum0[ltx] + s_sum0[ltx + 1] - s_sum0[ltx + 3];
           const auto sum1 = s_sum1[ltx] + s_sum1[ltx + 1] - s_sum1[ltx + 3];
           const auto sumA = s_sumA[ltx] + s_sumA[ltx + 1] - s_sumA[ltx + 3];
@@ -214,13 +208,6 @@ namespace ecal {
       // we will end up with inactive threads which need to be dragged along
       // through the synching point
       //
-      /*
-    bool const condToExit = ch >= nchannels
-        ? true
-        : useless_sample_values[tx_i] 
-          || useless_sample_values[tx_j]
-          || sample_values[tx_i]<=1 || sample_values[tx_j]<=1;
-          */
       bool const condForUselessSamples = useless_sample_values[tx_i] || useless_sample_values[tx_j] ||
                                          sample_values[tx_i] <= 1 || sample_values[tx_j] <= 1;
 
@@ -1100,7 +1087,6 @@ namespace ecal {
           std::sqrt(timeError * timeError + timeConstantTerm * timeConstantTerm * 0.04 * 0.04);  // 0.04 = 1./25.
 
 #ifdef DEBUG_TIME_CORRECTION
-      //    if (gtx == 0) {
       printf("ch = %d timeMax = %f timeError = %f jitter = %f correction = %f\n",
              gtx,
              timeMax,

--- a/RecoLocalCalo/EcalRecProducers/plugins/TimeComputationKernels.cu
+++ b/RecoLocalCalo/EcalRecProducers/plugins/TimeComputationKernels.cu
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <limits>
 
 #include <cuda.h>
@@ -787,7 +788,7 @@ namespace ecal {
         const auto sumFF = shr_sumFF[threadIdx.x] + shr_sumFF[threadIdx.x + 1] - shr_sumFF[threadIdx.x + 3];
 
         const auto denom = sumFF * sum1 - sumF * sumF;
-        const auto condForDenom = sum1 > 0 && ecal::abs(denom) > 1.e-20;
+        const auto condForDenom = sum1 > 0 && std::abs(denom) > 1.e-20;
         const auto amplitudeMax = condForDenom ? (sumAF * sum1 - sumA * sumF) / denom : static_cast<ScalarType>(0.);
 
         // store into global mem

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHitGPU_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHitGPU_cfi.py
@@ -8,19 +8,12 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
     uncalibrecHitsInLabelEB = cms.InputTag("ecalUncalibRecHitProducerGPU","EcalUncalibRecHitsEB"),
     uncalibrecHitsInLabelEE = cms.InputTag("ecalUncalibRecHitProducerGPU","EcalUncalibRecHitsEE"),
           
-    #recHitsLabelEB = cms.string("EcalRecHitsGPUEB"),
-    #recHitsLabelEE = cms.string("EcalRecHitsGPUEE"),
     recHitsLabelEB = cms.string("EcalRecHitsEB"),
     recHitsLabelEE = cms.string("EcalRecHitsEE"),
  
     maxNumberHitsEB = cms.uint32(61200),
     maxNumberHitsEE = cms.uint32(14648),  
   
-    #EErechitCollection = cms.string('EcalRecHitsEE'),
-    #EEuncalibRecHitCollection = cms.InputTag("ecalMultiFitUncalibRecHit","EcalUncalibRecHitsEE"),
-    #EBuncalibRecHitCollection = cms.InputTag("ecalMultiFitUncalibRecHit","EcalUncalibRecHitsEB"),
-    #EBrechitCollection = cms.string('EcalRecHitsEB'),
-   
     ## db statuses to be exluded from reconstruction (some will be recovered)
     ChannelStatusToBeExcluded = cms.vstring(   'kDAC',
                                                'kNoisy',
@@ -45,23 +38,15 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
     
     ## avoid propagation of dead channels other than after recovery
     killDeadChannels = cms.bool(True),
-    #algo = cms.string("EcalRecHitWorkerSimple"),
     
     ## define maximal and minimal values for the laser corrections
     
-    EBLaserMIN = cms.double(0.01),                    #    EBLaserMIN = cms.double(0.5),
-    EELaserMIN = cms.double(0.01),                    #    EELaserMIN = cms.double(0.5),
-                                                     
-    EBLaserMAX = cms.double(30.0),                    #    EBLaserMAX = cms.double(3.0),
-    EELaserMAX = cms.double(30.0),                    #    EELaserMAX = cms.double(8.0),
+    EBLaserMIN = cms.double(0.01),
+    EELaserMIN = cms.double(0.01),
 
+    EBLaserMAX = cms.double(30.0),
+    EELaserMAX = cms.double(30.0),
 
-    ## useful if time is not calculated, as at HLT                        
-    #skipTimeCalib = cms.bool(False),                         
-
-    ## apply laser corrections
-    #laserCorrection = cms.bool(True),
-                            
     ## reco flags association to DB flag
     flagsMapDBReco = cms.PSet(
         kGood  = cms.vstring('kOk','kDAC','kNoLaser','kNoisy'),
@@ -72,61 +57,13 @@ ecalRecHitGPU = cms.EDProducer("EcalRecHitProducerGPU",
         kTowerRecovered = cms.vstring('kDeadFE'),
         kDead           = cms.vstring('kNoDataNoTP')
         ), 
-        
-#//         flagmask_ |= 0x1 << EcalRecHit::kNeighboursRecovered;
-#//         flagmask_ |= 0x1 << EcalRecHit::kTowerRecovered;
-#//         flagmask_ |= 0x1 << EcalRecHit::kDead;
-#//         flagmask_ |= 0x1 << EcalRecHit::kKilled;
-#//         flagmask_ |= 0x1 << EcalRecHit::kTPSaturated;
-#//         flagmask_ |= 0x1 << EcalRecHit::kL1SpikeFlag;
 
-
-                            
     ## for channel recovery
-    #algoRecover = cms.string("EcalRecHitWorkerRecover"),
     recoverEBIsolatedChannels = cms.bool(False),
     recoverEEIsolatedChannels = cms.bool(False),
     recoverEBVFE  = cms.bool(False),
     recoverEEVFE  = cms.bool(False),
     recoverEBFE = cms.bool(True),
     recoverEEFE = cms.bool(True),
-
-    ##db statuses for which recovery in EE/EB should not be attempted           
-    #dbStatusToBeExcludedEE = cms.vint32(
-                                        #14,  # dead, no TP
-                                        #78,  # dead, HV off
-                                        #142, # dead,LV off
-                                        #), 
-    #dbStatusToBeExcludedEB = cms.vint32(
-                                        #14,  # dead, no TP
-                                        #78,  # dead, HV off
-                                        #142, # dead,LV off
-                                        #), 
-    
-    ## --- logWarnings for saturated DeadFEs
-    ## if the logWarningThreshold is negative the Algo will not try recovery (in EE is not tested we may need negative threshold e.g. -1.e+9)
-    ## if you want to enable recovery but you don't wish to throw logWarnings put the logWarningThresholds very high e.g +1.e+9
-    ##  ~64 GeV is the TP saturation level
-    #logWarningEtThreshold_EB_FE = cms.double(50),# in EB logWarningThreshold is actually in E (GeV)
-    #logWarningEtThreshold_EE_FE = cms.double(50),# in EE the energy should correspond to Et (GeV) but the recovered values of energies are not tested if make sense
-    #ebDetIdToBeRecovered = cms.InputTag("ecalDetIdToBeRecovered:ebDetId"),
-    #eeDetIdToBeRecovered = cms.InputTag("ecalDetIdToBeRecovered:eeDetId"),
-    #ebFEToBeRecovered = cms.InputTag("ecalDetIdToBeRecovered:ebFE"),
-    #eeFEToBeRecovered = cms.InputTag("ecalDetIdToBeRecovered:eeFE"),
-    #singleChannelRecoveryMethod = cms.string("NeuralNetworks"),
-    #singleChannelRecoveryThreshold = cms.double(8),
-    #triggerPrimitiveDigiCollection = cms.InputTag("ecalDigis:EcalTriggerPrimitives"),
-    #cleaningConfig=cleaningAlgoConfig,
-
-    )
-
-
-
-#from Configuration.Eras.Modifier_fastSim_cff import fastSim
-## no flags for bad channels in FastSim
-#fastSim.toModify(ecalRecHit, 
-                 #killDeadChannels = False,
-                 #recoverEBFE = False,
-                 #recoverEEFE = False)
-
+)
 


### PR DESCRIPTION
#### PR description:

[WIP] Implements the comments of https://github.com/cms-sw/cmssw/pull/31719
I will add more commits to this but wanted to make the a PR already to make the current status already available in case we want to add certain commits already to https://github.com/cms-sw/cmssw/pull/31719 now.

- Removes commented out code
- Removes unused header files
- Migrates to esConsumes
- Adds comments for documentation
- Introduces better variable names
- Copies parameterSets instead of storing a const ref
- Removes unused function
- Moves `__syncthreads()` outside of the if blocks to avoid blocked threads
- Replaces ecal::abs() with std::abs()
- Removes unused function eigen_solve_submatrix()

#### PR validation:

- Code compiles
- Tested on ` gpu-c2a02-39-01.cms` with 
```
cmsDriver.py step3  --conditions auto:phase1_2021_realistic -n 100 --era Run3 --eventcontent RECOSIM,DQM --procModifiers gpu -s RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --no_exec
```
Data from `/gpu_data/store/mc/RunIIAutumn18DR/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/`.
Also including PR #592 .
