### PR TITLE
Minor fixes and clean up for the pixel track reconstruction code

### DIFF
--- a/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
+++ b/RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py
@@ -51,11 +51,11 @@ def customizePixelTracksForTriplets(process):
 
 def customizePixelTracksSoAonCPUForProfiling(process):
 
-  process.MessageLogger.cerr.FwkReport.reportEvery = 100
-
   process = customizePixelTracksSoAonCPU(process)
+
   process.siPixelRecHitSoAFromLegacy.convertToLegacy = False
   
   process.TkSoA = cms.Path(process.offlineBeamSpot + process.siPixelDigis + process.siPixelClustersPreSplitting + process.siPixelRecHitSoAFromLegacy + process.pixelTrackSoA + process.pixelVertexSoA)
   process.schedule = cms.Schedule(process.TkSoA)
+
   return process

--- a/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
@@ -9,7 +9,7 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin file="testRiemannFit.cpp">
+<bin file="testFits.cpp">
   <use name="cuda"/>
   <use name="eigen"/>
   <flags CXXFLAGS="-g"/>
@@ -21,13 +21,13 @@
   <flags CXXFLAGS="-g -DUSE_BL"/>
 </bin>
 
-<bin file="testFits.cpp" name="testRiemannFitDump">
+<bin file="testFits.cpp" name="testFitsDump">
   <use name="cuda"/>
   <use name="eigen"/>
   <flags CXXFLAGS="-g -DRFIT_DEBUG"/>
 </bin>
 
-<bin file="testEigenGPU.cu" name="testRiemannFitGPU_t">
+<bin file="testEigenGPU.cu" name="testFitsGPU_t">
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="cuda"/>
   <use name="eigen"/>
@@ -48,7 +48,7 @@
   <flags CXXFLAGS="-g"/>
 </bin>
 
-<bin file="PixelTrackRiemannFit.cc">
+<bin file="PixelTrackFits.cc">
   <use name="cuda"/>
   <use name="eigen"/>
   <use name="root"/>
@@ -62,7 +62,7 @@
   <flags CXXFLAGS="-DEIGEN_NO_DEBUG -DUSE_BL"/>
 </bin>
 
-<bin file="PixelTrackFits.cc" name="PixelTrackRiemannFit_Debug">
+<bin file="PixelTrackFits.cc" name="PixelTrackFits_Debug">
   <use name="cuda"/>
   <use name="eigen"/>
   <use name="root"/>


### PR DESCRIPTION
Fix RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml following file renames.

Remove unnecessary customisation from
RecoPixelVertexing/Configuration/python/customizePixelTracksSoAonCPU.py .