### PR TITLE
Do not disable the CUDAService at HLT if there are no GPUs

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -18,19 +18,12 @@ def resetGpuOffload():
     HeterogeneousCore.CUDACore.SwitchProducerCUDA._switch_cuda()
 
 
-# check if CUDA is enabled, using the same mechanism as the SwitchProducerCUDA
-def cudaIsEnabled():
-    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
-    return HeterogeneousCore.CUDACore.SwitchProducerCUDA._switch_cuda()[0]
-
-
 # customisation for running the Patatrack reconstruction, common parts
 def customiseCommon(process):
 
     # Services
 
     process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
-    process.CUDAService.enabled = cudaIsEnabled()
 
     process.load("HeterogeneousCore.CUDAServices.NVProfilerService_cfi")
 


### PR DESCRIPTION
The `CUDAService` already checks for the availability of a suitable GPU at job startup, so there is no need to explicitly disable it in the python configuration.

This fixes the case where the configuration is expanded or pickled on a machine without GPUs, and then run on a machine with a GPU: in this case the `CUDAService` gets incorrectly disabled, breaking the configuration itself.