### PR TITLE
Clean up the pixel vertex reconstruction code

### DIFF
--- a/CUDADataFormats/Vertex/interface/ZVertexSoA.h
+++ b/CUDADataFormats/Vertex/interface/ZVertexSoA.h
@@ -1,5 +1,5 @@
-#ifndef CUDADataFormatsVertexZVertexSoA_H
-#define CUDADataFormatsVertexZVertexSoA_H
+#ifndef CUDADataFormats_Vertex_ZVertexSoA_h
+#define CUDADataFormats_Vertex_ZVertexSoA_h
 
 #include <cstdint>
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
@@ -23,4 +23,4 @@ struct ZVertexSoA {
   __host__ __device__ void init() { nvFinal = 0; }
 };
 
-#endif  // CUDADataFormatsVertexZVertexSoA.H
+#endif  // CUDADataFormats_Vertex_ZVertexSoA_h

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
@@ -49,13 +49,13 @@ private:
 PixelVertexProducerCUDA::PixelVertexProducerCUDA(const edm::ParameterSet& conf)
     : onGPU_(conf.getParameter<bool>("onGPU")),
       gpuAlgo_(conf.getParameter<bool>("oneKernel"),
-                conf.getParameter<bool>("useDensity"),
-                conf.getParameter<bool>("useDBSCAN"),
-                conf.getParameter<bool>("useIterative"),
-                conf.getParameter<int>("minT"),
-                conf.getParameter<double>("eps"),
-                conf.getParameter<double>("errmax"),
-                conf.getParameter<double>("chi2max")),
+               conf.getParameter<bool>("useDensity"),
+               conf.getParameter<bool>("useDBSCAN"),
+               conf.getParameter<bool>("useIterative"),
+               conf.getParameter<int>("minT"),
+               conf.getParameter<double>("eps"),
+               conf.getParameter<double>("errmax"),
+               conf.getParameter<double>("chi2max")),
       ptMin_(conf.getParameter<double>("PtMin"))  // 0.5 GeV
 {
   if (onGPU_) {
@@ -91,7 +91,9 @@ void PixelVertexProducerCUDA::fillDescriptions(edm::ConfigurationDescriptions& d
   descriptions.add(label, desc);
 }
 
-void PixelVertexProducerCUDA::produceOnGPU(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void PixelVertexProducerCUDA::produceOnGPU(edm::StreamID streamID,
+                                           edm::Event& iEvent,
+                                           const edm::EventSetup& iSetup) const {
   edm::Handle<cms::cuda::Product<PixelTrackHeterogeneous>> hTracks;
   iEvent.getByToken(tokenGPUTrack_, hTracks);
 
@@ -103,24 +105,27 @@ void PixelVertexProducerCUDA::produceOnGPU(edm::StreamID streamID, edm::Event& i
   ctx.emplace(iEvent, tokenGPUVertex_, gpuAlgo_.makeAsync(ctx.stream(), tracks, ptMin_));
 }
 
-void PixelVertexProducerCUDA::produceOnCPU(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void PixelVertexProducerCUDA::produceOnCPU(edm::StreamID streamID,
+                                           edm::Event& iEvent,
+                                           const edm::EventSetup& iSetup) const {
   auto const* tracks = iEvent.get(tokenCPUTrack_).get();
   assert(tracks);
 
-#ifdef PIXVERTEX_DEBUG_PRODUCE 
-  auto const & tsoa = *tracks;
+#ifdef PIXVERTEX_DEBUG_PRODUCE
+  auto const& tsoa = *tracks;
   auto maxTracks = tsoa.stride();
   std::cout << "size of SoA " << sizeof(tsoa) << " stride " << maxTracks << std::endl;
 
   int32_t nt = 0;
   for (int32_t it = 0; it < maxTracks; ++it) {
     auto nHits = tsoa.nHits(it);
-    assert(nHits==int(tsoa.hitIndices.size(it)));
-    if (nHits == 0) break;  // this is a guard: maybe we need to move to nTracks...
+    assert(nHits == int(tsoa.hitIndices.size(it)));
+    if (nHits == 0)
+      break;  // this is a guard: maybe we need to move to nTracks...
     nt++;
   }
   std::cout << "found " << nt << " tracks in cpu SoA for Vertexing at " << tracks << std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE
+#endif  // PIXVERTEX_DEBUG_PRODUCE
 
   iEvent.emplace(tokenCPUVertex_, gpuAlgo_.make(tracks, ptMin_));
 }

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -64,11 +64,9 @@ void PixelVertexProducerFromSoA::fillDescriptions(edm::ConfigurationDescriptions
 void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEvent, const edm::EventSetup &) const {
   auto vertexes = std::make_unique<reco::VertexCollection>();
 
-  auto const &tracks = iEvent.get(tokenTracks_);
+  auto tracksHandle = iEvent.getHandle(tokenTracks_);
   auto const &indToEdm = iEvent.get(tokenIndToEdm_);
-
-  edm::Handle<reco::BeamSpot> bsHandle;
-  iEvent.getByToken(tokenBeamSpot_, bsHandle);
+  auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
 
   float x0 = 0, y0 = 0, z0 = 0, dxdz = 0, dydz = 0;
   std::vector<int32_t> itrk;
@@ -92,7 +90,6 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
 #endif // PIXVERTEX_DEBUG_PRODUCE 
 
   std::set<uint16_t> uind;  // fort verifing index consistency
-  auto trackCollection = iEvent.getHandle(tokenTracks_);
   for (int j = nv - 1; j >= 0; --j) {
     auto i = soa.sortInd[j];  // on gpu sorted in ascending order....
     assert(i < nv);
@@ -126,11 +123,11 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
     for (auto it : itrk) {
       assert(it < int(indToEdm.size()));
       auto k = indToEdm[it];
-      if (k > tracks.size()) {
+      if (k > tracksHandle->size()) {
         edm::LogWarning("PixelVertexProducer") << "oops track " << it << " does not exists on CPU " << k;
         continue;
       }
-      auto tk = reco::TrackRef(trackCollection, k);
+      auto tk = reco::TrackRef(tracksHandle, k);
       v.add(reco::TrackBaseRef(tk));
     }
     itrk.clear();

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -65,6 +65,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
   auto vertexes = std::make_unique<reco::VertexCollection>();
 
   auto tracksHandle = iEvent.getHandle(tokenTracks_);
+  auto tracksSize = tracksHandle->size();
   auto const &indToEdm = iEvent.get(tokenIndToEdm_);
   auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
 
@@ -124,7 +125,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
     for (auto it : itrk) {
       assert(it < int(indToEdm.size()));
       auto k = indToEdm[it];
-      if (k > tracksHandle->size()) {
+      if (k > tracksSize) {
         edm::LogWarning("PixelVertexProducer") << "oops track " << it << " does not exists on CPU " << k;
         continue;
       }

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -92,6 +92,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
 #endif // PIXVERTEX_DEBUG_PRODUCE 
 
   std::set<uint16_t> uind;  // fort verifing index consistency
+  auto trackCollection = iEvent.getHandle(tokenTracks_);
   for (int j = nv - 1; j >= 0; --j) {
     auto i = soa.sortInd[j];  // on gpu sorted in ascending order....
     assert(i < nv);
@@ -129,7 +130,6 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
         edm::LogWarning("PixelVertexProducer") << "oops track " << it << " does not exists on CPU " << k;
         continue;
       }
-      auto trackCollection = iEvent.getHandle(tokenTracks_);
       auto tk = reco::TrackRef(trackCollection, k);
       v.add(reco::TrackBaseRef(tk));
     }

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerFromSoA.cc
@@ -86,8 +86,9 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
   int nv = soa.nvFinal;
 
 #ifdef PIXVERTEX_DEBUG_PRODUCE
-  std::cout << "converting " << nv << " vertices " << " from " << indToEdm.size() << " tracks" << std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE 
+  std::cout << "converting " << nv << " vertices "
+            << " from " << indToEdm.size() << " tracks" << std::endl;
+#endif  // PIXVERTEX_DEBUG_PRODUCE
 
   std::set<uint16_t> uind;  // fort verifing index consistency
   for (int j = nv - 1; j >= 0; --j) {
@@ -111,7 +112,7 @@ void PixelVertexProducerFromSoA::produce(edm::StreamID streamID, edm::Event &iEv
     if (nt == 0) {
 #ifdef PIXVERTEX_DEBUG_PRODUCE
       std::cout << "vertex " << i << " with no tracks..." << std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE
+#endif  // PIXVERTEX_DEBUG_PRODUCE
       continue;
     }
     if (nt < 2) {

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_src_gpuVertexFinder_h
-#define RecoPixelVertexing_PixelVertexFinding_src_gpuVertexFinder_h
+#ifndef RecoPixelVertexing_PixelVertexFinding_gpuVertexFinder_h
+#define RecoPixelVertexing_PixelVertexFinding_gpuVertexFinder_h
 
 #include <cstddef>
 #include <cstdint>
@@ -80,4 +80,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_src_gpuVertexFinder_h
+#endif  // RecoPixelVertexing_PixelVertexFinding_gpuVertexFinder_h

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
@@ -89,13 +89,13 @@ namespace gpuVertexFinder {
   ZVertexHeterogeneous Producer::makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin) const {
 #ifdef PIXVERTEX_DEBUG_PRODUCE
     std::cout << "producing Vertices on GPU" << std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE
+#endif  // PIXVERTEX_DEBUG_PRODUCE
     ZVertexHeterogeneous vertices(cms::cuda::make_device_unique<ZVertexSoA>(stream));
 #else
   ZVertexHeterogeneous Producer::make(TkSoA const* tksoa, float ptMin) const {
 #ifdef PIXVERTEX_DEBUG_PRODUCE
-    std::cout << "producing Vertices on  CPU" <<    std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE
+    std::cout << "producing Vertices on  CPU" << std::endl;
+#endif  // PIXVERTEX_DEBUG_PRODUCE
     ZVertexHeterogeneous vertices(std::make_unique<ZVertexSoA>());
 #endif
     assert(tksoa);
@@ -118,7 +118,7 @@ namespace gpuVertexFinder {
     init(soa, ws_d.get());
     loadTracks(tksoa, soa, ws_d.get(), ptMin);
 #endif
-    
+
 #ifdef __CUDACC__
     // Running too many thread lead to problems when printf is enabled.
     constexpr int maxThreadsForPrint = 1024 - 256;
@@ -166,7 +166,7 @@ namespace gpuVertexFinder {
     }
 #ifdef PIXVERTEX_DEBUG_PRODUCE
     std::cout << "found " << (*ws_d).nvIntermediate << " vertices " << std::endl;
-#endif // PIXVERTEX_DEBUG_PRODUCE
+#endif  // PIXVERTEX_DEBUG_PRODUCE
     fitVertices(soa, ws_d.get(), 50.);
     // one block per vertex!
     splitVertices(soa, ws_d.get(), 9.f);

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
@@ -122,8 +122,8 @@ namespace gpuVertexFinder {
 #ifdef __CUDACC__
     // Running too many thread lead to problems when printf is enabled.
     constexpr int maxThreadsForPrint = 1024 - 256;
-    constexpr int splitBlocks = 1024;
-    constexpr int splitThreadsPerBlock = 128;
+    constexpr int numBlocks = 1024;
+    constexpr int threadsPerBlock = 128;
 
     if (oneKernel_) {
       // implemented only for density clustesrs
@@ -133,7 +133,7 @@ namespace gpuVertexFinder {
       vertexFinderKernel1<<<1, maxThreadsForPrint, 0, stream>>>(soa, ws_d.get(), minT, eps, errmax, chi2max);
       cudaCheck(cudaGetLastError());
       // one block per vertex...
-      splitVerticesKernel<<<splitBlocks, splitThreadsPerBlock, 0, stream>>>(soa, ws_d.get(), 9.f);
+      splitVerticesKernel<<<numBlocks, threadsPerBlock, 0, stream>>>(soa, ws_d.get(), 9.f);
       cudaCheck(cudaGetLastError());
       vertexFinderKernel2<<<1, maxThreadsForPrint, 0, stream>>>(soa, ws_d.get());
 #endif
@@ -149,7 +149,7 @@ namespace gpuVertexFinder {
       fitVerticesKernel<<<1, maxThreadsForPrint, 0, stream>>>(soa, ws_d.get(), 50.);
       cudaCheck(cudaGetLastError());
       // one block per vertex...
-      splitVerticesKernel<<<splitBlocks, splitThreadsPerBlock, 0, stream>>>(soa, ws_d.get(), 9.f);
+      splitVerticesKernel<<<numBlocks, threadsPerBlock, 0, stream>>>(soa, ws_d.get(), 9.f);
       cudaCheck(cudaGetLastError());
       fitVerticesKernel<<<1, maxThreadsForPrint, 0, stream>>>(soa, ws_d.get(), 5000.);
       cudaCheck(cudaGetLastError());

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinderImpl.h
@@ -7,6 +7,8 @@
 #include "gpuSortByPt2.h"
 #include "gpuSplitVertices.h"
 
+#undef PIXVERTEX_DEBUG_PRODUCE
+
 namespace gpuVertexFinder {
 
   __global__ void loadTracks(TkSoA const* ptracks, ZVertexSoA* soa, WorkSpace* pws, float ptMin) {
@@ -85,11 +87,15 @@ namespace gpuVertexFinder {
 
 #ifdef __CUDACC__
   ZVertexHeterogeneous Producer::makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin) const {
-    // std::cout << "producing Vertices on GPU" << std::endl;
+#ifdef PIXVERTEX_DEBUG_PRODUCE
+    std::cout << "producing Vertices on GPU" << std::endl;
+#endif // PIXVERTEX_DEBUG_PRODUCE
     ZVertexHeterogeneous vertices(cms::cuda::make_device_unique<ZVertexSoA>(stream));
 #else
   ZVertexHeterogeneous Producer::make(TkSoA const* tksoa, float ptMin) const {
-    // std::cout << "producing Vertices on  CPU" <<    std::endl;
+#ifdef PIXVERTEX_DEBUG_PRODUCE
+    std::cout << "producing Vertices on  CPU" <<    std::endl;
+#endif // PIXVERTEX_DEBUG_PRODUCE
     ZVertexHeterogeneous vertices(std::make_unique<ZVertexSoA>());
 #endif
     assert(tksoa);
@@ -153,7 +159,9 @@ namespace gpuVertexFinder {
     } else if (useIterative_) {
       clusterTracksIterative(soa, ws_d.get(), minT, eps, errmax, chi2max);
     }
-    // std::cout << "found " << (*ws_d).nvIntermediate << " vertices " << std::endl;
+#ifdef PIXVERTEX_DEBUG_PRODUCE
+    std::cout << "found " << (*ws_d).nvIntermediate << " vertices " << std::endl;
+#endif // PIXVERTEX_DEBUG_PRODUCE
     fitVertices(soa, ws_d.get(), 50.);
     // one block per vertex!
     splitVertices(soa, ws_d.get(), 9.f);

--- a/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
+++ b/RecoPixelVertexing/PixelVertexFinding/test/VertexFinder_t.h
@@ -8,18 +8,18 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/launch.h"
 #ifdef USE_DBSCAN
-#include "../plugins/gpuClusterTracksDBSCAN.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuClusterTracksDBSCAN.h"
 #define CLUSTERIZE gpuVertexFinder::clusterTracksDBSCAN
 #elif USE_ITERATIVE
-#include "../plugins/gpuClusterTracksIterative.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuClusterTracksIterative.h"
 #define CLUSTERIZE gpuVertexFinder::clusterTracksIterative
 #else
-#include "../plugins/gpuClusterTracksByDensity.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuClusterTracksByDensity.h"
 #define CLUSTERIZE gpuVertexFinder::clusterTracksByDensityKernel
 #endif
-#include "../plugins/gpuFitVertices.h"
-#include "../plugins/gpuSortByPt2.h"
-#include "../plugins/gpuSplitVertices.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuFitVertices.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuSortByPt2.h"
+#include "RecoPixelVertexing/PixelVertexFinding/plugins/gpuSplitVertices.h"
 
 #ifdef ONE_KERNEL
 #ifdef __CUDACC__


### PR DESCRIPTION
#### PR description:

This PR will implement remarks for https://github.com/cms-sw/cmssw/pull/31723.

#### PR validation:

The baseline and new code will be run through TTbar validations:

   -  [501: CPU - Quad+Pentaplets](https://patatrack.web.cern.ch/patatrack/validation/pulls/13a7a77294b8e32b503b6abf63fcf96c22939c56/RelValTTbar_14TeV-CMSSW_11_2_0_pre7-PU_112X_mcRun3_2021_realistic_v8-v1/development-11634.501-step3.py)
   -  [502: GPU - Quad+Pentaplets](https://patatrack.web.cern.ch/patatrack/validation/pulls/13a7a77294b8e32b503b6abf63fcf96c22939c56/RelValTTbar_14TeV-CMSSW_11_2_0_pre7-PU_112X_mcRun3_2021_realistic_v8-v1/development-11634.502-step3.py)

  - [505: CPU - Trips+Quads+Penta](https://patatrack.web.cern.ch/patatrack/validation/pulls/13a7a77294b8e32b503b6abf63fcf96c22939c56/RelValTTbar_14TeV-CMSSW_11_2_0_pre7-PU_112X_mcRun3_2021_realistic_v8-v1/development-11634.505-step3.py)
   - [506: GPU - Trips+Quads+Penta](https://patatrack.web.cern.ch/patatrack/validation/pulls/13a7a77294b8e32b503b6abf63fcf96c22939c56/RelValTTbar_14TeV-CMSSW_11_2_0_pre7-PU_112X_mcRun3_2021_realistic_v8-v1/development-11634.506-step3.py)
