### PR TITLE
Backport: add and use preprocessors macros for loop unrolling (#32499)

### DIFF
--- a/FWCore/Utilities/interface/CMSUnrollLoop.h
+++ b/FWCore/Utilities/interface/CMSUnrollLoop.h
@@ -1,0 +1,51 @@
+#ifndef FWCore_Utilities_interface_CMSUnrollLoop_h
+#define FWCore_Utilities_interface_CMSUnrollLoop_h
+
+// convert the macro argument to a null-terminated quoted string
+#define STRINGIFY_(ARG) #ARG
+#define STRINGIFY(ARG) STRINGIFY_(ARG)
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+// CUDA or HIP device compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+
+#define CMS_DEVICE_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+
+#else  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+// any host compiler
+#define CMS_DEVICE_UNROLL_LOOP
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N)
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE
+
+#if defined(__clang__)
+// clang host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(clang loop unroll(enable)))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(clang loop unroll_count(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(clang loop unroll(disable)))
+
+#elif defined(__GNUC__)
+// GCC host compiler
+
+#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(GCC ivdep))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(GCC unroll N)) _Pragma(STRINGIFY(GCC ivdep))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(GCC unroll 1))
+
+#else
+// unsupported or unknown compiler
+
+#define CMS_UNROLL_LOOP
+#define CMS_UNROLL_LOOP_COUNT(N)
+#define CMS_UNROLL_LOOP_DISABLE
+
+#endif  // defined(__clang__) || defined(__GNUC__) || ...
+
+#endif  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
+
+#endif  // FWCore_Utilities_interface_CMSUnrollLoop_h

--- a/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 
+#include "FWCore/Utilities/interface/CMSUnrollLoop.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
 
@@ -13,7 +14,7 @@ __device__ void __forceinline__ warpPrefixScan(T const* __restrict__ ci, T* __re
   // ci and co may be the same
   auto x = ci[i];
   auto laneId = threadIdx.x & 0x1f;
-#pragma unroll
+  CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)
@@ -26,7 +27,7 @@ template <typename T>
 __device__ void __forceinline__ warpPrefixScan(T* c, uint32_t i, uint32_t mask) {
   auto x = c[i];
   auto laneId = threadIdx.x & 0x1f;
-#pragma unroll
+  CMS_UNROLL_LOOP
   for (int offset = 1; offset < 32; offset <<= 1) {
     auto y = __shfl_up_sync(mask, x, offset);
     if (laneId >= offset)

--- a/HeterogeneousCore/CUDAUtilities/interface/radixSort.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/radixSort.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "FWCore/Utilities/interface/CMSUnrollLoop.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
 
 template <typename T>
@@ -124,7 +125,7 @@ __device__ __forceinline__ void radixSortImpl(
     if (threadIdx.x < sb) {
       auto x = c[threadIdx.x];
       auto laneId = threadIdx.x & 0x1f;
-#pragma unroll
+      CMS_UNROLL_LOOP
       for (int offset = 1; offset < 32; offset <<= 1) {
         auto y = __shfl_up_sync(0xffffffff, x, offset);
         if (laneId >= offset)


### PR DESCRIPTION
Define preprocessor macros that expand to pragmas controlling loop unrolling.
Two set of macros are defined:
  - CMS_UNROLL_LOOP and friends are applied on both host and device compilation
  - CMS_DEVICE_UNROLL_LOOP and friends are only applied in device compilation, and expand to nothing on the host

The supported compilers are
  - CUDA nvcc
  - HIP (untested)
  - gcc
  - clang

Use CMS_UNROLL_LOOP instead of #pragma unroll.